### PR TITLE
feat(bundles): add @cron decorator and proc-owned bundle scheduler

### DIFF
--- a/app/ai-app/docs/sdk/bundle/bundle-index-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-index-README.md
@@ -11,6 +11,7 @@ see_also:
   - ks:docs/sdk/bundle/bundle-runtime-README.md
   - ks:docs/sdk/bundle/bundle-config-README.md
   - ks:docs/sdk/bundle/bundle-platform-integration-README.md
+  - ks:docs/sdk/bundle/bundle-scheduled-jobs-README.md
 ---
 # Bundle Docs Index
 
@@ -41,6 +42,7 @@ Use this as the **docs start point** when building, repairing, or reviewing a bu
 | Custom skills | [[docs/sdk/skills/custom-skills-README.md](../skills/custom-skills-README.md)](../skills/custom-skills-README.md) | `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/skills_descriptor.py`, `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/skills/product/preferences/SKILL.md` |
 | Storage, cache, bundle state | [[docs/sdk/bundle/bundle-storage-cache-README.md](bundle-storage-cache-README.md)](bundle-storage-cache-README.md) | `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/preferences_store.py` |
 | Widgets + operations | [[docs/sdk/bundle/bundle-platform-integration-README.md](bundle-platform-integration-README.md)](bundle-platform-integration-README.md), [[docs/sdk/bundle/bundle-interfaces-README.md](bundle-interfaces-README.md)](bundle-interfaces-README.md) | `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/ui/PreferencesBrowser.tsx`, `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py` |
+| Scheduled jobs (`@cron`) | [[docs/sdk/bundle/bundle-scheduled-jobs-README.md](bundle-scheduled-jobs-README.md)](bundle-scheduled-jobs-README.md) | `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/bundle_scheduler.py`, `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/echo.ui@2026-03-30/entrypoint.py` |
 | Custom main-view UI | [[docs/sdk/bundle/bundle-lifecycle-README.md](bundle-lifecycle-README.md)](bundle-lifecycle-README.md), [[docs/sdk/bundle/bundle-reference-versatile-README.md](bundle-reference-versatile-README.md)](bundle-reference-versatile-README.md) | `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/ui-src/src/App.tsx`, `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py` |
 | Direct isolated exec from bundle code | [[docs/sdk/bundle/bundle-reference-versatile-README.md](bundle-reference-versatile-README.md)](bundle-reference-versatile-README.md) | `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py` |
 | Bundle-defined `ks:` knowledge space | [[docs/sdk/bundle/bundle-knowledge-space-README.md](bundle-knowledge-space-README.md)](bundle-knowledge-space-README.md) | `src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05` |
@@ -82,8 +84,10 @@ Why this is the primary reference:
   [[docs/sdk/bundle/bundle-storage-cache-README.md](bundle-storage-cache-README.md)](bundle-storage-cache-README.md)
 - Bundle interfaces (widgets + operations + streaming):
   [[docs/sdk/bundle/bundle-interfaces-README.md](bundle-interfaces-README.md)](bundle-interfaces-README.md)
-- Declarative platform integration design (`@api`, `@ui_widget`, `@ui_main`, `@on_message`):
+- Declarative platform integration design (`@api`, `@ui_widget`, `@ui_main`, `@on_message`, `@cron`):
   [[docs/sdk/bundle/bundle-platform-integration-README.md](bundle-platform-integration-README.md)](bundle-platform-integration-README.md)
+- Scheduled jobs (`@cron` decorator, span semantics, cron resolution, local debug):
+  [[docs/sdk/bundle/bundle-scheduled-jobs-README.md](bundle-scheduled-jobs-README.md)](bundle-scheduled-jobs-README.md)
 - Bundle knowledge space (`ks:`):
   [[docs/sdk/bundle/bundle-knowledge-space-README.md](bundle-knowledge-space-README.md)](bundle-knowledge-space-README.md)
 - Bundle outbound firewall:

--- a/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
@@ -2,10 +2,11 @@
 id: ks:docs/sdk/bundle/bundle-platform-integration-README.md
 title: "Bundle Platform Integration"
 summary: "Current declarative bundle integration contract: supported decorators, manifest metadata, REST routes, and UI/static integration."
-tags: ["sdk", "bundle", "integration", "decorators", "widgets", "operations", "ui", "manifest"]
-keywords: ["agentic_workflow", "bundle_id decorator", "api decorator", "ui_widget", "ui_main", "on_message", "bundle manifest", "integrations widgets", "integrations operations", "public route"]
+tags: ["sdk", "bundle", "integration", "decorators", "widgets", "operations", "ui", "manifest", "cron", "scheduled-jobs"]
+keywords: ["agentic_workflow", "bundle_id decorator", "api decorator", "ui_widget", "ui_main", "on_message", "cron decorator", "scheduled jobs", "bundle manifest", "integrations widgets", "integrations operations", "public route"]
 see_also:
   - ks:docs/sdk/bundle/bundle-interfaces-README.md
+  - ks:docs/sdk/bundle/bundle-scheduled-jobs-README.md
   - ks:docs/sdk/bundle/bundle-dev-README.md
   - ks:docs/sdk/bundle/design/bundle-custom-venv-README.md
   - ks:docs/sdk/bundle/bundle-index-README.md
@@ -37,6 +38,7 @@ Bundles currently use these decorators:
 - `@ui_widget(...)`
 - `@ui_main`
 - `@on_message`
+- `@cron(...)`
 - `@venv(...)`
 
 These decorators are metadata for the bundle interface surface. They are not
@@ -225,7 +227,58 @@ Current practical pattern:
 - base entrypoints already decorate `run()` with `@on_message`
 - manifest discovery reports the message handler method name
 
-### 1.6 `@venv(...)`
+### 1.6 `@cron(...)`
+
+Marks a method as a recurring scheduled job managed by proc.
+
+```python
+from kdcube_ai_app.infra.plugin.agentic_loader import cron
+
+@cron(
+    alias="rebuild-indexes",
+    cron_expression="0 * * * *",
+    expr_config="routines.reindex.cron",
+    span="system",
+)
+async def rebuild_indexes(self) -> None:
+    ...
+```
+
+Current fields:
+
+- `alias`
+  - stable job identifier used in lock keys and logs
+  - default: Python method name
+- `cron_expression`
+  - inline cron expression, e.g. `"*/15 * * * *"`
+  - used when `expr_config` is not set
+- `expr_config`
+  - dot-separated path into bundle props/config, e.g. `"routines.reindex.cron"`
+  - if set, takes precedence over `cron_expression` at runtime
+  - if the resolved value is missing, blank, or `"disable"` (case-insensitive) → job is **not** scheduled
+  - does **not** fall back to `cron_expression` when `expr_config` is set but unresolvable
+- `span`
+  - `"process"` — runs independently in every proc worker process (no lock)
+  - `"instance"` — runs once per host instance, Redis lock per `INSTANCE_ID`
+  - `"system"` — runs once across all instances for this tenant/project/bundle/job, Redis lock
+  - omitting `span` or passing an empty string defaults to `"system"`
+  - an unrecognised value raises `ValueError` at decoration time
+
+Current behavior:
+
+- proc discovers `@cron` methods through the same manifest discovery path as `@api` and `@ui_widget`
+- `BundleSchedulerManager` in proc reconciles job tasks after every registry or props change
+- no proc restart required for schedule changes
+- if Redis is unavailable for `instance`/`system` spans, the tick is skipped and a warning is logged; the job is **not** silently degraded to `process`
+- the method runs headlessly — no user session or SSE stream, but normal bundle runtime access is available (`self.bundle_props`, `self.redis`, `self.pg_pool`, secrets)
+- async methods are executed directly; sync methods run via `asyncio.to_thread`
+- overlapping runs within the same exclusivity scope are prevented (in-process flag for `process`, Redis lock for `instance`/`system`)
+
+For full details on span semantics, cron resolution, and local debug:
+
+- [docs/sdk/bundle/bundle-scheduled-jobs-README.md](bundle-scheduled-jobs-README.md)
+
+### 1.7 `@venv(...)`
 
 Marks a callable to execute in a cached per-bundle subprocess venv.
 
@@ -314,7 +367,19 @@ class UIMainSpec:
     method_name: str
 ```
 
-### 2.5 `BundleInterfaceManifest`
+### 2.5 `CronJobSpec`
+
+```python
+@dataclass(frozen=True)
+class CronJobSpec:
+    method_name: str
+    alias: str = ""
+    cron_expression: str | None = None
+    expr_config: str | None = None
+    span: str = "system"
+```
+
+### 2.6 `BundleInterfaceManifest`
 
 ```python
 @dataclass(frozen=True)
@@ -325,10 +390,14 @@ class BundleInterfaceManifest:
     api_endpoints: tuple[APIEndpointSpec, ...] = ()
     ui_main: UIMainSpec | None = None
     on_message: OnMessageSpec | None = None
+    scheduled_jobs: tuple[CronJobSpec, ...] = ()
 ```
 
 `allowed_roles` is populated from the `allowed_roles` argument of
 `@agentic_workflow`. Empty tuple means no restriction.
+
+`scheduled_jobs` is populated from all `@cron`-decorated methods on the
+entrypoint class, sorted by `alias`.
 
 Discovery helpers currently exposed by the loader:
 
@@ -357,6 +426,12 @@ Current response shape includes:
   - includes `roles`
 - `ui_main`
 - `on_message`
+- `scheduled_jobs`
+  - includes `method_name`
+  - includes `alias`
+  - includes `cron_expression` (declared value, not runtime-resolved)
+  - includes `expr_config`
+  - includes `span`
 
 Example:
 
@@ -388,7 +463,16 @@ Example:
   },
   "on_message": {
     "method_name": "run"
-  }
+  },
+  "scheduled_jobs": [
+    {
+      "method_name": "rebuild_indexes",
+      "alias": "rebuild-indexes",
+      "cron_expression": "0 * * * *",
+      "expr_config": "routines.reindex.cron",
+      "span": "system"
+    }
+  ]
 }
 ```
 
@@ -521,6 +605,10 @@ Use these rules for new bundles:
 6. Use `@ui_main` when the bundle has a main iframe application.
 7. Use `@on_message` on the bundle message handler. The base entrypoints already
    do this on `run()`.
+8. Use `@cron(...)` for recurring background work. Prefer `span="system"` (the
+   default) unless process-local or instance-local semantics are required.
+   See [docs/sdk/bundle/bundle-scheduled-jobs-README.md](bundle-scheduled-jobs-README.md)
+   for details on span semantics, `expr_config` resolution, and local debug.
 
 Important current rule:
 

--- a/app/ai-app/docs/sdk/bundle/bundle-scheduled-jobs-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-scheduled-jobs-README.md
@@ -1,0 +1,291 @@
+---
+id: ks:docs/sdk/bundle/bundle-scheduled-jobs-README.md
+title: "Bundle Scheduled Jobs"
+summary: "Bundle-native cron jobs via the @cron decorator: span semantics, cron resolution, runtime access, and local debug."
+tags: ["sdk", "bundle", "cron", "scheduled-jobs", "scheduler", "proc"]
+keywords: ["@cron", "cron decorator", "CronJobSpec", "BundleSchedulerManager", "span", "process", "instance", "system", "expr_config", "cron_expression", "scheduled jobs", "BUNDLES_YAML_DESCRIPTOR_PATH"]
+see_also:
+  - ks:docs/sdk/bundle/bundle-platform-integration-README.md
+  - ks:docs/sdk/bundle/bundle-config-README.md
+  - ks:docs/sdk/bundle/bundle-index-README.md
+---
+# Bundle Scheduled Jobs
+
+Bundle methods decorated with `@cron` are automatically discovered by proc and
+scheduled as recurring background jobs. No manual wiring or ad hoc loops needed.
+
+---
+
+## Quick start
+
+```python
+from kdcube_ai_app.infra.plugin.agentic_loader import cron
+
+class MyBundle(BaseEntrypoint):
+
+    @cron(
+        alias="rebuild-indexes",
+        cron_expression="0 * * * *",
+        span="system",
+    )
+    async def rebuild_indexes(self) -> None:
+        ...
+```
+
+Proc picks this up on the next registry reconcile and runs `rebuild_indexes`
+once per hour across the whole system.
+
+---
+
+## Decorator reference
+
+```python
+@cron(
+    alias: str | None = None,
+    cron_expression: str | None = None,
+    expr_config: str | None = None,
+    span: str = "system",
+)
+```
+
+| Argument | Type | Description |
+|---|---|---|
+| `alias` | `str \| None` | Stable job identifier. Used in Redis lock keys and logs. Defaults to method name. |
+| `cron_expression` | `str \| None` | Inline cron expression, e.g. `"*/15 * * * *"`. |
+| `expr_config` | `str \| None` | Dot-path into bundle props/config, e.g. `"routines.reindex.cron"`. Wins over `cron_expression`. |
+| `span` | `str` | Exclusivity: `"process"`, `"instance"`, `"system"`. Default: `"system"`. |
+
+---
+
+## Cron source rules
+
+1. If `expr_config` is set — resolve the dot-path against bundle props/config.
+   - Missing / blank / exactly `"disable"` (case-insensitive) → job **not** scheduled.
+   - Do **not** fall back to `cron_expression`.
+2. Else if `cron_expression` is set — use it.
+3. Else — inert; nothing is scheduled.
+
+When both are set, `expr_config` wins at runtime. `cron_expression` still
+appears in the bundle descriptor as the declared default/fallback.
+
+---
+
+## Span semantics
+
+`span` defines the exclusivity scope of execution, not the cron source.
+
+### `process`
+
+- Runs independently in every proc worker process.
+- No Redis lock.
+- If 4 proc processes are running, the job may execute 4 times per tick.
+- Overlap within one process is prevented by an in-process flag.
+
+### `instance`
+
+- Exactly one execution per host (`INSTANCE_ID`).
+- Multiple proc processes on the same instance compete; only the one that
+  acquires the lock runs.
+
+Redis lock key:
+```
+bundle:cron:lock:{tenant}:{project}:{bundle_id}:{job_alias}:{instance_id}
+```
+
+### `system`
+
+- Exactly one execution across the whole deployed system for that
+  tenant/project/bundle/job.
+- All instances and all processes compete; only one wins.
+
+Redis lock key:
+```
+bundle:cron:lock:{tenant}:{project}:{bundle_id}:{job_alias}
+```
+
+### Redis unavailability
+
+For `instance` and `system`:
+
+- If Redis is unavailable, the tick is **skipped**.
+- A warning is logged.
+- The scheduler task stays alive and will try again on the next tick.
+- Jobs are **not** silently degraded to `process` behavior.
+
+### Span default
+
+Omitting `span` or passing an empty string defaults to `"system"`.
+An unrecognised value raises `ValueError` at decoration time (not at runtime).
+
+---
+
+## Method shape
+
+Instance methods on the bundle entrypoint class. No required arguments
+besides `self`.
+
+Async preferred:
+
+```python
+@cron(cron_expression="*/5 * * * *", span="process")
+async def check_queue(self) -> None:
+    ...
+```
+
+Sync also supported — run via `asyncio.to_thread`:
+
+```python
+@cron(cron_expression="0 0 * * *", span="system")
+def nightly_report(self) -> None:
+    ...
+```
+
+---
+
+## Runtime access
+
+Scheduled jobs run headlessly — no user session or SSE stream. The bundle
+instance is constructed through the standard loader path, so these are all
+available inside a cron method:
+
+| Surface | Notes |
+|---|---|
+| `self.bundle_props` | Full props loaded from Redis, refreshed before the method runs |
+| `self.bundle_prop("some.path")` | Typed prop accessor |
+| `self.redis` | Dedicated Redis client (separate pool, does not contend with the processor's shared pool) |
+| `self.pg_pool` | Postgres pool — same singleton used by the rest of the process |
+| Secrets | Same resolution path as normal bundle execution |
+| `self.config` | Real `Config` object; `self.config.ai_bundle_spec.id` is set correctly |
+
+What is **not** available:
+
+- `self.comm` / communicator — there is no user session or SSE stream target
+- `self.comm_context` — not bound in headless mode
+
+---
+
+## `expr_config` resolution chain
+
+When `expr_config` is set, the effective cron expression is resolved in this
+order:
+
+1. **Redis bundle props** — live values written by the bundle config update API.
+2. **bundles.yaml** — via `read_plain("b:<path>")` using
+   `BUNDLES_YAML_DESCRIPTOR_PATH` (local debug / static config).
+3. **assembly.yaml** — via `read_plain("<path>")` using
+   `ASSEMBLY_YAML_DESCRIPTOR_PATH` (local debug / static config).
+
+Redis always wins when a value is present. The YAML fallbacks are primarily
+for local development when Redis holds no props.
+
+---
+
+## Live updates (props change handling)
+
+When bundle props change (via `bundles.update` or any config update), proc
+reconciles all scheduled jobs for affected bundles automatically — no restart
+required:
+
+- Cron expression changes → old task cancelled, new one started.
+- Value becomes `"disable"` → task cancelled.
+- Previously disabled job gets a valid value → task started.
+
+The same reconcile path runs on startup and after every bundle registry update.
+
+---
+
+## Overlap guard
+
+If a job is still running when the next tick arrives, the new tick is skipped.
+
+- `span="process"` — in-process `_running` flag per job.
+- `span="instance"` / `"system"` — the held Redis lock prevents overlap
+  naturally. Lock TTL is 1 hour; renewed every 60 seconds while the job runs.
+
+The skip is logged at `INFO` level.
+
+---
+
+## Error handling
+
+Exceptions raised by a scheduled job are caught, logged with full traceback,
+and the scheduler loop continues with future ticks.
+A single failing job does not affect other jobs or proc.
+
+---
+
+## Multiple cron methods on one bundle
+
+Each method gets its own asyncio task and its own Redis lock key (by `alias`).
+
+```python
+@cron(alias="heartbeat", cron_expression="* * * * *", span="system")
+async def heartbeat(self) -> None:
+    ...
+
+@cron(alias="nightly-cleanup", cron_expression="0 2 * * *", span="system")
+async def nightly_cleanup(self) -> None:
+    ...
+```
+
+---
+
+## Bundle descriptor
+
+Every bundle descriptor returned by the integrations endpoint includes the
+declared scheduled jobs. Both `cron_expression` and `expr_config` are shown as
+declared on the decorator — not the runtime-resolved effective value.
+If `expr_config` is set and resolves to a different expression at runtime, the
+descriptor still shows the original `cron_expression` default.
+
+```json
+{
+  "scheduled_jobs": [
+    {
+      "method_name": "rebuild_indexes",
+      "alias": "rebuild-indexes",
+      "cron_expression": "0 * * * *",
+      "expr_config": "routines.reindex.cron",
+      "span": "system"
+    }
+  ]
+}
+```
+
+---
+
+## Implementation files
+
+| File | Purpose |
+|---|---|
+| `infra/plugin/agentic_loader.py` | `@cron` decorator, `CronJobSpec`, `BundleInterfaceManifest.scheduled_jobs`, manifest discovery |
+| `apps/chat/sdk/runtime/bundle_scheduler.py` | `BundleSchedulerManager`, `resolve_effective_cron`, per-job loops, Redis locking |
+| `apps/chat/processor.py` | Creates the manager; calls `reconcile` on startup and after every registry/props change |
+| `apps/chat/proc/rest/integrations/integrations.py` | Exposes `scheduled_jobs` in the bundle descriptor |
+| `apps/chat/sdk/runtime/tests/bundle_scheduler/` | Unit tests: loader discovery, cron resolution, scheduler lifecycle, descriptor |
+
+---
+
+## Reference example
+
+`apps/chat/sdk/examples/bundles/echo.ui@2026-03-30/entrypoint.py`:
+
+```python
+@cron(
+    alias="echo-heartbeat",
+    cron_expression="* * * * *",
+    expr_config="routines.heartbeat.cron",
+    span="system",
+)
+async def scheduled_heartbeat(self) -> None:
+    """
+    Fires every minute by default.
+    Override or disable via bundle props:
+      routines.heartbeat.cron: "*/5 * * * *"   # change interval
+      routines.heartbeat.cron: "disable"        # disable the job
+    """
+    ...
+```
+
+Because `expr_config` is set, the inline `cron_expression` is only used when
+no Redis props or YAML config override is present.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
@@ -609,6 +609,16 @@ def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]
             for s in manifest.ui_widgets
         ],
         "on_message": manifest.on_message.method_name if manifest.on_message else None,
+        "scheduled_jobs": [
+            {
+                "method_name": s.method_name,
+                "alias": s.alias,
+                "cron_expression": s.cron_expression,
+                "expr_config": s.expr_config,
+                "span": s.span,
+            }
+            for s in manifest.scheduled_jobs
+        ],
     }
 
 
@@ -629,6 +639,16 @@ def _manifest_to_descriptor_filtered(
             if _roles_visible(s.roles, session)
         ],
         "on_message": manifest.on_message.method_name if manifest.on_message else None,
+        "scheduled_jobs": [
+            {
+                "method_name": s.method_name,
+                "alias": s.alias,
+                "cron_expression": s.cron_expression,
+                "expr_config": s.expr_config,
+                "span": s.span,
+            }
+            for s in manifest.scheduled_jobs
+        ],
     }
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
@@ -150,6 +150,7 @@ class EnhancedChatRequestProcessor:
         self._processor_task: Optional[asyncio.Task] = None
         self._config_task: Optional[asyncio.Task] = None
         self._reaper_task: Optional[asyncio.Task] = None
+        self._scheduler: Optional[Any] = None
         self._active_tasks: set[asyncio.Task] = set()
         self._active_task_details: dict[asyncio.Task, Dict[str, Any]] = {}
         self._current_load = 0
@@ -190,6 +191,23 @@ class EnhancedChatRequestProcessor:
                 self._inflight_recovery_loop(),
                 name="chat-inflight-recovery-loop",
             )
+        if self._scheduler is None:
+            from kdcube_ai_app.apps.chat.sdk.config import get_settings
+            from kdcube_ai_app.apps.chat.sdk.runtime.bundle_scheduler import BundleSchedulerManager
+            from kdcube_ai_app.infra.plugin.bundle_store import load_registry
+            _settings = get_settings()
+            self._scheduler = BundleSchedulerManager(
+                redis=self.redis,
+                redis_url=getattr(_settings, "REDIS_URL", None),
+                tenant=_settings.TENANT,
+                project=_settings.PROJECT,
+                instance_id=_settings.INSTANCE_ID,
+            )
+            try:
+                _reg = await load_registry(self.redis, _settings.TENANT, _settings.PROJECT)
+                await self._scheduler.reconcile(_reg)
+            except Exception:
+                logger.warning("Initial bundle scheduler reconcile failed; will retry on next registry update", exc_info=True)
 
     async def _await_background_task_exit(
             self,
@@ -251,6 +269,9 @@ class EnhancedChatRequestProcessor:
         self._config_task = None
         await self._await_background_task_exit(self._reaper_task, name="chat-inflight-recovery-loop")
         self._reaper_task = None
+        if self._scheduler is not None:
+            await self._scheduler.shutdown()
+            self._scheduler = None
         await self.wait_for_active_tasks()
 
     def get_current_load(self) -> int:
@@ -803,6 +824,7 @@ class EnhancedChatRequestProcessor:
         project = settings.PROJECT
         update_channel = namespaces.CONFIG.BUNDLES.UPDATE_CHANNEL.format(tenant=tenant, project=project)
         cleanup_channel = namespaces.CONFIG.BUNDLES.CLEANUP_CHANNEL.format(tenant=tenant, project=project)
+        props_update_channel = namespaces.CONFIG.BUNDLES.PROPS_UPDATE_CHANNEL.format(tenant=tenant, project=project)
         backoff = 0.5
         while not self._stop_event.is_set():
             pubsub = None
@@ -811,10 +833,11 @@ class EnhancedChatRequestProcessor:
                 await pubsub.subscribe(
                     update_channel,
                     cleanup_channel,
+                    props_update_channel,
                 )
                 logger.info(
                     "Subscribed to bundles channels: "
-                    f"{update_channel}, {cleanup_channel}"
+                    f"{update_channel}, {cleanup_channel}, {props_update_channel}"
                 )
                 backoff = 0.5
                 self._last_config_error = None
@@ -871,6 +894,11 @@ class EnhancedChatRequestProcessor:
                             logger.debug("Could not save snapshot to Redis; continuing")
 
                         logger.info(f"Applied bundles SNAPSHOT; now have {len(get_all())} bundles")
+                        if self._scheduler is not None:
+                            try:
+                                await self._scheduler.reconcile(reg)
+                            except Exception:
+                                logger.warning("Bundle scheduler reconcile failed after snapshot", exc_info=True)
                         continue
 
                     if evt.get("type") == "bundles.update":
@@ -907,6 +935,11 @@ class EnhancedChatRequestProcessor:
                             pass
 
                         logger.info(f"Applied bundles COMMAND (op={op}); now have {len(get_all())} bundles. New env = {new_env}")
+                        if self._scheduler is not None:
+                            try:
+                                await self._scheduler.reconcile(reg)
+                            except Exception:
+                                logger.warning("Bundle scheduler reconcile failed after bundles.update", exc_info=True)
                         continue
 
                     if evt.get("type") == "bundles.cleanup":
@@ -1004,6 +1037,18 @@ class EnhancedChatRequestProcessor:
                         )
                         continue
 
+                    if message.get("channel") in (
+                        props_update_channel,
+                        props_update_channel.encode(),
+                    ):
+                        if self._scheduler is not None:
+                            try:
+                                current = await store_load(self.redis)
+                                await self._scheduler.reconcile(current)
+                            except Exception:
+                                logger.warning("Bundle scheduler reconcile failed after props update", exc_info=True)
+                        continue
+
                     logger.debug("Ignoring unrelated pub/sub message on bundles channel")
 
                 if self._stop_event.is_set():
@@ -1020,7 +1065,7 @@ class EnhancedChatRequestProcessor:
             finally:
                 if pubsub:
                     try:
-                        await pubsub.unsubscribe(update_channel, cleanup_channel)
+                        await pubsub.unsubscribe(update_channel, cleanup_channel, props_update_channel)
                         await pubsub.close()
                     except Exception:
                         pass

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/echo.ui@2026-03-30/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/echo.ui@2026-03-30/entrypoint.py
@@ -22,7 +22,7 @@ from langgraph.graph import StateGraph, START, END
 
 from kdcube_ai_app.apps.chat.sdk.protocol import ChatTaskPayload
 from kdcube_ai_app.infra.service_hub.inventory import Config, BundleState
-from kdcube_ai_app.infra.plugin.agentic_loader import agentic_workflow, api, bundle_id
+from kdcube_ai_app.infra.plugin.agentic_loader import agentic_workflow, api, bundle_id, cron
 from kdcube_ai_app.apps.chat.sdk.solutions.chatbot.entrypoint import BaseEntrypoint
 
 BUNDLE_ID = "echo.ui"
@@ -102,3 +102,25 @@ class EchoUIBundle(BaseEntrypoint):
         params: Dict[str, Any],
     ):
         return await self.graph.ainvoke(state)
+
+    @cron(
+        alias="echo-heartbeat",
+        cron_expression="* * * * *",
+        expr_config="routines.heartbeat.cron",
+        span="system",
+    )
+    async def scheduled_heartbeat(self) -> None:
+        """
+        Sandbox cron job for testing @cron decorator.
+        Fires every minute by default; can be overridden or disabled via bundle props:
+          routines.heartbeat.cron: "*/5 * * * *"   # change interval
+          routines.heartbeat.cron: "disable"        # disable the job
+        """
+        import logging
+        log = logging.getLogger("echo.ui.cron")
+        props_snapshot = dict(self.bundle_props or {})
+        log.info(
+            "[echo.ui] scheduled_heartbeat fired | bundle_props keys=%s | redis=%s",
+            list(props_snapshot.keys()),
+            "ok" if self.redis is not None else "none",
+        )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/bundle_scheduler.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/bundle_scheduler.py
@@ -1,0 +1,639 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# apps/chat/sdk/runtime/bundle_scheduler.py
+"""
+Proc-owned bundle scheduler manager.
+
+Responsibilities:
+- Enumerate active bundles in the current tenant/project registry
+- Load each bundle manifest and collect CronJobSpec entries
+- Resolve each job's effective cron expression (expr_config wins over cron_expression)
+- Create / cancel per-job asyncio tasks
+- Rebind tasks when registry or props change (reconcile)
+- Shut down cleanly when proc stops
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from croniter import croniter
+from datetime import datetime, timezone
+
+_log = logging.getLogger("kdcube.bundle.scheduler")
+
+# Lock key shapes from the spec:
+#   system:   bundle:cron:lock:{tenant}:{project}:{bundle_id}:{job_alias}
+#   instance: bundle:cron:lock:{tenant}:{project}:{bundle_id}:{job_alias}:{instance_id}
+_LOCK_KEY_SYSTEM = "bundle:cron:lock:{tenant}:{project}:{bundle_id}:{job_alias}"
+_LOCK_KEY_INSTANCE = "bundle:cron:lock:{tenant}:{project}:{bundle_id}:{job_alias}:{instance_id}"
+
+# How long (seconds) we hold the Redis lock — should cover the maximum expected job duration.
+_LOCK_TTL_SECONDS = 3600
+# How often (seconds) we renew the lock while the job is running.
+_LOCK_RENEW_INTERVAL = 60
+
+
+# ---------------------------------------------------------------------------
+# Internal key used to identify a running task
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _JobKey:
+    bundle_id: str
+    job_alias: str
+
+
+# ---------------------------------------------------------------------------
+# Effective cron resolution
+# ---------------------------------------------------------------------------
+
+def resolve_effective_cron(
+    cron_expression: Optional[str],
+    expr_config: Optional[str],
+    props: Dict[str, Any],
+) -> Optional[str]:
+    """
+    Return the effective cron expression string, or None if the job should not
+    be scheduled.
+
+    Precedence:
+    1. If expr_config is set — resolve dot-path against Redis bundle props first,
+       then fall back to read_plain(expr_config) from bundles.yaml / assembly.yaml
+       (configure via BUNDLES_YAML_DESCRIPTOR_PATH for local debug runs).
+       - missing / blank / "disable" (case-insensitive) -> None (do not schedule)
+       - do NOT fall back to cron_expression
+    2. Else if cron_expression is set — use it directly.
+    3. Else -> None (inert, do not schedule)
+    """
+    if expr_config:
+        from kdcube_ai_app.infra.plugin.bundle_store import resolve_dot_path
+        resolved = resolve_dot_path(props, expr_config)
+        if not isinstance(resolved, str):
+            # Not in Redis props — try bundles.yaml then assembly.yaml via read_plain.
+            # This is the standard way to provide config for local debug runs
+            # (set BUNDLES_YAML_DESCRIPTOR_PATH to point to your local bundles.yaml).
+            try:
+                from kdcube_ai_app.apps.chat.sdk.config import read_plain
+                resolved = read_plain(f"b:{expr_config}", default=None)
+                if not isinstance(resolved, str):
+                    resolved = read_plain(expr_config, default=None)
+            except Exception:
+                resolved = None
+        if not isinstance(resolved, str):
+            return None
+        resolved = resolved.strip()
+        if not resolved or resolved.lower() == "disable":
+            return None
+        return resolved
+
+    if cron_expression:
+        return cron_expression
+
+    return None
+
+
+def _is_valid_cron(expr: str) -> bool:
+    try:
+        croniter(expr, datetime.now(timezone.utc))
+        return True
+    except Exception:
+        return False
+
+
+def _compute_next_run(expr: str, now: datetime) -> datetime:
+    it = croniter(expr, now)
+    return it.get_next(datetime)
+
+
+# ---------------------------------------------------------------------------
+# Per-job loop
+# ---------------------------------------------------------------------------
+
+async def _run_job_loop(
+    *,
+    bundle_id: str,
+    job_alias: str,
+    method_name: str,
+    cron_expr: str,
+    span: str,
+    tenant: str,
+    project: str,
+    instance_id: str,
+    redis: Any,
+    bundle_spec: Any,
+    bundle_config: Any,
+) -> None:
+    """
+    Infinite loop for a single scheduled job. Sleeps until the next cron tick,
+    then fires the job according to span semantics.
+    """
+    _log.info(
+        "[scheduler] Job registered: bundle=%s alias=%s expr=%r span=%s",
+        bundle_id, job_alias, cron_expr, span,
+    )
+
+    # For span="process": the job runs as a background task so the tick loop
+    # stays on the absolute cron schedule. Overlap is detected at each tick by
+    # checking whether the previous task is still running.
+    _active_task: Optional[asyncio.Task] = None
+
+    while True:
+        now = datetime.now(timezone.utc)
+        try:
+            next_run = _compute_next_run(cron_expr, now)
+        except Exception:
+            _log.error(
+                "[scheduler] Failed to compute next run for bundle=%s alias=%s expr=%r; stopping job loop",
+                bundle_id, job_alias, cron_expr,
+            )
+            return
+
+        sleep_seconds = (next_run - now).total_seconds()
+        _log.debug(
+            "[scheduler] bundle=%s alias=%s next tick in %.1fs",
+            bundle_id, job_alias, sleep_seconds,
+        )
+
+        try:
+            await asyncio.sleep(sleep_seconds)
+        except asyncio.CancelledError:
+            _log.info("[scheduler] Job cancelled: bundle=%s alias=%s", bundle_id, job_alias)
+            if _active_task is not None and not _active_task.done():
+                _active_task.cancel()
+            return
+
+        _log.info("[scheduler] Tick fired: bundle=%s alias=%s span=%s", bundle_id, job_alias, span)
+
+        if span == "process":
+            if _active_task is not None and not _active_task.done():
+                _log.info(
+                    "[scheduler] Skipping tick — previous run still active: bundle=%s alias=%s",
+                    bundle_id, job_alias,
+                )
+                continue
+
+            async def _run_safe(
+                _bid: str = bundle_id,
+                _alias: str = job_alias,
+                _method: str = method_name,
+                _spec: Any = bundle_spec,
+                _cfg: Any = bundle_config,
+            ) -> None:
+                try:
+                    await _invoke_job(
+                        bundle_id=_bid,
+                        method_name=_method,
+                        bundle_spec=_spec,
+                        bundle_config=_cfg,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    _log.exception("[scheduler] Job failed: bundle=%s alias=%s", _bid, _alias)
+
+            _active_task = asyncio.create_task(
+                _run_safe(),
+                name=f"cron-job:{bundle_id}:{job_alias}",
+            )
+
+        elif span in ("instance", "system"):
+            await _run_with_redis_lock(
+                bundle_id=bundle_id,
+                job_alias=job_alias,
+                method_name=method_name,
+                span=span,
+                tenant=tenant,
+                project=project,
+                instance_id=instance_id,
+                redis=redis,
+                bundle_spec=bundle_spec,
+                bundle_config=bundle_config,
+            )
+
+
+async def _run_with_redis_lock(
+    *,
+    bundle_id: str,
+    job_alias: str,
+    method_name: str,
+    span: str,
+    tenant: str,
+    project: str,
+    instance_id: str,
+    redis: Any,
+    bundle_spec: Any,
+    bundle_config: Any,
+) -> None:
+    if redis is None:
+        _log.warning(
+            "[scheduler] Redis unavailable — skipping tick for bundle=%s alias=%s span=%s "
+            "(will not degrade to process)",
+            bundle_id, job_alias, span,
+        )
+        return
+
+    if span == "system":
+        lock_key = _LOCK_KEY_SYSTEM.format(
+            tenant=tenant, project=project,
+            bundle_id=bundle_id, job_alias=job_alias,
+        )
+    else:  # instance
+        lock_key = _LOCK_KEY_INSTANCE.format(
+            tenant=tenant, project=project,
+            bundle_id=bundle_id, job_alias=job_alias,
+            instance_id=instance_id,
+        )
+
+    token = str(uuid.uuid4())
+
+    try:
+        got_lock = await redis.set(lock_key, token, ex=_LOCK_TTL_SECONDS, nx=True)
+    except Exception:
+        _log.warning(
+            "[scheduler] Redis error acquiring lock for bundle=%s alias=%s — skipping tick",
+            bundle_id, job_alias, exc_info=True,
+        )
+        return
+
+    if not got_lock:
+        _log.info(
+            "[scheduler] Lock held by another; skipping tick: bundle=%s alias=%s span=%s key=%s",
+            bundle_id, job_alias, span, lock_key,
+        )
+        return
+
+    _log.info(
+        "[scheduler] Lock acquired: bundle=%s alias=%s span=%s key=%s",
+        bundle_id, job_alias, span, lock_key,
+    )
+
+    renewer_task: Optional[asyncio.Task] = None
+    try:
+        renewer_task = asyncio.create_task(
+            _renew_lock_loop(redis=redis, lock_key=lock_key, token=token)
+        )
+        await _invoke_job(
+            bundle_id=bundle_id,
+            method_name=method_name,
+            bundle_spec=bundle_spec,
+            bundle_config=bundle_config,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        _log.exception(
+            "[scheduler] Job failed: bundle=%s alias=%s", bundle_id, job_alias,
+        )
+    finally:
+        if renewer_task is not None:
+            renewer_task.cancel()
+            try:
+                await renewer_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        try:
+            current_val = await redis.get(lock_key)
+            if current_val is not None and current_val.decode() == token:
+                await redis.delete(lock_key)
+                _log.info(
+                    "[scheduler] Lock released: bundle=%s alias=%s key=%s",
+                    bundle_id, job_alias, lock_key,
+                )
+        except Exception:
+            _log.exception(
+                "[scheduler] Failed to release lock: bundle=%s alias=%s key=%s",
+                bundle_id, job_alias, lock_key,
+            )
+
+
+async def _renew_lock_loop(*, redis: Any, lock_key: str, token: str) -> None:
+    """Periodically extend the TTL of a held Redis lock."""
+    while True:
+        await asyncio.sleep(_LOCK_RENEW_INTERVAL)
+        try:
+            current_val = await redis.get(lock_key)
+            if current_val is None or current_val.decode() != token:
+                _log.warning("[scheduler] Lock lost during job run: key=%s", lock_key)
+                return
+            await redis.expire(lock_key, _LOCK_TTL_SECONDS)
+        except Exception:
+            _log.warning("[scheduler] Lock renewal failed: key=%s", lock_key, exc_info=True)
+
+
+async def _invoke_job(
+    *,
+    bundle_id: str,
+    method_name: str,
+    bundle_spec: Any,
+    bundle_config: Any,
+) -> None:
+    """Load the workflow instance and invoke the scheduled method."""
+    from kdcube_ai_app.infra.plugin.agentic_loader import get_workflow_instance
+
+    # Resolve pg_pool lazily — same singleton used by the rest of the proc process.
+    pg_pool = None
+    try:
+        from kdcube_ai_app.apps.chat.ingress.resolvers import get_pg_pool
+        pg_pool = await get_pg_pool()
+    except Exception:
+        _log.debug("[scheduler] pg_pool not available for bundle=%s; proceeding without", bundle_id)
+
+    _log.info("[scheduler] Job started: bundle=%s method=%s", bundle_id, method_name)
+    try:
+        comm_context = getattr(bundle_config, "_headless_comm_context", bundle_config)
+        instance, _ = get_workflow_instance(
+            bundle_spec,
+            bundle_config,
+            comm_context=comm_context,
+            redis=getattr(bundle_config, "redis", None),
+            pg_pool=pg_pool,
+        )
+        # Ensure the instance has Redis-loaded bundle props overrides, not just
+        # hardcoded defaults from configuration_defaults(). refresh_bundle_props
+        # is normally called during execute(), but scheduled jobs bypass that path.
+        refresh_fn = getattr(instance, "refresh_bundle_props", None)
+        if callable(refresh_fn):
+            try:
+                await refresh_fn(state={
+                    "tenant": getattr(bundle_config, "tenant", None),
+                    "project": getattr(bundle_config, "project", None),
+                })
+            except Exception:
+                _log.warning(
+                    "[scheduler] refresh_bundle_props failed for bundle=%s; "
+                    "proceeding with defaults",
+                    bundle_id, exc_info=True,
+                )
+
+        fn = getattr(instance, method_name, None)
+        if fn is None:
+            _log.error(
+                "[scheduler] Method not found on bundle instance: bundle=%s method=%s",
+                bundle_id, method_name,
+            )
+            return
+        if asyncio.iscoroutinefunction(fn):
+            await fn()
+        else:
+            await asyncio.to_thread(fn)
+        _log.info("[scheduler] Job completed: bundle=%s method=%s", bundle_id, method_name)
+    except Exception:
+        _log.exception("[scheduler] Job raised: bundle=%s method=%s", bundle_id, method_name)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# BundleSchedulerManager
+# ---------------------------------------------------------------------------
+
+class BundleSchedulerManager:
+    """
+    Central manager for all bundle-declared @cron jobs within one proc process.
+
+    Usage::
+
+        manager = BundleSchedulerManager(
+            redis=redis, redis_url=settings.REDIS_URL,
+            tenant=t, project=p, instance_id=iid,
+        )
+        await manager.reconcile(registry)   # call after startup and every registry/props update
+        await manager.shutdown()            # call on proc stop
+
+    ``redis`` is the processor's shared pool — used only for fast lock operations.
+    ``redis_url`` is used to create a **dedicated** pool for bundle job invocations
+    so that long-running jobs don't exhaust the processor's shared connection pool.
+    """
+
+    def __init__(
+        self,
+        *,
+        redis: Any,
+        redis_url: Optional[str] = None,
+        tenant: str,
+        project: str,
+        instance_id: str,
+    ) -> None:
+        self._redis = redis
+        self._tenant = tenant
+        self._project = project
+        self._instance_id = instance_id
+        # Dedicated Redis client for bundle job invocations (separate from processor pool).
+        # Uses decode_responses=False (default) which differs from the processor's
+        # decode_responses=True pool — so get_async_redis_client returns a distinct pool.
+        self._job_redis: Any = None
+        if redis_url:
+            try:
+                from kdcube_ai_app.infra.redis.client import get_async_redis_client
+                self._job_redis = get_async_redis_client(redis_url)
+            except Exception:
+                _log.warning(
+                    "[scheduler] Could not create dedicated job Redis client; "
+                    "falling back to shared pool",
+                    exc_info=True,
+                )
+                self._job_redis = redis
+        else:
+            self._job_redis = redis
+        # JobKey -> (asyncio.Task, effective_cron_expr)
+        self._tasks: Dict[_JobKey, Tuple[asyncio.Task, str]] = {}
+        _log.info(
+            "[scheduler] Manager initialised: tenant=%s project=%s instance=%s",
+            tenant, project, instance_id,
+        )
+
+    async def reconcile(self, registry: Any) -> None:
+        """
+        Diff running tasks against the current registry + props, cancel stale
+        tasks, and start new ones.  Idempotent — safe to call repeatedly.
+        """
+        from kdcube_ai_app.infra.plugin.agentic_loader import (
+            AgenticBundleSpec,
+            load_bundle_manifest,
+        )
+        from kdcube_ai_app.infra.plugin.bundle_store import get_bundle_props
+
+        desired: Dict[_JobKey, Tuple[str, str, str, Any, Any]] = {}
+        # desired[key] = (cron_expr, method_name, span, bundle_spec, bundle_config)
+
+        for bundle_id, entry in (registry.bundles or {}).items():
+            path = entry.path if hasattr(entry, "path") else entry.get("path", "")
+            module = entry.module if hasattr(entry, "module") else entry.get("module")
+            singleton = (
+                entry.singleton if hasattr(entry, "singleton") else entry.get("singleton", False)
+            )
+            if not path:
+                continue
+
+            spec = AgenticBundleSpec(path=path, module=module, singleton=bool(singleton))
+
+            try:
+                manifest = load_bundle_manifest(spec, bundle_id=bundle_id)
+            except Exception:
+                _log.warning(
+                    "[scheduler] Failed to load manifest for bundle=%s; skipping",
+                    bundle_id, exc_info=True,
+                )
+                continue
+
+            if not manifest.scheduled_jobs:
+                continue
+
+            try:
+                props = await get_bundle_props(
+                    self._redis,
+                    tenant=self._tenant,
+                    project=self._project,
+                    bundle_id=bundle_id,
+                )
+            except Exception:
+                _log.warning(
+                    "[scheduler] Failed to load props for bundle=%s; using empty props",
+                    bundle_id, exc_info=True,
+                )
+                props = {}
+
+            bundle_config = _make_headless_config(
+                tenant=self._tenant,
+                project=self._project,
+                bundle_id=bundle_id,
+                bundle_spec=spec,
+                redis=self._job_redis,
+                props=props,
+            )
+
+            for job_spec in manifest.scheduled_jobs:
+                effective = resolve_effective_cron(
+                    cron_expression=job_spec.cron_expression,
+                    expr_config=job_spec.expr_config,
+                    props=props,
+                )
+
+                key = _JobKey(bundle_id=bundle_id, job_alias=job_spec.alias)
+
+                if effective is None:
+                    _log.info(
+                        "[scheduler] Job disabled (no valid cron): bundle=%s alias=%s "
+                        "expr_config=%r cron_expression=%r",
+                        bundle_id, job_spec.alias,
+                        job_spec.expr_config, job_spec.cron_expression,
+                    )
+                    continue
+
+                if not _is_valid_cron(effective):
+                    _log.error(
+                        "[scheduler] Invalid cron expression — not scheduling: "
+                        "bundle=%s alias=%s expr=%r",
+                        bundle_id, job_spec.alias, effective,
+                    )
+                    continue
+
+                _log.debug(
+                    "[scheduler] Resolved cron: bundle=%s alias=%s expr=%r span=%s",
+                    bundle_id, job_spec.alias, effective, job_spec.span,
+                )
+                desired[key] = (effective, job_spec.method_name, job_spec.span, spec, bundle_config)
+
+        # Cancel tasks that are no longer desired or whose cron changed
+        for key in list(self._tasks.keys()):
+            task, old_expr = self._tasks[key]
+            if key not in desired:
+                _log.info(
+                    "[scheduler] Cancelling removed job: bundle=%s alias=%s",
+                    key.bundle_id, key.job_alias,
+                )
+                task.cancel()
+                del self._tasks[key]
+            elif desired[key][0] != old_expr:
+                _log.info(
+                    "[scheduler] Cron changed — rescheduling: bundle=%s alias=%s old=%r new=%r",
+                    key.bundle_id, key.job_alias, old_expr, desired[key][0],
+                )
+                task.cancel()
+                del self._tasks[key]
+
+        # Start new tasks
+        for key, (cron_expr, method_name, span, spec, bundle_config) in desired.items():
+            if key in self._tasks:
+                continue
+            _log.info(
+                "[scheduler] Scheduling job: bundle=%s alias=%s expr=%r span=%s",
+                key.bundle_id, key.job_alias, cron_expr, span,
+            )
+            task = asyncio.create_task(
+                _run_job_loop(
+                    bundle_id=key.bundle_id,
+                    job_alias=key.job_alias,
+                    method_name=method_name,
+                    cron_expr=cron_expr,
+                    span=span,
+                    tenant=self._tenant,
+                    project=self._project,
+                    instance_id=self._instance_id,
+                    redis=self._redis,
+                    bundle_spec=spec,
+                    bundle_config=bundle_config,
+                ),
+                name=f"cron:{key.bundle_id}:{key.job_alias}",
+            )
+            self._tasks[key] = (task, cron_expr)
+
+    async def shutdown(self) -> None:
+        """Cancel all running job tasks and wait for them to finish."""
+        _log.info("[scheduler] Shutting down — cancelling %d job(s)", len(self._tasks))
+        for key, (task, _) in list(self._tasks.items()):
+            task.cancel()
+        if self._tasks:
+            await asyncio.gather(*[t for t, _ in self._tasks.values()], return_exceptions=True)
+        self._tasks.clear()
+        _log.info("[scheduler] Shutdown complete")
+
+
+# ---------------------------------------------------------------------------
+# Headless bundle config
+# ---------------------------------------------------------------------------
+
+def _make_headless_config(
+    *,
+    tenant: str,
+    project: str,
+    bundle_id: str,
+    bundle_spec: Any,
+    redis: Any,
+    props: Dict[str, Any],
+) -> Any:
+    """
+    Build a real Config object for headless (no user session) scheduled job invocation.
+
+    Uses the real Config class so that bundle internals such as refresh_bundle_props
+    can resolve self.config.ai_bundle_spec.id for Redis props lookup.
+    """
+    from types import SimpleNamespace
+    from kdcube_ai_app.infra.service_hub.inventory import Config
+    from kdcube_ai_app.infra.plugin.bundle_registry import BundleSpec
+
+    config = Config()
+    config.tenant = tenant
+    config.project = project
+    config.ai_bundle_spec = BundleSpec(
+        id=bundle_id,
+        path=getattr(bundle_spec, "path", ""),
+        module=getattr(bundle_spec, "module", None),
+        singleton=getattr(bundle_spec, "singleton", False),
+    )
+
+    # Pass Redis so bundle internals (self.redis, storage helpers) work in headless mode.
+    config.redis = redis
+
+    # Minimal comm_context so get_workflow_instance can extract tenant/project
+    config._headless_comm_context = SimpleNamespace(
+        actor=SimpleNamespace(tenant_id=tenant, project_id=project),
+        meta=SimpleNamespace(tenant=tenant, project=project),
+    )
+
+    return config

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_descriptor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_descriptor.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+"""
+Descriptor serialization tests for scheduled_jobs.
+
+Verifies that _manifest_to_descriptor() and _manifest_to_descriptor_filtered()
+include the declared scheduled_jobs list and that it is not role-filtered.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from kdcube_ai_app.apps.chat.proc.rest.integrations.integrations import (
+    _manifest_to_descriptor,
+    _manifest_to_descriptor_filtered,
+)
+from kdcube_ai_app.infra.plugin.agentic_loader import (
+    BundleInterfaceManifest,
+    CronJobSpec,
+)
+
+
+def _make_manifest(jobs: list[CronJobSpec]) -> BundleInterfaceManifest:
+    return BundleInterfaceManifest(
+        bundle_id="test.bundle",
+        scheduled_jobs=tuple(jobs),
+    )
+
+
+def _make_session(roles: list[str] = None) -> MagicMock:
+    session = MagicMock()
+    session.roles = roles or []
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_descriptor_includes_scheduled_jobs():
+    jobs = [
+        CronJobSpec(
+            method_name="rebuild_indexes",
+            alias="rebuild",
+            cron_expression=None,
+            expr_config="apps.app1.routines.cron",
+            span="system",
+        )
+    ]
+    desc = _manifest_to_descriptor(_make_manifest(jobs))
+    assert "scheduled_jobs" in desc
+    assert len(desc["scheduled_jobs"]) == 1
+    job = desc["scheduled_jobs"][0]
+    assert job["method_name"] == "rebuild_indexes"
+    assert job["alias"] == "rebuild"
+    assert job["cron_expression"] is None
+    assert job["expr_config"] == "apps.app1.routines.cron"
+    assert job["span"] == "system"
+
+
+def test_descriptor_empty_when_no_jobs():
+    desc = _manifest_to_descriptor(_make_manifest([]))
+    assert desc["scheduled_jobs"] == []
+
+
+def test_descriptor_multiple_jobs():
+    jobs = [
+        CronJobSpec(method_name="job_a", alias="job-a", cron_expression="* * * * *", span="process"),
+        CronJobSpec(method_name="job_b", alias="job-b", expr_config="routines.b.cron", span="system"),
+    ]
+    desc = _manifest_to_descriptor(_make_manifest(jobs))
+    assert len(desc["scheduled_jobs"]) == 2
+    aliases = {j["alias"] for j in desc["scheduled_jobs"]}
+    assert aliases == {"job-a", "job-b"}
+
+
+def test_descriptor_filtered_includes_scheduled_jobs_regardless_of_role():
+    """scheduled_jobs are system metadata — not filtered by user role."""
+    jobs = [
+        CronJobSpec(method_name="heartbeat", alias="hb", cron_expression="* * * * *", span="system"),
+    ]
+    manifest = _make_manifest(jobs)
+
+    # Session with no roles
+    desc = _manifest_to_descriptor_filtered(manifest, _make_session(roles=[]))
+    assert len(desc["scheduled_jobs"]) == 1
+    assert desc["scheduled_jobs"][0]["alias"] == "hb"
+
+    # Session with arbitrary roles
+    desc2 = _manifest_to_descriptor_filtered(manifest, _make_session(roles=["kdcube:role:chat-user"]))
+    assert len(desc2["scheduled_jobs"]) == 1
+
+
+def test_descriptor_preserves_all_fields():
+    job = CronJobSpec(
+        method_name="my_method",
+        alias="my-alias",
+        cron_expression="*/30 * * * *",
+        expr_config="some.config.path",
+        span="instance",
+    )
+    desc = _manifest_to_descriptor(_make_manifest([job]))
+    serialized = desc["scheduled_jobs"][0]
+    assert serialized["method_name"] == "my_method"
+    assert serialized["alias"] == "my-alias"
+    assert serialized["cron_expression"] == "*/30 * * * *"
+    assert serialized["expr_config"] == "some.config.path"
+    assert serialized["span"] == "instance"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_loader.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_loader.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+"""
+Loader discovery tests for @cron-decorated bundle methods.
+
+Verifies that CronJobSpec entries are correctly collected into
+BundleInterfaceManifest.scheduled_jobs by discover_bundle_interface_manifest().
+"""
+from __future__ import annotations
+
+import pytest
+
+from kdcube_ai_app.infra.plugin.agentic_loader import (
+    cron,
+    CronJobSpec,
+    discover_bundle_interface_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal stub bundle classes
+# ---------------------------------------------------------------------------
+
+class _BundleWithInlineExpr:
+    BUNDLE_ID = "test.inline"
+
+    @cron(alias="do-work", cron_expression="*/5 * * * *", span="process")
+    async def do_work(self) -> None:
+        pass
+
+
+class _BundleWithExprConfig:
+    BUNDLE_ID = "test.cfg"
+
+    @cron(alias="rebuild", expr_config="routines.rebuild.cron", span="system")
+    async def rebuild(self) -> None:
+        pass
+
+
+class _BundleWithBothSources:
+    BUNDLE_ID = "test.both"
+
+    @cron(
+        alias="job",
+        cron_expression="*/15 * * * *",
+        expr_config="routines.job.cron",
+        span="instance",
+    )
+    async def job(self) -> None:
+        pass
+
+
+class _BundleWithNoAlias:
+    BUNDLE_ID = "test.noalias"
+
+    @cron(cron_expression="0 * * * *", span="process")
+    async def hourly_task(self) -> None:
+        pass
+
+
+class _BundleWithMultipleCronMethods:
+    BUNDLE_ID = "test.multi"
+
+    @cron(alias="job-a", cron_expression="*/5 * * * *", span="process")
+    async def job_a(self) -> None:
+        pass
+
+    @cron(alias="job-b", cron_expression="0 * * * *", span="system")
+    async def job_b(self) -> None:
+        pass
+
+
+class _BundleWithSyncMethod:
+    BUNDLE_ID = "test.sync"
+
+    @cron(alias="sync-job", cron_expression="*/10 * * * *", span="process")
+    def sync_job(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_cron_expression_discovered():
+    manifest = discover_bundle_interface_manifest(_BundleWithInlineExpr, bundle_id="test.inline")
+    assert len(manifest.scheduled_jobs) == 1
+    job = manifest.scheduled_jobs[0]
+    assert isinstance(job, CronJobSpec)
+    assert job.alias == "do-work"
+    assert job.cron_expression == "*/5 * * * *"
+    assert job.expr_config is None
+    assert job.span == "process"
+    assert job.method_name == "do_work"
+
+
+def test_expr_config_discovered():
+    manifest = discover_bundle_interface_manifest(_BundleWithExprConfig, bundle_id="test.cfg")
+    assert len(manifest.scheduled_jobs) == 1
+    job = manifest.scheduled_jobs[0]
+    assert job.alias == "rebuild"
+    assert job.cron_expression is None
+    assert job.expr_config == "routines.rebuild.cron"
+    assert job.span == "system"
+
+
+def test_both_sources_preserved_in_manifest():
+    manifest = discover_bundle_interface_manifest(_BundleWithBothSources, bundle_id="test.both")
+    assert len(manifest.scheduled_jobs) == 1
+    job = manifest.scheduled_jobs[0]
+    assert job.cron_expression == "*/15 * * * *"
+    assert job.expr_config == "routines.job.cron"
+    assert job.span == "instance"
+
+
+def test_alias_defaults_to_method_name():
+    manifest = discover_bundle_interface_manifest(_BundleWithNoAlias, bundle_id="test.noalias")
+    assert len(manifest.scheduled_jobs) == 1
+    job = manifest.scheduled_jobs[0]
+    assert job.alias == "hourly_task"
+    assert job.method_name == "hourly_task"
+
+
+def test_multiple_cron_methods_on_same_bundle_allowed():
+    manifest = discover_bundle_interface_manifest(_BundleWithMultipleCronMethods, bundle_id="test.multi")
+    assert len(manifest.scheduled_jobs) == 2
+    aliases = {j.alias for j in manifest.scheduled_jobs}
+    assert aliases == {"job-a", "job-b"}
+
+
+def test_sync_method_discovered():
+    manifest = discover_bundle_interface_manifest(_BundleWithSyncMethod, bundle_id="test.sync")
+    assert len(manifest.scheduled_jobs) == 1
+    assert manifest.scheduled_jobs[0].alias == "sync-job"
+
+
+def test_invalid_span_rejected_at_decoration_time():
+    with pytest.raises(ValueError, match="Invalid cron span"):
+        @cron(cron_expression="* * * * *", span="weekly")
+        async def bad(self) -> None:
+            pass
+
+
+def test_empty_span_defaults_to_system():
+    class _Bundle:
+        BUNDLE_ID = "test.empty-span"
+
+        @cron(cron_expression="* * * * *", span="")
+        async def job(self) -> None:
+            pass
+
+    manifest = discover_bundle_interface_manifest(_Bundle, bundle_id="test.empty-span")
+    assert manifest.scheduled_jobs[0].span == "system"
+
+
+def test_default_span_is_system():
+    class _Bundle:
+        BUNDLE_ID = "test.default-span"
+
+        @cron(cron_expression="* * * * *")
+        async def job(self) -> None:
+            pass
+
+    manifest = discover_bundle_interface_manifest(_Bundle, bundle_id="test.default-span")
+    assert manifest.scheduled_jobs[0].span == "system"
+
+
+def test_bundle_without_cron_has_empty_scheduled_jobs():
+    class _NoCronBundle:
+        BUNDLE_ID = "test.nocron"
+
+        async def regular_method(self) -> None:
+            pass
+
+    manifest = discover_bundle_interface_manifest(_NoCronBundle, bundle_id="test.nocron")
+    assert manifest.scheduled_jobs == ()
+
+
+def test_scheduled_jobs_sorted_by_alias():
+    class _Sorted:
+        BUNDLE_ID = "test.sorted"
+
+        @cron(alias="zzz", cron_expression="* * * * *", span="process")
+        async def zzz(self) -> None:
+            pass
+
+        @cron(alias="aaa", cron_expression="* * * * *", span="process")
+        async def aaa(self) -> None:
+            pass
+
+    manifest = discover_bundle_interface_manifest(_Sorted, bundle_id="test.sorted")
+    assert [j.alias for j in manifest.scheduled_jobs] == ["aaa", "zzz"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_resolution.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_resolution.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+"""
+Resolution tests for resolve_effective_cron().
+
+Verifies all precedence and disable rules from the spec.
+"""
+from __future__ import annotations
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.runtime.bundle_scheduler import resolve_effective_cron
+
+
+def test_inline_only():
+    assert resolve_effective_cron("*/5 * * * *", None, {}) == "*/5 * * * *"
+
+
+def test_expr_config_found_in_props():
+    props = {"routines": {"job": {"cron": "0 * * * *"}}}
+    result = resolve_effective_cron(None, "routines.job.cron", props)
+    assert result == "0 * * * *"
+
+
+def test_expr_config_wins_over_cron_expression():
+    props = {"routines": {"job": {"cron": "0 * * * *"}}}
+    result = resolve_effective_cron("*/5 * * * *", "routines.job.cron", props)
+    assert result == "0 * * * *"
+
+
+def test_expr_config_missing_from_props_returns_none():
+    result = resolve_effective_cron("*/5 * * * *", "routines.job.cron", {})
+    assert result is None
+
+
+def test_expr_config_disable_returns_none():
+    props = {"routines": {"job": {"cron": "disable"}}}
+    result = resolve_effective_cron(None, "routines.job.cron", props)
+    assert result is None
+
+
+def test_expr_config_disable_case_insensitive():
+    for value in ("DISABLE", "Disable", "DISABLE  ", "  disable  "):
+        props = {"routines": {"job": {"cron": value}}}
+        result = resolve_effective_cron(None, "routines.job.cron", props)
+        assert result is None, f"expected None for {value!r}"
+
+
+def test_expr_config_blank_returns_none():
+    for blank in ("", "   "):
+        props = {"routines": {"job": {"cron": blank}}}
+        result = resolve_effective_cron(None, "routines.job.cron", props)
+        assert result is None, f"expected None for {blank!r}"
+
+
+def test_expr_config_non_string_returns_none():
+    props = {"routines": {"job": {"cron": 42}}}
+    result = resolve_effective_cron(None, "routines.job.cron", props)
+    assert result is None
+
+
+def test_neither_provided_returns_none():
+    assert resolve_effective_cron(None, None, {}) is None
+
+
+def test_expr_config_deep_path():
+    props = {"a": {"b": {"c": {"d": "*/10 * * * *"}}}}
+    assert resolve_effective_cron(None, "a.b.c.d", props) == "*/10 * * * *"
+
+
+def test_expr_config_path_partially_missing_returns_none():
+    props = {"a": {"b": {}}}
+    assert resolve_effective_cron(None, "a.b.c.d", props) is None
+
+
+def test_expr_config_no_fallback_to_cron_expression_when_disabled():
+    """If expr_config resolves to 'disable', cron_expression must NOT be used."""
+    props = {"routines": {"cron": "disable"}}
+    result = resolve_effective_cron("*/5 * * * *", "routines.cron", props)
+    assert result is None
+
+
+def test_expr_config_no_fallback_to_cron_expression_when_missing():
+    """If expr_config path is missing in props, cron_expression must NOT be used."""
+    result = resolve_effective_cron("*/5 * * * *", "routines.cron", {})
+    assert result is None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_scheduler.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_scheduler.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+"""
+BundleSchedulerManager lifecycle tests.
+
+Covers: startup reconcile, live rebind, cancellation on disable,
+no-overlap guard for process span, shutdown.
+All tests use fake registries and stub manifests — no Redis, no real bundles.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from kdcube_ai_app.apps.chat.sdk.runtime.bundle_scheduler import (
+    BundleSchedulerManager,
+    _JobKey,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_registry(*bundle_ids: str) -> Any:
+    bundles = {
+        bid: SimpleNamespace(path=f"/fake/path/{bid}", module=None, singleton=False)
+        for bid in bundle_ids
+    }
+    return SimpleNamespace(bundles=bundles)
+
+
+def _empty_registry() -> Any:
+    return SimpleNamespace(bundles={})
+
+
+def _make_job_spec(
+    *,
+    alias: str,
+    method_name: str = "run",
+    cron_expression: str | None = "* * * * *",
+    expr_config: str | None = None,
+    span: str = "process",
+) -> Any:
+    return SimpleNamespace(
+        alias=alias,
+        method_name=method_name,
+        cron_expression=cron_expression,
+        expr_config=expr_config,
+        span=span,
+    )
+
+
+def _make_manifest(jobs: list) -> Any:
+    return SimpleNamespace(scheduled_jobs=jobs)
+
+
+def _patches(manifest, props=None):
+    """Return three independent patches for reconcile dependencies.
+
+    load_bundle_manifest and get_bundle_props are lazy-imported inside reconcile(),
+    so we must patch them at their source modules.
+    _make_headless_config is module-level so we can patch it directly.
+    """
+    return (
+        patch(
+            "kdcube_ai_app.infra.plugin.agentic_loader.load_bundle_manifest",
+            return_value=manifest,
+        ),
+        patch(
+            "kdcube_ai_app.infra.plugin.bundle_store.get_bundle_props",
+            new=AsyncMock(return_value=props or {}),
+        ),
+        patch(
+            "kdcube_ai_app.apps.chat.sdk.runtime.bundle_scheduler._make_headless_config",
+            return_value=SimpleNamespace(tenant="t", project="p", redis=None),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_reconcile_empty_registry_creates_no_tasks():
+    async def _t():
+        mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+        await mgr.reconcile(_empty_registry())
+        assert len(mgr._tasks) == 0
+        await mgr.shutdown()
+    _run(_t())
+
+
+def test_reconcile_schedules_job_for_bundle():
+    manifest = _make_manifest([_make_job_spec(alias="heartbeat")])
+    pm, pp, ph = _patches(manifest)
+
+    async def _t():
+        with pm, pp, ph:
+            mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+            await mgr.reconcile(_make_registry("echo.ui"))
+        assert _JobKey(bundle_id="echo.ui", job_alias="heartbeat") in mgr._tasks
+        await mgr.shutdown()
+        assert len(mgr._tasks) == 0
+    _run(_t())
+
+
+def test_reconcile_skips_bundle_without_path():
+    async def _t():
+        mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+        reg = SimpleNamespace(bundles={
+            "bad.bundle": SimpleNamespace(path="", module=None, singleton=False)
+        })
+        await mgr.reconcile(reg)
+        assert len(mgr._tasks) == 0
+        await mgr.shutdown()
+    _run(_t())
+
+
+def test_reconcile_disabled_job_not_scheduled():
+    # expr_config present but props empty -> effective=None -> not scheduled
+    manifest = _make_manifest([
+        _make_job_spec(alias="job", cron_expression=None, expr_config="routines.cron")
+    ])
+    pm, pp, ph = _patches(manifest, props={})
+
+    async def _t():
+        with pm, pp, ph:
+            mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+            await mgr.reconcile(_make_registry("demo.bundle"))
+        assert len(mgr._tasks) == 0
+        await mgr.shutdown()
+    _run(_t())
+
+
+def test_reconcile_cancels_job_removed_from_registry():
+    manifest = _make_manifest([_make_job_spec(alias="job")])
+    pm, pp, ph = _patches(manifest)
+
+    async def _t():
+        with pm, pp, ph:
+            mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+            await mgr.reconcile(_make_registry("echo.ui"))
+            assert len(mgr._tasks) == 1
+            # Second reconcile with empty registry -> job removed
+            await mgr.reconcile(_empty_registry())
+        assert len(mgr._tasks) == 0
+        await mgr.shutdown()
+    _run(_t())
+
+
+def test_reconcile_reschedules_job_when_cron_changes():
+    manifest_v1 = _make_manifest([_make_job_spec(alias="job", cron_expression="* * * * *")])
+    manifest_v2 = _make_manifest([_make_job_spec(alias="job", cron_expression="*/5 * * * *")])
+    key = _JobKey(bundle_id="demo.bundle", job_alias="job")
+
+    async def _t():
+        mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+        pm1, pp1, ph1 = _patches(manifest_v1)
+        with pm1, pp1, ph1:
+            await mgr.reconcile(_make_registry("demo.bundle"))
+        task_v1, expr_v1 = mgr._tasks[key]
+        assert expr_v1 == "* * * * *"
+
+        pm2, pp2, ph2 = _patches(manifest_v2)
+        with pm2, pp2, ph2:
+            await mgr.reconcile(_make_registry("demo.bundle"))
+        task_v2, expr_v2 = mgr._tasks[key]
+        assert expr_v2 == "*/5 * * * *"
+        assert task_v1 is not task_v2
+
+        await mgr.shutdown()
+    _run(_t())
+
+
+def test_reconcile_stable_when_cron_unchanged():
+    manifest = _make_manifest([_make_job_spec(alias="job")])
+    key = _JobKey(bundle_id="demo.bundle", job_alias="job")
+
+    async def _t():
+        mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+        pm, pp, ph = _patches(manifest)
+        with pm, pp, ph:
+            await mgr.reconcile(_make_registry("demo.bundle"))
+            task_first = mgr._tasks[key][0]
+            await mgr.reconcile(_make_registry("demo.bundle"))
+            task_second = mgr._tasks[key][0]
+        assert task_first is task_second  # same task, not recreated
+        await mgr.shutdown()
+    _run(_t())
+
+
+def test_reconcile_invalid_cron_not_scheduled():
+    manifest = _make_manifest([_make_job_spec(alias="bad", cron_expression="not-a-cron")])
+    pm, pp, ph = _patches(manifest)
+
+    async def _t():
+        with pm, pp, ph:
+            mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+            await mgr.reconcile(_make_registry("demo.bundle"))
+        assert len(mgr._tasks) == 0
+        await mgr.shutdown()
+    _run(_t())
+
+
+def test_shutdown_cancels_all_tasks():
+    manifest = _make_manifest([
+        _make_job_spec(alias="job-a"),
+        _make_job_spec(alias="job-b", cron_expression="*/5 * * * *"),
+    ])
+    pm, pp, ph = _patches(manifest)
+
+    async def _t():
+        with pm, pp, ph:
+            mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+            await mgr.reconcile(_make_registry("demo.bundle"))
+            assert len(mgr._tasks) == 2
+        await mgr.shutdown()
+        assert len(mgr._tasks) == 0
+    _run(_t())
+
+
+def test_reconcile_manifest_load_failure_skips_bundle():
+    async def _t():
+        with patch(
+            "kdcube_ai_app.infra.plugin.agentic_loader.load_bundle_manifest",
+            side_effect=RuntimeError("cannot load"),
+        ):
+            mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+            # Must not raise — failure is logged and skipped
+            await mgr.reconcile(_make_registry("broken.bundle"))
+        assert len(mgr._tasks) == 0
+        await mgr.shutdown()
+    _run(_t())
+
+
+def test_reconcile_enables_previously_disabled_job():
+    """Job that was disabled (expr_config missing) becomes active when props appear."""
+    manifest = _make_manifest([
+        _make_job_spec(alias="job", cron_expression=None, expr_config="routines.cron")
+    ])
+    key = _JobKey(bundle_id="demo.bundle", job_alias="job")
+
+    async def _t():
+        mgr = BundleSchedulerManager(redis=None, tenant="t", project="p", instance_id="i1")
+
+        # First reconcile: no props -> disabled
+        pm, pp, ph = _patches(manifest, props={})
+        with pm, pp, ph:
+            await mgr.reconcile(_make_registry("demo.bundle"))
+        assert len(mgr._tasks) == 0
+
+        # Second reconcile: props now present -> job starts
+        pm2, pp2, ph2 = _patches(
+            manifest,
+            props={"routines": {"cron": "*/5 * * * *"}},
+        )
+        with pm2, pp2, ph2:
+            await mgr.reconcile(_make_registry("demo.bundle"))
+        assert key in mgr._tasks
+
+        await mgr.shutdown()
+    _run(_t())

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
@@ -40,6 +40,7 @@ API_METHOD_ATTR = "__bundle_api_method__"
 UI_WIDGET_ATTR = "__bundle_ui_widget__"
 ON_MESSAGE_ATTR = "__bundle_on_message__"
 UI_MAIN_ATTR = "__bundle_ui_main__"
+CRON_JOB_ATTR = "__bundle_cron_job__"
 BUNDLE_VENV_ATTR = "__bundle_venv__"
 _BUNDLE_VENV_EXEC_ENV = "KDCUBE_BUNDLE_VENV_EXEC"
 _BUNDLE_VENV_STAMP_FILE = ".kdcube_venv_stamp.json"
@@ -96,6 +97,15 @@ class UIMainSpec:
 
 
 @dataclass(frozen=True)
+class CronJobSpec:
+    method_name: str
+    alias: str = ""
+    cron_expression: str | None = None
+    expr_config: str | None = None
+    span: str = "system"
+
+
+@dataclass(frozen=True)
 class BundleInterfaceManifest:
     bundle_id: str
     allowed_roles: tuple[str, ...] = ()
@@ -103,6 +113,7 @@ class BundleInterfaceManifest:
     api_endpoints: tuple[APIEndpointSpec, ...] = ()
     ui_main: UIMainSpec | None = None
     on_message: OnMessageSpec | None = None
+    scheduled_jobs: tuple[CronJobSpec, ...] = ()
 
 
 def _clean_alias(value: str | None, default: str) -> str:
@@ -369,6 +380,52 @@ def venv(
 
         setattr(_sync_wrapper, BUNDLE_VENV_ATTR, meta)
         return _sync_wrapper
+
+
+_VALID_CRON_SPANS = frozenset({"process", "instance", "system"})
+
+
+def cron(
+        *,
+        alias: str | None = None,
+        cron_expression: str | None = None,
+        expr_config: str | None = None,
+        span: str = "system",
+):
+    """
+    Mark a bundle method as a scheduled job.
+
+    Args:
+        alias: human-readable job name used as a stable identifier. Defaults
+            to the method name if not provided.
+        cron_expression: inline cron expression, e.g. ``"*/15 * * * *"``.
+        expr_config: dot-separated path into bundle props/config, e.g.
+            ``"apps.app1.routines.cron"``. If provided, takes precedence over
+            ``cron_expression`` at runtime. If the resolved value is missing,
+            blank, or ``"disable"``, the job is not scheduled.
+        span: exclusivity level — one of ``"process"``, ``"instance"``,
+            ``"system"``. Defaults to ``"system"``.
+    """
+    span_norm = str(span).strip().lower() if span else "system"
+    if span_norm not in _VALID_CRON_SPANS:
+        raise ValueError(
+            f"Invalid cron span: {span!r}. Must be one of: process, instance, system"
+        )
+
+    def _wrap(fn):
+        method_name = getattr(fn, "__name__", "cron_job")
+        setattr(
+            fn,
+            CRON_JOB_ATTR,
+            CronJobSpec(
+                method_name=method_name,
+                alias=_clean_alias(alias, method_name),
+                cron_expression=str(cron_expression).strip() if cron_expression is not None else None,
+                expr_config=str(expr_config).strip() if expr_config is not None else None,
+                span=span_norm,
+            ),
+        )
+        return fn
 
     return _wrap
 
@@ -1205,7 +1262,7 @@ def _instantiate_symbol(kind: str, symbol: Any, config: Any, extra_kwargs: Dict[
 
 def _iter_bundle_callable_members(target: Any):
     cls = target if isinstance(target, type) else target.__class__
-    _bundle_attrs = (API_METHOD_ATTR, UI_WIDGET_ATTR, ON_MESSAGE_ATTR, UI_MAIN_ATTR)
+    _bundle_attrs = (API_METHOD_ATTR, UI_WIDGET_ATTR, ON_MESSAGE_ATTR, UI_MAIN_ATTR, CRON_JOB_ATTR)
     for name, member in inspect.getmembers(cls, predicate=callable):
         if name.startswith("__"):
             continue
@@ -1238,6 +1295,7 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
     ui_widgets: list[UIWidgetSpec] = []
     ui_main_spec: UIMainSpec | None = None
     on_message_spec: OnMessageSpec | None = None
+    scheduled_jobs: list[CronJobSpec] = []
     seen_api: set[tuple[str, str]] = set()
     seen_widgets: set[str] = set()
 
@@ -1288,11 +1346,22 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 raise ValueError("Multiple @on_message methods detected on bundle entrypoint")
             on_message_spec = resolved
 
+        cron_spec = getattr(fn, CRON_JOB_ATTR, None)
+        if isinstance(cron_spec, CronJobSpec):
+            scheduled_jobs.append(CronJobSpec(
+                method_name=member_name,
+                alias=cron_spec.alias or member_name,
+                cron_expression=cron_spec.cron_expression,
+                expr_config=cron_spec.expr_config,
+                span=cron_spec.span,
+            ))
+
     meta = getattr(cls, AGENTIC_META_ATTR, {}) or {}
     allowed_roles: tuple[str, ...] = _tuple_str(meta.get("allowed_roles"))
 
     api_endpoints.sort(key=lambda item: (item.alias, item.route, item.http_method, item.method_name))
     ui_widgets.sort(key=lambda item: (item.alias, item.method_name))
+    scheduled_jobs.sort(key=lambda item: (item.alias, item.method_name))
     return BundleInterfaceManifest(
         bundle_id=resolved_bundle_id,
         allowed_roles=allowed_roles,
@@ -1300,6 +1369,7 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
         api_endpoints=tuple(api_endpoints),
         ui_main=ui_main_spec,
         on_message=on_message_spec,
+        scheduled_jobs=tuple(scheduled_jobs),
     )
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_store.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_store.py
@@ -410,6 +410,35 @@ async def _apply_bundle_props(
         await redis.set(key, json.dumps(props, ensure_ascii=False))
 
 
+async def get_bundle_props(
+    redis,
+    *,
+    tenant: str,
+    project: str,
+    bundle_id: str,
+) -> Dict[str, Any]:
+    """Return the stored props dict for a bundle, or {} if not set."""
+    key = _props_key(tenant=tenant, project=project, bundle_id=bundle_id)
+    raw = await redis.get(key)
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def resolve_dot_path(obj: Any, path: str) -> Any:
+    """
+    Resolve a dot-separated path into a nested dict, e.g.
+    ``resolve_dot_path(props, "apps.some_app.routines.cron")`` returns the value
+    at ``props["apps"]["some_app"]["routines"]["cron"]``, or ``None`` if any
+    segment is missing or the traversal hits a non-dict node.
+    """
+    for part in path.split("."):
+        if not isinstance(obj, dict):
+            return None
+        obj = obj.get(part)
+    return obj
+
+
 def _decode_redis_key(raw: Any) -> str:
     if isinstance(raw, bytes):
         return raw.decode("utf-8", errors="ignore")


### PR DESCRIPTION
  - @cron(alias, cron_expression, expr_config, span) decorator in agentic_loader
  - CronJobSpec dataclass; BundleInterfaceManifest.scheduled_jobs field
  - scheduled_jobs exposed in bundle descriptor (integrations endpoint)
  - BundleSchedulerManager: reconcile on startup and after every registry/props change
  - effective cron resolution: expr_config (Redis props → bundles.yaml → assembly.yaml) wins over cron_expression
  - span semantics: process (no lock), instance/system (Redis lock with TTL renewal)
  - Redis unavailability: tick skipped, warning logged — no silent degradation to process
  - dedicated Redis pool for job invocations (avoids contention with processor pool)
  - span="" defaults to "system"; invalid span raises at decoration time
  - echo.ui example extended with @cron sandbox job
  - unit tests: loader discovery, cron resolution, scheduler lifecycle, descriptor (40 tests)
  - docs: bundle-scheduled-jobs-README.md; bundle-platform-integration-README.md updated