### PR TITLE
Migrate os.getenv call sites to get_settings/get_secret

### DIFF
--- a/app/ai-app/deployment/assembly.yaml
+++ b/app/ai-app/deployment/assembly.yaml
@@ -1,129 +1,285 @@
-config:
-  version: "2026.3.10.209"
-
-release_name: "local-default"
-domain: ""   # required when proxy.ssl=true; used for proxylogin URLs and nginx SSL server_name/cert paths
-company: ""
+domain: "" # required when proxy.ssl=true; used for proxylogin URLs and nginx SSL server_name/cert paths
+company: "KDCube"
 
 context:
-  tenant: "demo-tenant"
-  project: "demo-project"
+  tenant: "demo-tenant"    # TENANT_ID
+  project: "demo-project"  # PROJECT_ID
 
-secrets:
-  provider: "secrets-service"   # "secrets-service" | "aws-sm" | "in-memory" | "secrets-file"
-
-# for cloud
-storage:
-  kdcube: "s3://../data/kdcube"
-  bundles: "s3://../data/kdcube"
-  workspace:
-    type: git
-    repo: "" # repo url
-  claude_code_session:
-    type: local   # local | git
-    repo: ""      # repo url; used only when type=git
-
-paths:
-  host_bundles_path: ""   # required for descriptor-driven local bundle installs; host folder mounted into /bundles
-  host_git_bundles_path: ""   # optional separate host folder for git-resolved bundle clones; mounted into /git-bundles when configured
-
-notifications:
-  email:
-    enabled: true
-    host: ""
-    port: "587"
-    user: ""
-    from: ""
-    to: "ops@example.com"
-    use_tls: true
-
-routines:
-
-  economics:
-    subscription_rollover_enabled: true
-    subscription_rollover_cron: "15 * * * *"
-    subscription_rollover_lock_ttl_seconds: 900
-    subscription_rollover_sweep_limit: 500
-
-  stripe:
-    reconcile_enabled: true
-    reconcile_cron: "45 * * * *"
-    reconcile_lock_ttl_seconds: 900
-
-  opex:
-    agg_cron: "0 3 * * *"
-
+# ---------------------------------------------------------------------------
+# Authentication
+# Set type to "simple" (local IDP), "cognito" (AWS Cognito), or "delegated".
+# ---------------------------------------------------------------------------
 auth:
-  type: "simple"  # "simple" | "cognito" | "delegated"
+  type: "simple"  # AUTH_PROVIDER: simple | cognito | delegated
+
+  # Token / cookie header names (new)
+  id_token_header_name: "X-ID-Token"         # ID_TOKEN_HEADER_NAME
+  auth_token_cookie_name: "__Secure-LATC"    # AUTH_TOKEN_COOKIE_NAME
+  id_token_cookie_name: "__Secure-LITC"      # ID_TOKEN_COOKIE_NAME
+  jwks_cache_ttl_seconds: 86400              # JWKS_CACHE_TTL_SECONDS
+
+  # OIDC service account credentials → secrets.yaml: auth.oidc.{admin_email,admin_username,admin_password}
+
+  # Cognito — fill in when type = "cognito"
   cognito:
-    region: "eu-west-1"
-    user_pool_id: ""
-    app_client_id: ""
-    service_client_id: ""
+    region: eu-west-1                 # COGNITO_REGION
+    user_pool_id: eu-west-1_XXXXXXXXX # COGNITO_USER_POOL_ID
+    app_client_id: ""                 # COGNITO_APP_CLIENT_ID
+    service_client_id: ""             # COGNITO_SERVICE_CLIENT_ID
+
   proxy_login:
     redis_key_prefix: "proxylogin:<TENANT>:<PROJECT>:"
     token_masquerade: true
     password_reset:
-      company: ""
-      sender: "email@your-org.com"
-      template_name: ""
-      redirect_url: "http://YOUR_DOMAIN/chatbot/reset-password?user=%[1]s"
-    http_urlbase: "https://YOUR_DOMAIN/auth"
+      company: "KDCube"
+      sender: "info@example.com"
+      template_name: "KDCubeNewUserWelcomeTemplate"
+      redirect_url: "http://YOUR_DOMAIN/platform/reset-password?user=%[1]s"
+    http_urlbase: "http://YOUR_DOMAIN/auth"
 
 proxy:
-  ssl: false   # when true, CLI uses SSL nginx templates and applies `domain` to LetsEncrypt paths under /etc/letsencrypt/live/<domain>/
-  route_prefix: "/chatbot"
+  ssl: false
+  route_prefix: "/platform"
 
+# ---------------------------------------------------------------------------
+# Service ports
+# ports.ingress → CHAT_APP_PORT; ports.proc → CHAT_PROCESSOR_PORT
+# ---------------------------------------------------------------------------
 ports:
-  ingress: "8010"
-  proc: "8020"
+  ingress: "8010"  # CHAT_APP_PORT
+  proc: "8020"     # CHAT_PROCESSOR_PORT
   metrics: "8090"
-  ui: "80"
+  ui: "5174"
   ui_ssl: "443"
 
+# ---------------------------------------------------------------------------
+# Infrastructure — Postgres and Redis
+# Passwords live in secrets.yaml (infra.postgres.password / infra.redis.password)
+# ---------------------------------------------------------------------------
 infra:
   postgres:
-    user: "postgres"
-    password: "postgres"
-    database: "kdcube"
-    host: "postgres-db"
-    port: "5432"
-    ssl: false
+    host: "postgres-db"  # POSTGRES_HOST
+    port: "5432"         # POSTGRES_PORT
+    user: "postgres"     # POSTGRES_USER
+    database: "kdcube"   # POSTGRES_DATABASE
+    password: "postgres" # POSTGRES_PASSWORD → also in secrets.yaml: infra.postgres.password
+    postgres_ssl: false  # POSTGRES_SSL (new)
+    # postgres_ssl_mode: "require"  # POSTGRES_SSL_MODE (new, optional)
+    # postgres_ssl_root_cert: ""    # POSTGRES_SSL_ROOT_CERT (new, optional)
   redis:
-    password: "redispass"
-    host: "redis"
-    port: "6379"
+    host: "redis"        # REDIS_HOST
+    port: "6379"         # REDIS_PORT
+    password: "redispass" # REDIS_PASSWORD → also in secrets.yaml: infra.redis.password
 
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+storage:
+  kdcube: "s3://YOUR_BUCKET/data/kdcube/dev"    # KDCUBE_STORAGE_PATH; for local storage use an absolute path
+  bundles: "s3://YOUR_BUCKET/data/kdcube/dev"   # CB_BUNDLE_STORAGE_URL; for local storage use an absolute path
+  workspace:
+    type: git             # REACT_WORKSPACE_IMPLEMENTATION: local | git
+    repo: "https://github.com/YOUR_ORG/agentic-workspace.git"  # REACT_WORKSPACE_GIT_REPO
+  claude_code_session:
+    type: git             # CLAUDE_CODE_SESSION_STORE_IMPLEMENTATION: local | git
+    repo: "https://github.com/YOUR_ORG/agentic-workspace.git"  # CLAUDE_CODE_SESSION_GIT_REPO; used only when type=git
+
+# ---------------------------------------------------------------------------
+# AWS
+# ---------------------------------------------------------------------------
 aws:
-  region: ""
-  profile: ""
-  ec2: false
+  aws_region: "eu-west-1"                          # AWS_REGION
+  # aws_profile: ""                                # AWS_PROFILE (optional)
+  aws_sdk_load_config: true                        # AWS_SDK_LOAD_CONFIG; make boto3 read ~/.aws/config when present
+  aws_ec2_metadata_disabled: false                 # AWS_EC2_METADATA_DISABLED
+  no_proxy: "169.254.169.254,localhost,127.0.0.1"  # NO_PROXY
 
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+models:
+  default_llm_model_id: "claude-sonnet-4-6"                   # DEFAULT_LLM_MODEL_ID
+  default_embedding_model_id: "openai-text-embedding-3-small"  # DEFAULT_EMBEDDING_MODEL_ID
+
+# ---------------------------------------------------------------------------
+# Services (LLM provider config, non-secret)
+# Leaf keys match env var names (lowercase).
+# ---------------------------------------------------------------------------
+services:
+  llm:
+    gemini:
+      gemini_cache_enabled: false     # GEMINI_CACHE_ENABLED
+      gemini_cache_ttl_seconds: 3600  # GEMINI_CACHE_TTL_SECONDS
+
+# ---------------------------------------------------------------------------
+# CORS — parsed as a block into CorsConfig (maps to CORS_CONFIG env var).
+# Keys match CorsConfig field names.
+# ---------------------------------------------------------------------------
+cors:
+  allow_origins:
+    - "http://localhost:3000"
+    - "http://localhost:3001"
+    - "http://localhost:4000"
+    - "http://localhost:5173"
+    - "http://localhost:5174"
+    - "http://localhost:5175"
+    - "http://localhost:8050"
+  allow_credentials: true
+  allow_methods: "*"
+  allow_headers: "*"
+
+# ---------------------------------------------------------------------------
+# Notifications
+# ---------------------------------------------------------------------------
+notifications:
+  email:
+    enabled: true          # EMAIL_ENABLED
+    host: ""               # EMAIL_HOST
+    port: "587"            # EMAIL_PORT
+    user: ""               # EMAIL_USER
+    from: ""               # EMAIL_FROM
+    to: "ops@example.com"  # EMAIL_TO
+    use_tls: true          # EMAIL_USE_TLS
+    # email_password → secrets.yaml: services.email.password
+
+# ---------------------------------------------------------------------------
+# Scheduled routines
+# ---------------------------------------------------------------------------
+routines:
+
+  economics:
+    subscription_rollover_enabled: true          # SUBSCRIPTION_ROLLOVER_ENABLED
+    subscription_rollover_cron: "15 * * * *"     # SUBSCRIPTION_ROLLOVER_CRON
+    subscription_rollover_lock_ttl_seconds: 900  # SUBSCRIPTION_ROLLOVER_LOCK_TTL_SECONDS
+    subscription_rollover_sweep_limit: 500       # SUBSCRIPTION_ROLLOVER_SWEEP_LIMIT
+
+  stripe:
+    reconcile_enabled: true          # STRIPE_RECONCILE_ENABLED
+    reconcile_cron: "45 * * * *"     # STRIPE_RECONCILE_CRON
+    reconcile_lock_ttl_seconds: 900  # STRIPE_RECONCILE_LOCK_TTL_SECONDS
+
+  opex:
+    agg_cron: "0 3 * * *"  # OPEX_AGG_CRON
+
+# ---------------------------------------------------------------------------
+# Secrets provider
+# ---------------------------------------------------------------------------
+secrets:
+  provider: "secrets-file"  # SECRETS_PROVIDER: secrets-service | aws-sm | in-memory | secrets-file
+
+# ---------------------------------------------------------------------------
+# Host paths (used by docker-compose mounts; not read by services directly)
+# ---------------------------------------------------------------------------
+paths:
+  host_bundles_path: "/YOUR/HOST/PATH/src"                           # HOST_BUNDLES_PATH; required for descriptor-driven local bundle installs; host folder mounted into /bundles
+  host_git_bundles_path: "/YOUR/HOST/PATH/.kdcube/git-bundles"       # HOST_GIT_BUNDLES_PATH; optional separate host folder for git-resolved bundle clones/cache; mounted into /git-bundles
+  host_bundle_storage_path: "/YOUR/HOST/PATH/.kdcube/bundle-storage" # HOST_BUNDLE_STORAGE_PATH; host folder for local bundle storage; mounted into container
+
+# ---------------------------------------------------------------------------
+# Platform metadata
+# ---------------------------------------------------------------------------
 platform:
+  repo: "git@github.com:kdcube/kdcube-ai-app.git"
+  ref: "2026.4.12.500"
+  config:
+    version: "2026.4.12.500"
+
+  # -------------------------------------------------------------------------
+  # Component-scoped settings.
+  # Each component (ingress / proc) only reads its own section.
+  # Leaf keys match env var names (lowercase).
+  # -------------------------------------------------------------------------
   services:
     ingress:
-      service:
-        uvicorn_reload: false
-        cb_relay_identity: "kdcube.relay.chatbot"
-    proc:
-      service:
-        uvicorn_reload: false
-        cb_relay_identity: "kdcube.relay.chatbot"
-        chat_scheduler_backend: "legacy_lists"
-        chat_task_timeout_sec: 600
-        chat_task_idle_timeout_sec: 600
-        chat_task_max_wall_time_sec: 2400
-        chat_task_watchdog_poll_interval_sec: 1.0
-    metrics:
-      service:
-        uvicorn_reload: false
+      log:
+        log_level: "INFO"            # LOG_LEVEL
+        log_max_mb: 20               # LOG_MAX_MB
+        log_backup_count: 10         # LOG_BACKUP_COUNT
+        log_dir: ""                  # LOG_DIR; absolute path; leave empty to use default
+        log_file_prefix: "chat-ingress"  # LOG_FILE_PREFIX
 
-bundles:
-  default_bundle_id: "react@2026-02-10-02-44"
-  items:
-    - id: app@2-0
-      name: Customer App
-      repo: git@github.com:org/customer-repo.git
-      ref: bundle-v2026.02.22
-      subdir: service/bundles
-      module: app@2-0.entrypoint
+      service:
+        uvicorn_reload: false                      # UVICORN_RELOAD
+        heartbeat_interval: 5                      # HEARTBEAT_INTERVAL
+        cb_relay_identity: "kdcube.relay.chatbot"  # CB_RELAY_IDENTITY
+
+      av:
+        app_av_scan: true         # APP_AV_SCAN
+        app_av_timeout_s: 3.0     # APP_AV_TIMEOUT_S
+        clamav_host: "localhost"  # CLAMAV_HOST
+        clamav_port: 3310         # CLAMAV_PORT
+
+      idp:
+        idp_db_path: ""                            # IDP_DB_PATH; absolute path to idp_users.json; leave empty to use default location
+        idp_import_enabled: false                  # IDP_IMPORT_ENABLED
+        idp_import_run_at: "2026-02-22T07:00:00Z"  # IDP_IMPORT_RUN_AT; ISO timestamp; UTC assumed when no tz
+        idp_import_script_path: ""                 # IDP_IMPORT_SCRIPT_PATH; absolute path to import_users.py
+
+      monitoring:
+        monitoring_burst_enable: true  # MONITORING_BURST_ENABLE
+
+    proc:
+      log:
+        log_level: "INFO"          # LOG_LEVEL
+        log_max_mb: 20             # LOG_MAX_MB
+        log_backup_count: 10       # LOG_BACKUP_COUNT
+        log_dir: ""                # LOG_DIR; absolute path; leave empty to use default
+        log_file_prefix: "chat-proc"  # LOG_FILE_PREFIX
+
+      service:
+        uvicorn_reload: false                      # UVICORN_RELOAD
+        heartbeat_interval: 5                      # HEARTBEAT_INTERVAL
+        cb_relay_identity: "kdcube.relay.chatbot"  # CB_RELAY_IDENTITY
+        chat_scheduler_backend: "legacy_lists"     # CHAT_SCHEDULER_BACKEND: legacy_lists | kafka
+        chat_task_timeout_sec: 600                 # CHAT_TASK_TIMEOUT_SEC
+        chat_task_idle_timeout_sec: 600            # CHAT_TASK_IDLE_TIMEOUT_SEC
+        chat_task_max_wall_time_sec: 2400          # CHAT_TASK_MAX_WALL_TIME_SEC
+        chat_task_watchdog_poll_interval_sec: 1.0  # CHAT_TASK_WATCHDOG_POLL_INTERVAL_SEC
+
+      exec:
+        exec_workspace_root: ""                # EXEC_WORKSPACE_ROOT; absolute path
+        py_code_exec_image: "py-code-exec:latest"  # PY_CODE_EXEC_IMAGE
+        py_code_exec_timeout: 600              # PY_CODE_EXEC_TIMEOUT
+        py_code_exec_network_mode: "host"      # PY_CODE_EXEC_NETWORK_MODE
+
+      tools:
+        web_search:
+          tools_web_search_fetch_content: true     # TOOLS_WEB_SEARCH_FETCH_CONTENT
+          web_search_agentic_thinking_budget: 200  # WEB_SEARCH_AGENTIC_THINKING_BUDGET
+          web_search_primary_backend: "brave"      # WEB_SEARCH_PRIMARY_BACKEND
+          web_search_backend: "hybrid"             # WEB_SEARCH_BACKEND: duckduckgo | brave | hybrid
+          web_search_hybrid_mode: "sequential"     # WEB_SEARCH_HYBRID_MODE: sequential | parallel
+          web_search_segmenter: "fast"             # WEB_SEARCH_SEGMENTER
+        web_fetch:
+          web_fetch_resources_medium: ""  # WEB_FETCH_RESOURCES_MEDIUM; JSON: {"cookies": {"uid": "...", "sid": "..."}}
+        mcp_cache_ttl_seconds: 36000      # MCP_CACHE_TTL_SECONDS
+        accounting_services: '{"web_search": {"brave": {"tier": "free"}, "duckduckgo": {"tier": "free"}}}'  # ACCOUNTING_SERVICES
+
+      bundles:
+        agentic_bundles_root: "/bundles"              # AGENTIC_BUNDLES_ROOT; host path → paths.host_bundles_path
+        bundle_storage_root: ""                       # BUNDLE_STORAGE_ROOT
+        bundles_include_examples: true                # BUNDLES_INCLUDE_EXAMPLES
+        bundle_cleanup_enabled: true                  # BUNDLE_CLEANUP_ENABLED
+        bundle_cleanup_interval_seconds: 3600         # BUNDLE_CLEANUP_INTERVAL_SECONDS
+        bundle_cleanup_lock_ttl_seconds: 900          # BUNDLE_CLEANUP_LOCK_TTL_SECONDS
+        bundle_ref_ttl_seconds: 3600                  # BUNDLE_REF_TTL_SECONDS
+        bundles_force_env_on_startup: true            # BUNDLES_FORCE_ENV_ON_STARTUP
+        bundles_force_env_lock_ttl_seconds: 60        # BUNDLES_FORCE_ENV_LOCK_TTL_SECONDS
+        bundles_preload_on_start: true                # BUNDLES_PRELOAD_ON_START
+        bundles_preload_lock_ttl_seconds: 900         # BUNDLES_PRELOAD_LOCK_TTL_SECONDS
+        git:
+          bundle_git_resolution_enabled: true         # BUNDLE_GIT_RESOLUTION_ENABLED
+          bundle_git_atomic: true                     # BUNDLE_GIT_ATOMIC
+          bundle_git_always_pull: false               # BUNDLE_GIT_ALWAYS_PULL
+          bundle_git_redis_lock: true                 # BUNDLE_GIT_REDIS_LOCK
+          bundle_git_redis_lock_ttl_seconds: 300      # BUNDLE_GIT_REDIS_LOCK_TTL_SECONDS
+          bundle_git_redis_lock_wait_seconds: 60      # BUNDLE_GIT_REDIS_LOCK_WAIT_SECONDS
+          bundle_git_prefetch_enabled: true           # BUNDLE_GIT_PREFETCH_ENABLED
+          bundle_git_prefetch_interval_seconds: 15    # BUNDLE_GIT_PREFETCH_INTERVAL_SECONDS
+          bundle_git_fail_backoff_seconds: 60         # BUNDLE_GIT_FAIL_BACKOFF_SECONDS
+          bundle_git_fail_max_backoff_seconds: 300    # BUNDLE_GIT_FAIL_MAX_BACKOFF_SECONDS
+          bundle_git_keep: 3                          # BUNDLE_GIT_KEEP
+          bundle_git_ttl_hours: 0                     # BUNDLE_GIT_TTL_HOURS
+          git_ssh_key_path: ""                        # GIT_SSH_KEY_PATH; absolute path to SSH private key
+          git_ssh_known_hosts: ""                     # GIT_SSH_KNOWN_HOSTS; absolute path to known_hosts file
+          git_ssh_strict_host_key_checking: "yes"     # GIT_SSH_STRICT_HOST_KEY_CHECKING

--- a/app/ai-app/deployment/assembly.yaml
+++ b/app/ai-app/deployment/assembly.yaml
@@ -102,6 +102,14 @@ models:
   default_embedding_model_id: "openai-text-embedding-3-small"  # DEFAULT_EMBEDDING_MODEL_ID
 
 # ---------------------------------------------------------------------------
+# AI feature flags
+# ---------------------------------------------------------------------------
+ai:
+  react:
+    react_agent_version: "v2"       # AI_REACT_AGENT_VERSION: v2 | v3
+    react_agent_multiaction: "off"  # AI_REACT_AGENT_MULTI_ACTION: on | off
+
+# ---------------------------------------------------------------------------
 # Services (LLM provider config, non-secret)
 # Leaf keys match env var names (lowercase).
 # ---------------------------------------------------------------------------

--- a/app/ai-app/deployment/secrets.yaml
+++ b/app/ai-app/deployment/secrets.yaml
@@ -1,35 +1,47 @@
 services:
   openai:
-    api_key: null
+    api_key: "<open ai key>"
   google:
-    api_key: null
+    api_key: "<google key>"
   anthropic:
-    api_key: null
+    api_key: "<anthropic key>"
     claude_code_key: null
   brave:
-    api_key: null
+    api_key: "<brave key>"
+    api_comm_mid_key: null
   openrouter:
+    api_key: null
+  serpapi:
     api_key: null
   huggingface:
     api_key: null
   stripe:
     secret_key: null
     webhook_secret: null
-  email:
-    password: null
+  git:
+    http_token: "<Github PAT>"
+  web:
+    # Browser session cookies for authenticated web-fetch (medium paywall sites).
+    # Format: JSON string with "cookies" object containing cookie key-value pairs.
+    # Example: '{"cookies": {"uid": "abc123", "sid": "xyz..."}}'
+    fetch_resources_medium: null
 
 git:
-  http_token: null
+  http_token: "<Github PAT>"
 
 infra:
   postgres:
-    password: null
+    password: postgres
   redis:
-    password: null
+    password: redispass
 
 auth:
   cognito:
     client_secret: null
+  oidc:
+    admin_username: ""
+    admin_password: ""
+    admin_email: ""
 
 aws:
   access_key_id: null

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/emitters.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/emitters.py
@@ -89,8 +89,8 @@ class ChatRelayCommunicator:
         self._comm = comm or ServiceCommunicator(
             redis_url=redis_url,
             orchestrator_identity=orchestrator_identity
-                                  or os.environ.get(
-                "CB_RELAY_IDENTITY") or "kdcube.relay.chatbot",
+                                  or get_settings().PLATFORM.SERVICE.CB_RELAY_IDENTITY
+                                  or "kdcube.relay.chatbot",
         )
         self._channel = channel
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/external_events.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/external_events.py
@@ -11,6 +11,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from kdcube_ai_app.apps.chat.sdk.continuations import ContinuationKind
 from kdcube_ai_app.infra.namespaces import REDIS, ns_key
 
@@ -532,7 +533,7 @@ class RedisConversationExternalEventSource:
         lease = TimelineOwnerLease(
             turn_id=turn_id or "",
             bundle_id=bundle_id or "",
-            instance_id=os.getenv("INSTANCE_ID", "unknown"),
+            instance_id=get_settings().INSTANCE_ID,
             process_id=os.getpid(),
             listener_id=listener_id,
             lease_token=lease_token,
@@ -569,7 +570,7 @@ class RedisConversationExternalEventSource:
         lease = TimelineOwnerLease(
             turn_id=turn_id or "",
             bundle_id=bundle_id or existing.bundle_id,
-            instance_id=os.getenv("INSTANCE_ID", "unknown"),
+            instance_id=get_settings().INSTANCE_ID,
             process_id=os.getpid(),
             listener_id=listener_id or existing.listener_id,
             lease_token=existing.lease_token,
@@ -694,7 +695,7 @@ redis.call('SETEX', token_key, ttl, ARGV[7])
 return epoch
 """
         evaluator = getattr(self.redis, "eval", None)
-        instance_id = os.getenv("INSTANCE_ID", "unknown")
+        instance_id = get_settings().INSTANCE_ID
         process_id = os.getpid()
         if callable(evaluator):
             try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/chat_core.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/chat_core.py
@@ -28,7 +28,6 @@ from kdcube_ai_app.infra.accounting.envelope import build_envelope_from_session
 from kdcube_ai_app.infra.gateway.rate_limiter import RateLimitError
 from kdcube_ai_app.infra.gateway.backpressure import BackpressureError
 from kdcube_ai_app.infra.gateway.circuit_breaker import CircuitBreakerError
-from kdcube_ai_app.infra.namespaces import CONFIG
 from kdcube_ai_app.apps.middleware.token_extract import (
     resolve_auth_from_headers_and_cookies,
     resolve_socket_auth_tokens,
@@ -698,8 +697,9 @@ async def process_chat_message(
     # --- Attachments (host after lock; reject entire message on any failure) ---
     if raw_attachments:
         store = getattr(app.state, "conversation_store", None)
-        enable_av = os.getenv("APP_AV_SCAN", "1") == "1"
-        av_timeout = float(os.getenv("APP_AV_TIMEOUT_S", "3.0"))
+        _av = get_settings().PLATFORM.HOSTED_SERVICES.AV
+        enable_av = _av.APP_AV_SCAN
+        av_timeout = _av.APP_AV_TIMEOUT_S
         from kdcube_ai_app.infra.gateway.safe_preflight import PreflightConfig, preflight_async
         cfg = PreflightConfig(av_scan=enable_av, av_timeout_s=av_timeout)
 
@@ -1212,8 +1212,8 @@ def build_sse_request_context(
     else:
         _, resolved_id_token = resolve_auth_from_headers_and_cookies(
             None,
-            request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME)
-            or request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME.lower()),
+            request.headers.get(get_settings().AUTH.ID_TOKEN_HEADER_NAME)
+            or request.headers.get(get_settings().AUTH.ID_TOKEN_HEADER_NAME.lower()),
             request.cookies,
         )
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/conversations_browser.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/conversations_browser.py
@@ -77,7 +77,6 @@ def _get_shared_components():
     req = ConfigRequest(
         openai_api_key=settings.OPENAI_API_KEY,
         claude_api_key=settings.ANTHROPIC_API_KEY,
-        selected_model=settings.DEFAULT_MODEL_LLM,
     )
     model_service = ModelServiceBase(create_workflow_config(req))
     store = ConversationStore(settings.STORAGE_PATH)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/monitoring/monitoring.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/monitoring/monitoring.py
@@ -6,6 +6,7 @@ import json
 import time
 from dataclasses import asdict
 from datetime import datetime
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 from fastapi import Depends
 from fastapi.responses import JSONResponse
@@ -226,7 +227,7 @@ async def reset_throttling_state(
 
 
 def _burst_sim_enabled() -> bool:
-    return os.getenv("MONITORING_BURST_ENABLE", "0").lower() in {"1", "true", "yes", "on"}
+    return get_settings().PLATFORM.MONITORING.MONITORING_BURST_ENABLE
 
 
 @router.get("/admin/burst/users")
@@ -238,7 +239,7 @@ async def get_burst_users(session: UserSession = Depends(auth_without_pressure()
     if not _burst_sim_enabled():
         raise HTTPException(status_code=404, detail="Burst simulator is disabled")
 
-    if os.getenv("AUTH_PROVIDER", "simple").lower() != "simple":
+    if (get_settings().AUTH_PROVIDER or "simple").lower() != "simple":
         raise HTTPException(status_code=400, detail="Burst simulator requires AUTH_PROVIDER=simple")
 
     try:
@@ -651,7 +652,7 @@ async def debug_environment(session: UserSession = Depends(auth_without_pressure
         },
         "AVG_PROCESSING_TIME_SECONDS": os.getenv("AVG_PROCESSING_TIME_SECONDS", "25.0"),
         "GATEWAY_PROFILE": os.getenv("GATEWAY_PROFILE", "development"),
-        "INSTANCE_ID": os.getenv("INSTANCE_ID", "default-instance"),
+        "INSTANCE_ID": get_settings().INSTANCE_ID,
         "GATEWAY_CONFIG_JSON_SET": bool(os.getenv("GATEWAY_CONFIG_JSON")),
         "all_env_vars": {k: v for k, v in os.environ.items() if any(keyword in k.upper() for keyword in ["CHAT", "CONCURRENT", "PARALLEL", "GATEWAY", "CAPACITY"])}
     }

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/opex/opex.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/opex/opex.py
@@ -46,7 +46,7 @@ async def opex_lifespan(app: FastAPI):
     if _scheduler_task is None:
         _scheduler_task = asyncio.create_task(routines.aggregation_scheduler_loop())
         logger.info("[OPEX Aggregator] Background scheduler task started")
-    component = (os.getenv("GATEWAY_COMPONENT") or "ingress").strip().lower()
+    component = (get_settings().GATEWAY_COMPONENT or "ingress").strip().lower()
     if component == "proc":
         if _bundle_cleanup_task is None:
             _bundle_cleanup_task = asyncio.create_task(routines.bundle_cleanup_loop())
@@ -180,8 +180,7 @@ def _compute_cost_estimate(rollup: List[dict]) -> dict:
     emb_pricelist = configuration.get("embedding", [])
     web_search_pricelist = configuration.get("web_search", [])  # NEW
 
-    # Load tier configuration from environment
-    config_str = os.environ.get("ACCOUNTING_SERVICES", "{}")
+    config_str = get_settings().PLATFORM.ACCOUNTING.ACCOUNTING_SERVICES or "{}"
     try:
         accounting_services_config = json.loads(config_str)
     except json.JSONDecodeError:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/opex/routines.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/opex/routines.py
@@ -47,14 +47,11 @@ def _get_aggregator() -> AccountingAggregator:
 
 
 def _idp_import_enabled() -> bool:
-    try:
-        return bool(get_settings().IDP_IMPORT_ENABLED)  # type: ignore[attr-defined]
-    except Exception:
-        return os.environ.get("IDP_IMPORT_ENABLED", "0").lower() in {"1", "true", "yes"}
+    return get_settings().AUTH.IDP.local.IDP_IMPORT_ENABLED
 
 
 def _idp_import_run_at() -> Optional[datetime]:
-    raw = os.environ.get("IDP_IMPORT_RUN_AT")
+    raw = get_settings().AUTH.IDP.local.IDP_IMPORT_RUN_AT
     if not raw:
         return None
     try:
@@ -68,7 +65,7 @@ def _idp_import_run_at() -> Optional[datetime]:
 
 
 def _idp_import_script_path() -> Optional[Path]:
-    raw = os.environ.get("IDP_IMPORT_SCRIPT_PATH")
+    raw = get_settings().AUTH.IDP.local.IDP_IMPORT_SCRIPT_PATH
     if not raw:
         return None
     p = Path(raw).expanduser()
@@ -203,47 +200,17 @@ async def _get_agg_redis() -> Optional[aioredis.Redis]:
     return _agg_redis
 
 def _get_cron_expression() -> str:
-    """
-    Return cron expression from assembly.yaml, settings, or env.
-
-    Priority:
-      1) assembly.yaml routines.opex.agg_cron
-      2) settings.OPEX_AGG_CRON if exists
-      3) env OPEX_AGG_CRON
-      4) default: "0 3 * * *" (daily at 03:00)
-    """
-    expr = read_plain("routines.opex.agg_cron", default=None)
-    try:
-        if not expr:
-            _settings = get_settings()
-            expr = getattr(_settings, "OPEX_AGG_CRON", None)
-    except Exception:
-        # if settings don’t have it, silently ignore
-        pass
-
-    expr = expr or os.getenv("OPEX_AGG_CRON")
-    if not expr:
-        expr = "0 3 * * *"
-    return expr
+    return get_settings().OPEX_AGG_CRON
 
 
 def _bundle_cleanup_enabled() -> bool:
-    try:
-        return bool(get_settings().BUNDLE_CLEANUP_ENABLED)
-    except Exception:
-        return os.environ.get("BUNDLE_CLEANUP_ENABLED", "1").lower() in {"1", "true", "yes"}
+    return bool(get_settings().PLATFORM.APPLICATIONS.BUNDLE_CLEANUP_ENABLED)
 
 def _bundle_cleanup_interval_seconds() -> int:
-    try:
-        return int(get_settings().BUNDLE_CLEANUP_INTERVAL_SECONDS)
-    except Exception:
-        return int(os.environ.get("BUNDLE_CLEANUP_INTERVAL_SECONDS", "3600") or "3600")
+    return int(get_settings().PLATFORM.APPLICATIONS.BUNDLE_CLEANUP_INTERVAL_SECONDS)
 
 def _bundle_cleanup_lock_ttl_seconds() -> int:
-    try:
-        return int(get_settings().BUNDLE_CLEANUP_LOCK_TTL_SECONDS)
-    except Exception:
-        return int(os.environ.get("BUNDLE_CLEANUP_LOCK_TTL_SECONDS", "900") or "900")
+    return int(get_settings().PLATFORM.APPLICATIONS.BUNDLE_CLEANUP_LOCK_TTL_SECONDS)
 
 
 def _compute_next_run(now: datetime) -> datetime:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/resolvers.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/resolvers.py
@@ -43,8 +43,8 @@ logger = logging.getLogger(__name__)
 
 # TENANT_ID = os.environ.get("TENANT_ID", "home")
 # INSTANCE_ID = os.environ.get("INSTANCE_ID", "home-instance-1")
-CHAT_APP_PORT = int(os.environ.get("CHAT_APP_PORT", 8010))
-CHAT_PROCESSOR_PORT = int(os.environ.get("CHAT_PROCESSOR_PORT", CHAT_APP_PORT))
+CHAT_APP_PORT = get_settings().CHAT_APP_PORT
+CHAT_PROCESSOR_PORT = get_settings().CHAT_PROCESSOR_PORT
 
 # Gateway Profile Selection
 GATEWAY_PROFILE = os.environ.get("GATEWAY_PROFILE", "development").lower()
@@ -155,7 +155,7 @@ def create_auth_manager():
     """Create the authentication manager"""
     # You can switch between different auth managers here:
 
-    provider = os.getenv("AUTH_PROVIDER", "simple").lower()
+    provider = (get_settings().AUTH_PROVIDER or "simple").lower()
     if provider == "cognito":
         from kdcube_ai_app.auth.implementations.cognito import CognitoAuthManager
         logger.info("Using CognitoAuthManager for authentication")
@@ -521,7 +521,7 @@ def _announce_startup():
     url = os.environ.get("CHAT_PUBLIC_URL")
     if not url:
         # fallback: infer from port if no env provided
-        port = os.environ.get("CHAT_APP_PORT") or str(CHAT_APP_PORT)
+        port = str(CHAT_APP_PORT)
         url = f"http://localhost:{port}/health"
     try:
         # Bold line
@@ -665,7 +665,6 @@ async def get_conversation_system(pg_pool) -> Tuple[ContextRAGClient, ConvIndex,
     req = ConfigRequest(
         openai_api_key=_settings.OPENAI_API_KEY,
         claude_api_key=_settings.ANTHROPIC_API_KEY,
-        selected_model=_settings.DEFAULT_MODEL_LLM,
     )
     model_service = ModelServiceBase(create_workflow_config(req))
     _conv_store = ConversationStore(_settings.STORAGE_PATH)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/socketio/chat.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/socketio/chat.py
@@ -13,6 +13,7 @@ import os
 import uuid
 from pathlib import Path
 import logging
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 import hashlib
@@ -96,7 +97,7 @@ class SocketIOChatHandler:
         self._comm = ChatRelayCommunicator(
             redis_url=redis_url,
             channel="chat.events",
-            orchestrator_identity=os.getenv("CB_RELAY_IDENTITY"),
+            orchestrator_identity=get_settings().PLATFORM.SERVICE.CB_RELAY_IDENTITY,
         )
         self._listener_started = False
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/sse/chat.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/sse/chat.py
@@ -111,7 +111,7 @@ class SSEHub:
     ):
         self.chat_comm = chat_comm
         self.redis = redis
-        self.instance_id = instance_id or os.getenv("INSTANCE_ID", "unknown")
+        self.instance_id = instance_id or get_settings().INSTANCE_ID
         self.process_id = process_id or os.getpid()
         self._stats_ttl_sec = stats_ttl_sec
         self._by_session: Dict[str, List[Client]] = {}
@@ -429,7 +429,7 @@ def create_sse_router(
     chat_comm = ChatRelayCommunicator(
         redis_url=redis_url,
         channel="chat.events",
-        orchestrator_identity=os.getenv("CB_RELAY_IDENTITY"),
+        orchestrator_identity=get_settings().PLATFORM.SERVICE.CB_RELAY_IDENTITY,
     )
 
     # Ensure hub exists on app

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/web_app.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/web_app.py
@@ -87,7 +87,7 @@ from kdcube_ai_app.infra.gateway.config import (
     GatewayConfigFactory,
     gateway_config_cache_key,
 )
-from kdcube_ai_app.infra.namespaces import CONFIG
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 from kdcube_ai_app.apps.chat.ingress.resolvers import (
     get_fastapi_adapter, get_fast_api_accounting_binder, get_user_session_dependency, require_auth,
@@ -182,7 +182,7 @@ async def lifespan(app: FastAPI):
         CHAT_APP_PORT,
         os.getpid(),
         _get_uvicorn_workers_from_config(),
-        os.getenv("UVICORN_RELOAD", "0"),
+        get_settings().PLATFORM.SERVICE.UVICORN_RELOAD,
     )
 
     # mark not shutting down yet
@@ -491,11 +491,11 @@ async def gateway_middleware(request: Request, call_next):
             if bearer_token and "authorization" not in {k.lower(): v for k, v in headers.items()}:
                 headers["authorization"] = f"Bearer {bearer_token}"
             if id_token:
-                headers[CONFIG.ID_TOKEN_HEADER_NAME] = id_token
+                headers[get_settings().AUTH.ID_TOKEN_HEADER_NAME] = id_token
             if user_timezone:
-                headers[CONFIG.USER_TIMEZONE_HEADER_NAME] = user_timezone
+                headers[get_settings().RUNTIME_CONFIG.USER_TIMEZONE_HEADER_NAME] = user_timezone
             if user_utc_offset_min:
-                headers[CONFIG.USER_UTC_OFFSET_MIN_HEADER_NAME] = user_utc_offset_min
+                headers[get_settings().RUNTIME_CONFIG.USER_UTC_OFFSET_MIN_HEADER_NAME] = user_utc_offset_min
 
         # session = await app.state.gateway_adapter.process_request(request, [])
         session = await app.state.gateway_adapter.process_by_policy(request)
@@ -701,7 +701,7 @@ if __name__ == "__main__":
     install_uvicorn_shutdown_diagnostics(uvicorn, logger, component="chat-ingress")
 
     workers = _get_uvicorn_workers_from_config()
-    reload_enabled = os.getenv("UVICORN_RELOAD", "").lower() in {"1", "true", "yes", "on"}
+    reload_enabled = get_settings().PLATFORM.SERVICE.UVICORN_RELOAD
     worker_healthcheck_timeout = _get_uvicorn_worker_healthcheck_timeout()
 
     # Uvicorn requires an import string when using workers or reload.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
@@ -2018,12 +2018,6 @@ async def _load_bundle_workflow(
     tenant_id, project_id = _resolve_path_scope(tenant=tenant, project=project)
     _bind_route_scope_to_config_request(cfg_req, tenant=tenant_id, project=project_id)
 
-    if not cfg_req.selected_model:
-        cfg_req.selected_model = (namespaces.CONFIG.AGENTIC.DEFAULT_LLM_MODEL_CONFIG or {}).get("model_name",
-                                                                                                "gpt-4o-mini")
-    if not cfg_req.selected_embedder:
-        cfg_req.selected_embedder = (namespaces.CONFIG.AGENTIC.DEFAULT_EMBEDDING_MODEL_CONFIG or {}).get("model_name",
-                                                                                                         "gpt-4o-mini")
     if not cfg_req.openai_api_key:
         cfg_req.openai_api_key = settings.OPENAI_API_KEY
     if not cfg_req.claude_api_key:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/web_app.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/web_app.py
@@ -217,25 +217,19 @@ PROC_UVICORN_GRACEFUL_SHUTDOWN_TIMEOUT_SEC = _get_proc_graceful_shutdown_timeout
 
 
 def _git_prefetch_enabled() -> bool:
-    return os.environ.get("BUNDLE_GIT_PREFETCH_ENABLED", "1").lower() in {"1", "true", "yes", "on"}
+    return get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_PREFETCH_ENABLED
 
 
 def _git_resolution_enabled() -> bool:
-    return os.environ.get("BUNDLE_GIT_RESOLUTION_ENABLED", "1").lower() in {"1", "true", "yes", "on"}
+    return get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_RESOLUTION_ENABLED
 
 
 def _bundles_preload_enabled() -> bool:
-    try:
-        return bool(get_settings().BUNDLES_PRELOAD_ON_START)
-    except Exception:
-        return os.environ.get("BUNDLES_PRELOAD_ON_START", "0").lower() in {"1", "true", "yes", "on"}
+    return bool(get_settings().PLATFORM.APPLICATIONS.BUNDLES_PRELOAD_ON_START)
 
 
 def _bundle_preload_lock_ttl_seconds() -> int:
-    try:
-        return int(get_settings().BUNDLES_PRELOAD_LOCK_TTL_SECONDS)
-    except Exception:
-        return int(os.environ.get("BUNDLES_PRELOAD_LOCK_TTL_SECONDS", "900") or "900")
+    return int(get_settings().PLATFORM.APPLICATIONS.BUNDLES_PRELOAD_LOCK_TTL_SECONDS)
 
 
 async def _prefetch_git_bundles_loop(app) -> None:
@@ -403,7 +397,7 @@ async def lifespan(app: FastAPI):
         CHAT_PROCESSOR_PORT,
         os.getpid(),
         _get_uvicorn_workers_from_config(),
-        os.getenv("UVICORN_RELOAD", "0"),
+        get_settings().PLATFORM.SERVICE.UVICORN_RELOAD,
     )
     app.state.shutting_down = False
     app.state.draining = False
@@ -777,11 +771,11 @@ async def gateway_middleware(request: Request, call_next):
             if bearer_token and "authorization" not in {k.lower(): v for k, v in headers.items()}:
                 headers["authorization"] = f"Bearer {bearer_token}"
             if id_token:
-                headers[CONFIG.ID_TOKEN_HEADER_NAME] = id_token
+                headers[get_settings().AUTH.ID_TOKEN_HEADER_NAME] = id_token
             if user_timezone:
-                headers[CONFIG.USER_TIMEZONE_HEADER_NAME] = user_timezone
+                headers[get_settings().RUNTIME_CONFIG.USER_TIMEZONE_HEADER_NAME] = user_timezone
             if user_utc_offset_min:
-                headers[CONFIG.USER_UTC_OFFSET_MIN_HEADER_NAME] = user_utc_offset_min
+                headers[get_settings().RUNTIME_CONFIG.USER_UTC_OFFSET_MIN_HEADER_NAME] = user_utc_offset_min
 
         session = await app.state.gateway_adapter.process_by_policy(request)
         setattr(request.state, STATE_SESSION, session)
@@ -836,7 +830,7 @@ if __name__ == "__main__":
     install_uvicorn_shutdown_diagnostics(uvicorn, logger, component="chat-proc")
 
     workers = _get_uvicorn_workers_from_config()
-    reload_enabled = os.getenv("UVICORN_RELOAD", "").lower() in {"1", "true", "yes", "on"}
+    reload_enabled = get_settings().PLATFORM.SERVICE.UVICORN_RELOAD
     worker_healthcheck_timeout = _get_uvicorn_worker_healthcheck_timeout()
 
     # Uvicorn requires an import string when using workers or reload.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
@@ -165,7 +165,7 @@ async def prefetch_git_bundles() -> dict[str, str]:
     """
     errors: dict[str, str] = {}
     reg = _get_bundle_registry()
-    force_pull = os.environ.get("BUNDLE_GIT_ALWAYS_PULL", "0").lower() in {"1", "true", "yes"}
+    force_pull = get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_ALWAYS_PULL
 
     for bid, entry in reg.items():
         repo = entry.get("repo")
@@ -200,7 +200,7 @@ async def prefetch_git_bundles() -> dict[str, str]:
                 git_ref=entry.get("ref"),
                 git_subdir=entry.get("subdir"),
                 bundles_root=resolve_git_bundles_root(),
-                atomic=os.environ.get("BUNDLE_GIT_ATOMIC", "1").lower() in {"1", "true", "yes"},
+                atomic=get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_ATOMIC,
             )
         except GitBundleCooldown as e:
             errors[bid] = str(e)
@@ -247,27 +247,23 @@ class EnhancedChatRequestProcessor:
         self.chat_handler = chat_handler
         self.process_id = process_id or os.getpid()
         self.max_concurrent = int(max_concurrent or 5)
+        _svc = get_settings().PLATFORM.SERVICE
         self.scheduler_backend_name = normalize_processor_scheduler_backend(
-            os.getenv("CHAT_SCHEDULER_BACKEND", scheduler_backend or ""),
+            scheduler_backend or _svc.CHAT_SCHEDULER_BACKEND,
         )
         self._task_scheduler_backend = build_processor_scheduler_backend(self.scheduler_backend_name)
         legacy_task_timeout_sec = max(
             1,
-            int(os.getenv("CHAT_TASK_TIMEOUT_SEC", str(task_timeout_sec or 600))),
+            task_timeout_sec or _svc.CHAT_TASK_TIMEOUT_SEC,
         )
         self.task_timeout_sec = legacy_task_timeout_sec
         self.task_idle_timeout_sec = max(
             1,
-            int(os.getenv("CHAT_TASK_IDLE_TIMEOUT_SEC", str(task_idle_timeout_sec or legacy_task_timeout_sec))),
+            task_idle_timeout_sec or _svc.CHAT_TASK_IDLE_TIMEOUT_SEC or legacy_task_timeout_sec,
         )
         self.task_max_wall_time_sec = max(
             self.task_idle_timeout_sec,
-            int(
-                os.getenv(
-                    "CHAT_TASK_MAX_WALL_TIME_SEC",
-                    str(task_max_wall_time_sec or max(legacy_task_timeout_sec, legacy_task_timeout_sec * 4)),
-                )
-            ),
+            task_max_wall_time_sec or _svc.CHAT_TASK_MAX_WALL_TIME_SEC or max(legacy_task_timeout_sec, legacy_task_timeout_sec * 4),
         )
         self.lock_ttl_sec = lock_ttl_sec
         self.lock_renew_sec = lock_renew_sec
@@ -329,7 +325,7 @@ class EnhancedChatRequestProcessor:
         )
         self._task_watchdog_poll_interval_sec = max(
             0.1,
-            float(os.getenv("CHAT_TASK_WATCHDOG_POLL_INTERVAL_SEC", str(TASK_WATCHDOG_POLL_INTERVAL_SEC)) or str(TASK_WATCHDOG_POLL_INTERVAL_SEC)),
+            get_settings().PLATFORM.SERVICE.CHAT_TASK_WATCHDOG_POLL_INTERVAL_SEC,
         )
         self._host_draining = False
         self._host_draining_since: Optional[str] = None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
@@ -13,6 +13,13 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from functools import lru_cache
 import yaml
 
+from kdcube_ai_app.apps.chat.sdk.config_scopes import (
+    PLATFORM_CONFIG, RUNTIME_CONFIG,
+    _load_assembly_plain, _parse_plain_key, _load_plain_yaml, _resolve_dotted_value,
+    LOGConfig, ServiceConfig, AVConfig, HostedServicesConfig, MonitoringConfig,
+    PyExecConfig, ExecConfig, AccountingConfig, GitBundlesConfig, ApplicationsConfig,
+    PlatformConfig, IDPLocalConfig, IDPConfig, AuthConfig, ServicesConfig,
+)
 from kdcube_ai_app.infra.props import get_props_manager
 from kdcube_ai_app.infra.secrets import get_secrets_manager
 
@@ -24,22 +31,26 @@ _SECRET_ALIASES: dict[str, list[str]] = {
     "services.anthropic.api_key": ["ANTHROPIC_API_KEY"],
     "services.anthropic.claude_code_key": ["CLAUDE_CODE_KEY"],
     "services.brave.api_key": ["BRAVE_API_KEY"],
+    "services.brave.api_comm_mid_key": ["BRAVE_API_COMM_MID_KEY"],
     "services.google.api_key": ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
     "services.git.http_token": ["GIT_HTTP_TOKEN"],
     "services.git.http_user": ["GIT_HTTP_USER"],
     "services.openrouter.api_key": ["OPENROUTER_API_KEY"],
+    "services.serpapi.api_key": ["SERPAPI_API_KEY"],
     "services.stripe.secret_key": ["STRIPE_SECRET_KEY", "STRIPE_API_KEY"],
     "services.stripe.webhook_secret": ["STRIPE_WEBHOOK_SECRET"],
-    "services.huggingface.api_key": ["HUGGING_FACE_KEY", "HUGGINGFACE_API_KEY"],
+    "services.huggingface.api_key": ["HUGGING_FACE_KEY", "HUGGINGFACE_API_KEY", "HUGGING_FACE_API_TOKEN"],
     "services.firecrawl.api_key": ["FIRECRAWL_API_KEY"],
     "services.email.password": ["EMAIL_PASSWORD"],
+    "auth.oidc.admin_email": ["OIDC_SERVICE_USER_EMAIL"],
+    "auth.oidc.admin_username": ["OIDC_SERVICE_ADMIN_USERNAME"],
+    "auth.oidc.admin_password": ["OIDC_SERVICE_ADMIN_PASSWORD"],
 }
 _LEGACY_SECRET_TO_CANON: dict[str, str] = {
     legacy: canon for canon, aliases in _SECRET_ALIASES.items() for legacy in aliases
 }
 _PG_SSL_MODES = {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}
-_ASSEMBLY_YAML_PATH = Path(os.getenv("ASSEMBLY_YAML_DESCRIPTOR_PATH") or "/config/assembly.yaml")
-_BUNDLES_YAML_PATH = Path(os.getenv("BUNDLES_YAML_DESCRIPTOR_PATH") or "/config/bundles.yaml")
+
 
 
 def _secret_candidates(key: str) -> list[str]:
@@ -123,86 +134,6 @@ def get_secret(key: str, default: str | None = None) -> str | None:
 
 def read_secret(key: str, default: str | None = None) -> str | None:
     return get_secret(key, default=default)
-
-
-def _parse_plain_key(key: str) -> tuple[Path, str]:
-    raw = str(key or "").strip()
-    if not raw:
-        return _ASSEMBLY_YAML_PATH, ""
-    for prefix, path in {
-        "a:": _ASSEMBLY_YAML_PATH,
-        "assembly:": _ASSEMBLY_YAML_PATH,
-        "b:": _BUNDLES_YAML_PATH,
-        "bundles:": _BUNDLES_YAML_PATH,
-    }.items():
-        if raw.startswith(prefix):
-            return path, raw[len(prefix):]
-    return _ASSEMBLY_YAML_PATH, raw
-
-
-def _descriptor_cache_token(path: Path) -> tuple[str, int, int] | None:
-    try:
-        stat = path.stat()
-    except OSError:
-        return None
-    return str(path), stat.st_mtime_ns, stat.st_size
-
-
-@lru_cache(maxsize=8)
-def _load_plain_yaml_cached(path_str: str, _mtime_ns: int, _size: int) -> Any:
-    path = Path(path_str)
-    try:
-        return yaml.safe_load(path.read_text()) if path.exists() else None
-    except Exception:
-        return None
-
-
-def _load_plain_yaml(path: Path) -> Any:
-    token = _descriptor_cache_token(path)
-    if token is None:
-        return None
-    return _load_plain_yaml_cached(*token)
-
-
-def _load_assembly_plain(dotted_path: str) -> Any:
-    return _resolve_dotted_value(_load_plain_yaml(_ASSEMBLY_YAML_PATH), dotted_path)
-
-
-def _resolve_dotted_value(data: Any, dotted_path: str) -> Any:
-    if not dotted_path:
-        return data
-    cur: Any = data
-    segments = [part for part in dotted_path.split(".") if part]
-    idx = 0
-    while idx < len(segments):
-        segment = segments[idx]
-        if isinstance(cur, dict):
-            if segment in cur:
-                cur = cur.get(segment)
-                idx += 1
-                continue
-            matched = False
-            for end in range(len(segments), idx, -1):
-                compound = ".".join(segments[idx:end])
-                if compound in cur:
-                    cur = cur.get(compound)
-                    idx = end
-                    matched = True
-                    break
-            if not matched:
-                return None
-            continue
-        if isinstance(cur, list):
-            if not segment.isdigit():
-                return None
-            list_idx = int(segment)
-            if list_idx < 0 or list_idx >= len(cur):
-                return None
-            cur = cur[list_idx]
-            idx += 1
-            continue
-        return None
-    return cur
 
 
 def get_plain(key: str, default: Any = None) -> Any:
@@ -500,6 +431,7 @@ def delete_user_prop(
     )
 
 
+
 def log_secret_statuses(force: bool = False) -> None:
     if force:
         _SECRET_LOGGED.clear()
@@ -539,9 +471,11 @@ class CorsConfig(BaseModel):
         return [str(v)]
 
 
-class Settings(BaseSettings):
+class Settings(PLATFORM_CONFIG):
     # API
     PORT: int = 8011
+    CHAT_APP_PORT: int = Field(default=8010)
+    CHAT_PROCESSOR_PORT: int = Field(default=8020)
     CORS_CONFIG: str | None = None
     CORS_CONFIG_OBJ: CorsConfig | None = None
 
@@ -563,6 +497,15 @@ class Settings(BaseSettings):
     GLOBAL_SECRETS_YAML: str | None = None
     BUNDLE_SECRETS_YAML: str | None = None
     LINK_PREVIEW_ENABLED: bool = Field(default=True)
+
+    # Nested config objects — populated in model_post_init.
+    # Primary access: get_settings().PLATFORM.<sub>.<attr>
+    #                 get_settings().AUTH.<attr>
+    #                 get_settings().SERVICES.<attr>
+    PLATFORM: Any = None
+    AUTH: Any = None
+    SERVICES: Any = None
+    RUNTIME_CONFIG: Any = None
 
     # Postgres
     PGHOST: str = Field(default="localhost", alias="POSTGRES_HOST")
@@ -606,8 +549,10 @@ class Settings(BaseSettings):
     TENANT: str = Field(default="home", alias="TENANT_ID")
     PROJECT: str = Field(default="default-project", alias="PROJECT_ID")
     INSTANCE_ID: str = Field(default="home-instance-1", alias="INSTANCE_ID")
+    AUTH_PROVIDER: str | None = Field(default=None, alias="AUTH_PROVIDER")
 
-    DEFAULT_MODEL_LLM: str | None = "claude-3-7-sonnet-20250219"
+    DEFAULT_MODEL_LLM_ID: str | None = Field(default="claude-3-7-sonnet-20250219", alias="DEFAULT_LLM_MODEL_ID")
+    DEFAULT_EMBEDDER: str | None = "openai-text-embedding-3-small"
 
     # OPEX aggregation scheduler
     OPEX_AGG_CRON: str = Field(default="0 3 * * *")
@@ -623,18 +568,17 @@ class Settings(BaseSettings):
     STRIPE_RECONCILE_CRON: str = Field(default="45 * * * *")
     STRIPE_RECONCILE_LOCK_TTL_SECONDS: int = Field(default=900)
 
-    # Bundle cleanup + ref tracking
+    # Bundle lifecycle settings — primary access via get_settings().PLATFORM.APPLICATIONS.*
+    # Flat fields below are kept for backward-compat env-var reads on cloud deployments
+    # where PLATFORM is not yet initialised (e.g. early startup checks).
     BUNDLE_CLEANUP_ENABLED: bool = Field(default=True)
     BUNDLE_CLEANUP_INTERVAL_SECONDS: int = Field(default=3600)
     BUNDLE_CLEANUP_LOCK_TTL_SECONDS: int = Field(default=900)
     BUNDLE_REF_TTL_SECONDS: int = Field(default=3600)
     BUNDLES_PRELOAD_LOCK_TTL_SECONDS: int = Field(default=900)
-    # Include built-in example bundles from sdk/examples/bundles
     BUNDLES_INCLUDE_EXAMPLES: bool = Field(default=True)
-    # Force bundles registry to be overwritten from AGENTIC_BUNDLES_JSON at startup (processor only).
     BUNDLES_FORCE_ENV_ON_STARTUP: bool = Field(default=False)
     BUNDLES_FORCE_ENV_LOCK_TTL_SECONDS: int = Field(default=60)
-    # Eagerly load all configured bundles at proc startup.
     BUNDLES_PRELOAD_ON_START: bool = Field(default=False)
 
     # Email notifications (admin alerts for Stripe events)
@@ -650,16 +594,12 @@ class Settings(BaseSettings):
     SOLUTION_RETAIN_TURN_WORKSPACE: bool = Field(default=False)
 
     def model_post_init(self, __context) -> None:
-        def _fetch_secret(key: str) -> str | None:
-            try:
-                return get_secrets_manager(self).get_secret(key)
-            except Exception:
-                return None
 
-        def _env_present(name: str) -> bool:
-            return bool(str(os.getenv(name) or "").strip())
 
-        # Override tenant/project from GATEWAY_CONFIG_JSON if present.
+        # 1. Override tenant/project from GATEWAY_CONFIG_JSON if present (backward compat).
+        #    Track whether GATEWAY_CONFIG_JSON supplied them so assembly.yaml does not override.
+        _gateway_json_set_tenant = False
+        _gateway_json_set_project = False
         cfg_json = os.getenv("GATEWAY_CONFIG_JSON")
         if isinstance(cfg_json, str) and cfg_json.strip():
             try:
@@ -669,41 +609,218 @@ class Settings(BaseSettings):
                 project = cfg.get("project_id") or cfg.get("project")
                 if tenant:
                     self.TENANT = tenant
+                    _gateway_json_set_tenant = True
                 if project:
                     self.PROJECT = project
+                    _gateway_json_set_project = True
             except Exception:
-                # Keep env-derived values on parse failure
                 pass
 
-        # Parse CORS_CONFIG JSON (if provided)
+        # 2. Parse CORS_CONFIG JSON (if provided); fall back to assembly cors.* section.
         if isinstance(self.CORS_CONFIG, str) and self.CORS_CONFIG.strip():
             try:
                 import json
                 self.CORS_CONFIG_OBJ = CorsConfig.model_validate(json.loads(self.CORS_CONFIG))
             except Exception:
-                # Leave None on parse failure
                 self.CORS_CONFIG_OBJ = None
+        if self.CORS_CONFIG_OBJ is None:
+            cors_data = _load_assembly_plain("cors")
+            if cors_data and isinstance(cors_data, dict):
+                try:
+                    self.CORS_CONFIG_OBJ = CorsConfig.model_validate(cors_data)
+                except Exception:
+                    pass
 
-        # If REDIS_URL is not explicitly set, build it from host/port/password/db.
+        # 3. Read infra settings from assembly.yaml before building REDIS_URL,
+        #    so the assembled values feed into the URL construction below.
+        if not self._env_present("SECRETS_PROVIDER") and not self.SECRETS_PROVIDER:
+            self.SECRETS_PROVIDER = self._assembly_str("secrets.provider")
+
+        if not self._env_present("POSTGRES_HOST"):
+            val = self._assembly_str("infra.postgres.host")
+            if val:
+                self.PGHOST = val
+        if not self._env_present("POSTGRES_PORT"):
+            val = self._assembly_int("infra.postgres.port")
+            if val is not None:
+                self.PGPORT = val
+        if not self._env_present("POSTGRES_USER"):
+            val = self._assembly_str("infra.postgres.user")
+            if val:
+                self.PGUSER = val
+        if not self._env_present("POSTGRES_PASSWORD"):
+            raw = _load_assembly_plain("infra.postgres.password")
+            if raw is not None:
+                self.PGPASSWORD = str(raw)
+        if not self._env_present("POSTGRES_DATABASE"):
+            val = self._assembly_str("infra.postgres.database")
+            if val:
+                self.PGDATABASE = val
+        if not self._env_present("POSTGRES_SSL"):
+            val = self._assembly_bool("infra.postgres.postgres_ssl")
+            if val is not None:
+                self.PGSSL = val
+
+        if not self._env_present("REDIS_HOST"):
+            val = self._assembly_str("infra.redis.host")
+            if val:
+                self.REDIS_HOST = val
+        if not self._env_present("REDIS_PORT"):
+            val = self._assembly_int("infra.redis.port")
+            if val is not None:
+                self.REDIS_PORT = val
+        if not self._env_present("REDIS_PASSWORD"):
+            raw = _load_assembly_plain("infra.redis.password")
+            if raw is not None:
+                self.REDIS_PASSWORD = str(raw) if str(raw).strip() else None
+
+        # 4. Build REDIS_URL from components if not explicitly set in env.
+        #    Must happen after infra reads so assembly.yaml host/port/password are reflected.
         if not os.getenv("REDIS_URL"):
             auth = f":{self.REDIS_PASSWORD}@" if self.REDIS_PASSWORD else ""
             self.REDIS_URL = f"redis://{auth}{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
 
-        # Populate non-secret storage/runtime settings from assembly.yaml when
-        # they are not explicitly provided via env. This lets runtime code use
-        # get_settings() while keeping assembly.yaml as the source of truth.
-        if not _env_present("SECRETS_PROVIDER") and not self.SECRETS_PROVIDER:
-            self.SECRETS_PROVIDER = _load_assembly_plain("secrets.provider")
-        if not _env_present("KDCUBE_STORAGE_PATH") and not self.STORAGE_PATH:
-            self.STORAGE_PATH = _load_assembly_plain("storage.kdcube")
-        if not _env_present("CB_BUNDLE_STORAGE_URL") and not self.BUNDLE_STORAGE_URL:
-            self.BUNDLE_STORAGE_URL = _load_assembly_plain("storage.bundles")
-        if not _env_present("REACT_WORKSPACE_IMPLEMENTATION"):
+        # 5. context: tenant/project from assembly.yaml when neither env var nor
+        #    GATEWAY_CONFIG_JSON supplied them.
+        if not self._env_present("TENANT_ID") and not _gateway_json_set_tenant:
+            val = self._assembly_str("context.tenant")
+            if val:
+                self.TENANT = val
+        if not self._env_present("PROJECT_ID") and not _gateway_json_set_project:
+            val = self._assembly_str("context.project")
+            if val:
+                self.PROJECT = val
+
+        # 6. auth provider
+        if not self._env_present("AUTH_PROVIDER") and not self.AUTH_PROVIDER:
+            self.AUTH_PROVIDER = self._assembly_str("auth.type")
+
+        # 7. AWS settings
+        if not self._env_present("AWS_REGION"):
+            val = self._assembly_str("aws.aws_region")
+            if val:
+                self.AWS_REGION = val
+        if not self._env_present("AWS_PROFILE") and not self.AWS_PROFILE:
+            self.AWS_PROFILE = self._assembly_str("aws.aws_profile")
+
+        # 8. Build PLATFORM nested config (per-service reads from assembly.yaml).
+        component = (self.GATEWAY_COMPONENT or "").strip().lower()
+        svc = f"platform.services.{component}"
+        log_p = f"{svc}.log"
+        svc_p = f"{svc}.service"
+        av_p = f"{svc}.av"
+        idp_p = f"{svc}.idp"
+        mon_p = f"{svc}.monitoring"
+        exec_p = f"{svc}.exec"
+        bundles_p = f"{svc}.bundles"
+        git_p = f"{bundles_p}.git"
+
+        self.PLATFORM = PlatformConfig(
+            LOG=LOGConfig(
+                LOG_LEVEL=self._resolve_str("LOG_LEVEL", f"{log_p}.log_level", "INFO"),
+                LOG_MAX_MB=self._resolve_int("LOG_MAX_MB", f"{log_p}.log_max_mb", 20),
+                LOG_BACKUP_COUNT=self._resolve_int("LOG_BACKUP_COUNT", f"{log_p}.log_backup_count", 10),
+                LOG_DIR=self._resolve_str("LOG_DIR", f"{log_p}.log_dir"),
+                LOG_FILE_PREFIX=self._resolve_str("LOG_FILE_PREFIX", f"{log_p}.log_file_prefix"),
+            ),
+            SERVICE=ServiceConfig(
+                UVICORN_RELOAD=self._resolve_bool("UVICORN_RELOAD", f"{svc_p}.uvicorn_reload", False),
+                HEARTBEAT_INTERVAL=self._resolve_int("HEARTBEAT_INTERVAL", f"{svc_p}.heartbeat_interval", 5),
+                CB_RELAY_IDENTITY=self._resolve_str("CB_RELAY_IDENTITY", f"{svc_p}.cb_relay_identity"),
+                CHAT_SCHEDULER_BACKEND=self._resolve_str("CHAT_SCHEDULER_BACKEND", f"{svc_p}.chat_scheduler_backend", "legacy_lists"),
+                CHAT_TASK_TIMEOUT_SEC=self._resolve_int("CHAT_TASK_TIMEOUT_SEC", f"{svc_p}.chat_task_timeout_sec", 600),
+                CHAT_TASK_IDLE_TIMEOUT_SEC=self._resolve_int("CHAT_TASK_IDLE_TIMEOUT_SEC", f"{svc_p}.chat_task_idle_timeout_sec", 600),
+                CHAT_TASK_MAX_WALL_TIME_SEC=self._resolve_int("CHAT_TASK_MAX_WALL_TIME_SEC", f"{svc_p}.chat_task_max_wall_time_sec", 2400),
+                CHAT_TASK_WATCHDOG_POLL_INTERVAL_SEC=self._resolve_float("CHAT_TASK_WATCHDOG_POLL_INTERVAL_SEC", f"{svc_p}.chat_task_watchdog_poll_interval_sec", 1.0),
+            ),
+            HOSTED_SERVICES=HostedServicesConfig(
+                AV=AVConfig(
+                    APP_AV_SCAN=self._resolve_bool("APP_AV_SCAN", f"{av_p}.app_av_scan", True),
+                    APP_AV_TIMEOUT_S=self._resolve_float("APP_AV_TIMEOUT_S", f"{av_p}.app_av_timeout_s", 3.0),
+                    CLAMAV_HOST=self._resolve_str("CLAMAV_HOST", f"{av_p}.clamav_host", "localhost"),
+                    CLAMAV_PORT=self._resolve_int("CLAMAV_PORT", f"{av_p}.clamav_port", 3310),
+                ),
+            ),
+            MONITORING=MonitoringConfig(
+                MONITORING_BURST_ENABLE=self._resolve_bool("MONITORING_BURST_ENABLE", f"{mon_p}.monitoring_burst_enable", True),
+            ),
+            EXEC=ExecConfig(
+                EXEC_WORKSPACE_ROOT=self._resolve_str("EXEC_WORKSPACE_ROOT", f"{exec_p}.exec_workspace_root"),
+                PY=PyExecConfig(
+                    PY_CODE_EXEC_IMAGE=self._resolve_str("PY_CODE_EXEC_IMAGE", f"{exec_p}.py_code_exec_image", "py-code-exec:latest"),
+                    PY_CODE_EXEC_TIMEOUT=self._resolve_int("PY_CODE_EXEC_TIMEOUT", f"{exec_p}.py_code_exec_timeout", 600),
+                    PY_CODE_EXEC_NETWORK_MODE=self._resolve_str("PY_CODE_EXEC_NETWORK_MODE", f"{exec_p}.py_code_exec_network_mode", "host"),
+                ),
+            ),
+            ACCOUNTING=AccountingConfig(
+                ACCOUNTING_SERVICES=self._resolve_str("ACCOUNTING_SERVICES", f"{svc}.tools.accounting_services"),
+            ),
+            APPLICATIONS=ApplicationsConfig(
+                AGENTIC_BUNDLES_ROOT=self._resolve_str("AGENTIC_BUNDLES_ROOT", f"{bundles_p}.agentic_bundles_root", "/bundles"),
+                BUNDLE_STORAGE_ROOT=self._resolve_str("BUNDLE_STORAGE_ROOT", f"{bundles_p}.bundle_storage_root"),
+                BUNDLES_INCLUDE_EXAMPLES=self._resolve_bool("BUNDLES_INCLUDE_EXAMPLES", f"{bundles_p}.bundles_include_examples", True),
+                BUNDLE_CLEANUP_ENABLED=self._resolve_bool("BUNDLE_CLEANUP_ENABLED", f"{bundles_p}.bundle_cleanup_enabled", True),
+                BUNDLE_CLEANUP_INTERVAL_SECONDS=self._resolve_int("BUNDLE_CLEANUP_INTERVAL_SECONDS", f"{bundles_p}.bundle_cleanup_interval_seconds", 3600),
+                BUNDLE_CLEANUP_LOCK_TTL_SECONDS=self._resolve_int("BUNDLE_CLEANUP_LOCK_TTL_SECONDS", f"{bundles_p}.bundle_cleanup_lock_ttl_seconds", 900),
+                BUNDLE_REF_TTL_SECONDS=self._resolve_int("BUNDLE_REF_TTL_SECONDS", f"{bundles_p}.bundle_ref_ttl_seconds", 3600),
+                BUNDLES_FORCE_ENV_ON_STARTUP=self._resolve_bool("BUNDLES_FORCE_ENV_ON_STARTUP", f"{bundles_p}.bundles_force_env_on_startup", False),
+                BUNDLES_FORCE_ENV_LOCK_TTL_SECONDS=self._resolve_int("BUNDLES_FORCE_ENV_LOCK_TTL_SECONDS", f"{bundles_p}.bundles_force_env_lock_ttl_seconds", 60),
+                BUNDLES_PRELOAD_ON_START=self._resolve_bool("BUNDLES_PRELOAD_ON_START", f"{bundles_p}.bundles_preload_on_start", False),
+                BUNDLES_PRELOAD_LOCK_TTL_SECONDS=self._resolve_int("BUNDLES_PRELOAD_LOCK_TTL_SECONDS", f"{bundles_p}.bundles_preload_lock_ttl_seconds", 900),
+                GIT=GitBundlesConfig(
+                    BUNDLE_GIT_RESOLUTION_ENABLED=self._resolve_bool("BUNDLE_GIT_RESOLUTION_ENABLED", f"{git_p}.bundle_git_resolution_enabled", True),
+                    BUNDLE_GIT_ATOMIC=self._resolve_bool("BUNDLE_GIT_ATOMIC", f"{git_p}.bundle_git_atomic", True),
+                    BUNDLE_GIT_ALWAYS_PULL=self._resolve_bool("BUNDLE_GIT_ALWAYS_PULL", f"{git_p}.bundle_git_always_pull", False),
+                    BUNDLE_GIT_REDIS_LOCK=self._resolve_bool("BUNDLE_GIT_REDIS_LOCK", f"{git_p}.bundle_git_redis_lock", True),
+                    BUNDLE_GIT_REDIS_LOCK_TTL_SECONDS=self._resolve_int("BUNDLE_GIT_REDIS_LOCK_TTL_SECONDS", f"{git_p}.bundle_git_redis_lock_ttl_seconds", 300),
+                    BUNDLE_GIT_REDIS_LOCK_WAIT_SECONDS=self._resolve_int("BUNDLE_GIT_REDIS_LOCK_WAIT_SECONDS", f"{git_p}.bundle_git_redis_lock_wait_seconds", 60),
+                    BUNDLE_GIT_PREFETCH_ENABLED=self._resolve_bool("BUNDLE_GIT_PREFETCH_ENABLED", f"{git_p}.bundle_git_prefetch_enabled", True),
+                    BUNDLE_GIT_PREFETCH_INTERVAL_SECONDS=self._resolve_int("BUNDLE_GIT_PREFETCH_INTERVAL_SECONDS", f"{git_p}.bundle_git_prefetch_interval_seconds", 15),
+                    BUNDLE_GIT_FAIL_BACKOFF_SECONDS=self._resolve_int("BUNDLE_GIT_FAIL_BACKOFF_SECONDS", f"{git_p}.bundle_git_fail_backoff_seconds", 60),
+                    BUNDLE_GIT_FAIL_MAX_BACKOFF_SECONDS=self._resolve_int("BUNDLE_GIT_FAIL_MAX_BACKOFF_SECONDS", f"{git_p}.bundle_git_fail_max_backoff_seconds", 300),
+                    BUNDLE_GIT_KEEP=self._resolve_int("BUNDLE_GIT_KEEP", f"{git_p}.bundle_git_keep", 3),
+                    BUNDLE_GIT_TTL_HOURS=self._resolve_int("BUNDLE_GIT_TTL_HOURS", f"{git_p}.bundle_git_ttl_hours", 0),
+                    GIT_SSH_KEY_PATH=self._resolve_str("GIT_SSH_KEY_PATH", f"{git_p}.git_ssh_key_path"),
+                    GIT_SSH_KNOWN_HOSTS=self._resolve_str("GIT_SSH_KNOWN_HOSTS", f"{git_p}.git_ssh_known_hosts"),
+                    GIT_SSH_STRICT_HOST_KEY_CHECKING=self._resolve_str("GIT_SSH_STRICT_HOST_KEY_CHECKING", f"{git_p}.git_ssh_strict_host_key_checking", "yes"),
+                ),
+            ),
+        )
+
+        # Service port from assembly.yaml based on GATEWAY_COMPONENT.
+        _port_key = {"ingress": "ports.ingress", "proc": "ports.proc",
+                     "processor": "ports.proc", "metrics": "ports.metrics"}.get(component)
+        if _port_key and not self._env_present("CHAT_APP_PORT") and not self._env_present("CHAT_PROCESSOR_PORT") \
+                and not self._env_present("METRICS_PORT"):
+            val = self._assembly_int(_port_key)
+            if val is not None:
+                self.PORT = val
+
+        # CHAT_APP_PORT / CHAT_PROCESSOR_PORT — explicit per-service port fields (always from assembly).
+        if not self._env_present("CHAT_APP_PORT"):
+            val = self._assembly_int("ports.ingress")
+            if val is not None:
+                self.CHAT_APP_PORT = val
+        if not self._env_present("CHAT_PROCESSOR_PORT"):
+            val = self._assembly_int("ports.proc")
+            if val is not None:
+                self.CHAT_PROCESSOR_PORT = val
+
+        # Default LLM model (env: DEFAULT_LLM_MODEL_ID, assembly: models.default_llm_model_id).
+        if not self._env_present("DEFAULT_LLM_MODEL_ID"):
+            val = self._assembly_str("models.default_llm_model_id")
+            if val:
+                self.DEFAULT_MODEL_LLM_ID = val
+
+        # 9. Storage / workspace settings from assembly.yaml.
+        if not self._env_present("KDCUBE_STORAGE_PATH") and not self.STORAGE_PATH:
+            self.STORAGE_PATH = self._assembly_str("storage.kdcube")
+        if not self._env_present("CB_BUNDLE_STORAGE_URL") and not self.BUNDLE_STORAGE_URL:
+            self.BUNDLE_STORAGE_URL = self._assembly_str("storage.bundles")
+        if not self._env_present("REACT_WORKSPACE_IMPLEMENTATION"):
             self.REACT_WORKSPACE_IMPLEMENTATION = str(
-                _load_assembly_plain("storage.workspace.type") or self.REACT_WORKSPACE_IMPLEMENTATION
+                self._assembly_str("storage.workspace.type") or self.REACT_WORKSPACE_IMPLEMENTATION
             )
-        if not _env_present("REACT_WORKSPACE_GIT_REPO") and not self.REACT_WORKSPACE_GIT_REPO:
-            self.REACT_WORKSPACE_GIT_REPO = _load_assembly_plain("storage.workspace.repo")
         self.AI_REACT_AGENT_VERSION = (
             str(self.AI_REACT_AGENT_VERSION or "v2").strip().lower() or "v2"
         )
@@ -711,16 +828,75 @@ class Settings(BaseSettings):
             self.AI_REACT_AGENT_VERSION = "v2"
         if not self.AI_REACT_AGENT_MULTI_ACTION:
             self.AI_REACT_AGENT_MULTI_ACTION = "off"
-
-        if not _env_present("CLAUDE_CODE_SESSION_STORE_IMPLEMENTATION"):
+        if not self._env_present("REACT_WORKSPACE_GIT_REPO") and not self.REACT_WORKSPACE_GIT_REPO:
+            self.REACT_WORKSPACE_GIT_REPO = self._assembly_str("storage.workspace.repo")
+        if not self._env_present("CLAUDE_CODE_SESSION_STORE_IMPLEMENTATION"):
             self.CLAUDE_CODE_SESSION_STORE_IMPLEMENTATION = str(
-                _load_assembly_plain("storage.claude_code_session.type")
+                self._assembly_str("storage.claude_code_session.type")
                 or self.CLAUDE_CODE_SESSION_STORE_IMPLEMENTATION
             )
-        if not _env_present("CLAUDE_CODE_SESSION_GIT_REPO") and not self.CLAUDE_CODE_SESSION_GIT_REPO:
-            self.CLAUDE_CODE_SESSION_GIT_REPO = _load_assembly_plain("storage.claude_code_session.repo")
+        if not self._env_present("CLAUDE_CODE_SESSION_GIT_REPO") and not self.CLAUDE_CODE_SESSION_GIT_REPO:
+            self.CLAUDE_CODE_SESSION_GIT_REPO = self._assembly_str("storage.claude_code_session.repo")
 
-        # Populate secrets from provider if not set in env.
+        # 10. Routines / scheduler settings from assembly.yaml.
+        if not self._env_present("OPEX_AGG_CRON"):
+            val = self._assembly_str("routines.opex.agg_cron")
+            if val:
+                self.OPEX_AGG_CRON = val
+        if not self._env_present("SUBSCRIPTION_ROLLOVER_ENABLED"):
+            val = self._assembly_bool("routines.economics.subscription_rollover_enabled")
+            if val is not None:
+                self.SUBSCRIPTION_ROLLOVER_ENABLED = val
+        if not self._env_present("SUBSCRIPTION_ROLLOVER_CRON"):
+            val = self._assembly_str("routines.economics.subscription_rollover_cron")
+            if val:
+                self.SUBSCRIPTION_ROLLOVER_CRON = val
+        if not self._env_present("SUBSCRIPTION_ROLLOVER_LOCK_TTL_SECONDS"):
+            val = self._assembly_int("routines.economics.subscription_rollover_lock_ttl_seconds")
+            if val is not None:
+                self.SUBSCRIPTION_ROLLOVER_LOCK_TTL_SECONDS = val
+        if not self._env_present("SUBSCRIPTION_ROLLOVER_SWEEP_LIMIT"):
+            val = self._assembly_int("routines.economics.subscription_rollover_sweep_limit")
+            if val is not None:
+                self.SUBSCRIPTION_ROLLOVER_SWEEP_LIMIT = val
+        if not self._env_present("STRIPE_RECONCILE_ENABLED"):
+            val = self._assembly_bool("routines.stripe.reconcile_enabled")
+            if val is not None:
+                self.STRIPE_RECONCILE_ENABLED = val
+        if not self._env_present("STRIPE_RECONCILE_CRON"):
+            val = self._assembly_str("routines.stripe.reconcile_cron")
+            if val:
+                self.STRIPE_RECONCILE_CRON = val
+        if not self._env_present("STRIPE_RECONCILE_LOCK_TTL_SECONDS"):
+            val = self._assembly_int("routines.stripe.reconcile_lock_ttl_seconds")
+            if val is not None:
+                self.STRIPE_RECONCILE_LOCK_TTL_SECONDS = val
+
+        # 11. Email notification settings from assembly.yaml.
+        if not self._env_present("EMAIL_ENABLED"):
+            val = self._assembly_bool("notifications.email.enabled")
+            if val is not None:
+                self.EMAIL_ENABLED = val
+        if not self._env_present("EMAIL_HOST") and not self.EMAIL_HOST:
+            self.EMAIL_HOST = self._assembly_str("notifications.email.host")
+        if not self._env_present("EMAIL_PORT"):
+            val = self._assembly_int("notifications.email.port")
+            if val is not None:
+                self.EMAIL_PORT = val
+        if not self._env_present("EMAIL_USER") and not self.EMAIL_USER:
+            self.EMAIL_USER = self._assembly_str("notifications.email.user")
+        if not self._env_present("EMAIL_FROM") and not self.EMAIL_FROM:
+            self.EMAIL_FROM = self._assembly_str("notifications.email.from")
+        if not self._env_present("EMAIL_TO"):
+            val = self._assembly_str("notifications.email.to")
+            if val:
+                self.EMAIL_TO = val
+        if not self._env_present("EMAIL_USE_TLS"):
+            val = self._assembly_bool("notifications.email.use_tls")
+            if val is not None:
+                self.EMAIL_USE_TLS = val
+
+        # 12. Populate secrets from provider if not set in env.
         env_openai = os.getenv("OPENAI_API_KEY")
         env_anthropic = os.getenv("ANTHROPIC_API_KEY")
         env_gemini = os.getenv("GEMINI_API_KEY")
@@ -730,27 +906,27 @@ class Settings(BaseSettings):
         env_openrouter = os.getenv("OPENROUTER_API_KEY")
 
         if not self.OPENAI_API_KEY:
-            self.OPENAI_API_KEY = _fetch_secret("services.openai.api_key") or _fetch_secret("OPENAI_API_KEY")
+            self.OPENAI_API_KEY = self._fetch_secret("services.openai.api_key") or self._fetch_secret("OPENAI_API_KEY")
         if not self.ANTHROPIC_API_KEY:
-            self.ANTHROPIC_API_KEY = _fetch_secret("services.anthropic.api_key") or _fetch_secret("ANTHROPIC_API_KEY")
+            self.ANTHROPIC_API_KEY = self._fetch_secret("services.anthropic.api_key") or self._fetch_secret("ANTHROPIC_API_KEY")
         if not self.GOOGLE_API_KEY:
             self.GOOGLE_API_KEY = (
-                _fetch_secret("services.google.api_key")
-                or _fetch_secret("GOOGLE_API_KEY")
-                or _fetch_secret("GEMINI_API_KEY")
+                self._fetch_secret("services.google.api_key")
+                or self._fetch_secret("GOOGLE_API_KEY")
+                or self._fetch_secret("GEMINI_API_KEY")
             )
         if not self.BRAVE_API_KEY:
-            self.BRAVE_API_KEY = _fetch_secret("services.brave.api_key") or _fetch_secret("BRAVE_API_KEY")
+            self.BRAVE_API_KEY = self._fetch_secret("services.brave.api_key") or self._fetch_secret("BRAVE_API_KEY")
         if not self.GIT_HTTP_TOKEN:
-            self.GIT_HTTP_TOKEN = _fetch_secret("services.git.http_token") or _fetch_secret("GIT_HTTP_TOKEN")
+            self.GIT_HTTP_TOKEN = self._fetch_secret("services.git.http_token") or self._fetch_secret("GIT_HTTP_TOKEN")
         if not self.GIT_HTTP_USER and self.GIT_HTTP_TOKEN:
-            self.GIT_HTTP_USER = _fetch_secret("services.git.http_user") or "x-access-token"
+            self.GIT_HTTP_USER = self._fetch_secret("services.git.http_user") or "x-access-token"
         if not self.OPENROUTER_API_KEY:
-            self.OPENROUTER_API_KEY = _fetch_secret("services.openrouter.api_key") or _fetch_secret("OPENROUTER_API_KEY")
+            self.OPENROUTER_API_KEY = self._fetch_secret("services.openrouter.api_key") or self._fetch_secret("OPENROUTER_API_KEY")
         if not self.OPENROUTER_BASE_URL:
             self.OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL") or "https://openrouter.ai/api/v1"
         if not self.CLAUDE_CODE_KEY:
-            self.CLAUDE_CODE_KEY = _fetch_secret("services.anthropic.claude_code_key") or _fetch_secret("CLAUDE_CODE_KEY")
+            self.CLAUDE_CODE_KEY = self._fetch_secret("services.anthropic.claude_code_key") or self._fetch_secret("CLAUDE_CODE_KEY")
 
         _log_secret_status("services.openai.api_key", self.OPENAI_API_KEY, "env" if env_openai else "secrets")
         _log_secret_status("services.anthropic.api_key", self.ANTHROPIC_API_KEY, "env" if env_anthropic else "secrets")
@@ -759,6 +935,39 @@ class Settings(BaseSettings):
         _log_secret_status("services.git.http_token", self.GIT_HTTP_TOKEN, "env" if env_git_token else "secrets")
         _log_secret_status("services.git.http_user", self.GIT_HTTP_USER, "env" if env_git_user else "secrets")
         _log_secret_status("services.openrouter.api_key", self.OPENROUTER_API_KEY, "env" if env_openrouter else "secrets")
+
+        # 13. Build AUTH config (env > assembly.yaml > default).
+        self.AUTH = AuthConfig(
+            COGNITO_REGION=self._resolve_str("COGNITO_REGION", "auth.cognito.region"),
+            COGNITO_USER_POOL_ID=self._resolve_str("COGNITO_USER_POOL_ID", "auth.cognito.user_pool_id"),
+            COGNITO_APP_CLIENT_ID=self._resolve_str("COGNITO_APP_CLIENT_ID", "auth.cognito.app_client_id"),
+            COGNITO_SERVICE_CLIENT_ID=self._resolve_str("COGNITO_SERVICE_CLIENT_ID", "auth.cognito.service_client_id"),
+            ID_TOKEN_HEADER_NAME=self._resolve_str("ID_TOKEN_HEADER_NAME", "auth.id_token_header_name", "X-ID-Token"),
+            AUTH_TOKEN_COOKIE_NAME=self._resolve_str("AUTH_TOKEN_COOKIE_NAME", "auth.auth_token_cookie_name", "__Secure-LATC"),
+            ID_TOKEN_COOKIE_NAME=self._resolve_str("ID_TOKEN_COOKIE_NAME", "auth.id_token_cookie_name", "__Secure-LITC"),
+            JWKS_CACHE_TTL_SECONDS=self._resolve_int("JWKS_CACHE_TTL_SECONDS", "auth.jwks_cache_ttl_seconds", 86400),
+            OIDC_SERVICE_USER_EMAIL=self._fetch_secret("auth.oidc.admin_email") or self._env_str("OIDC_SERVICE_USER_EMAIL"),
+            OIDC_SERVICE_ADMIN_USERNAME=self._fetch_secret("auth.oidc.admin_username") or self._env_str("OIDC_SERVICE_ADMIN_USERNAME"),
+            OIDC_SERVICE_ADMIN_PASSWORD=self._fetch_secret("auth.oidc.admin_password") or self._env_str("OIDC_SERVICE_ADMIN_PASSWORD"),
+            IDP=IDPConfig(
+                local=IDPLocalConfig(
+                    IDP_DB_PATH=self._resolve_str("IDP_DB_PATH", f"{svc}.idp.idp_db_path"),
+                    IDP_IMPORT_ENABLED=self._resolve_bool("IDP_IMPORT_ENABLED", f"{svc}.idp.idp_import_enabled", False),
+                    IDP_IMPORT_RUN_AT=self._resolve_str("IDP_IMPORT_RUN_AT", f"{svc}.idp.idp_import_run_at"),
+                    IDP_IMPORT_SCRIPT_PATH=self._resolve_str("IDP_IMPORT_SCRIPT_PATH", f"{svc}.idp.idp_import_script_path"),
+                ),
+            ),
+        )
+
+        # 14. Build SERVICES config.
+        self.SERVICES = ServicesConfig(
+            DEFAULT_EMBEDDING_MODEL_ID=self._resolve_str("DEFAULT_EMBEDDING_MODEL_ID", "models.default_embedding_model_id"),
+        )
+
+        # 15. Build RUNTIME_CONFIG (request-context header names).
+        # RUNTIME_CONFIG inherits PLATFORM_CONFIG (BaseSettings) so env vars are
+        # picked up automatically by Pydantic — no manual resolution needed here.
+        self.RUNTIME_CONFIG = RUNTIME_CONFIG()
 
     def secret(self, key: str, default: str | None = None) -> str | None:
         normalized_key = _normalize_secret_lookup_key(key)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
@@ -822,12 +822,13 @@ class Settings(PLATFORM_CONFIG):
                 self._assembly_str("storage.workspace.type") or self.REACT_WORKSPACE_IMPLEMENTATION
             )
         self.AI_REACT_AGENT_VERSION = (
-            str(self.AI_REACT_AGENT_VERSION or "v2").strip().lower() or "v2"
+            str(self._resolve_str("AI_REACT_AGENT_VERSION", "ai.react.react_agent_version", "v2") or "v2").strip().lower() or "v2"
         )
         if self.AI_REACT_AGENT_VERSION not in {"v2", "v3"}:
             self.AI_REACT_AGENT_VERSION = "v2"
-        if not self.AI_REACT_AGENT_MULTI_ACTION:
-            self.AI_REACT_AGENT_MULTI_ACTION = "off"
+        self.AI_REACT_AGENT_MULTI_ACTION = (
+            self._resolve_str("AI_REACT_AGENT_MULTI_ACTION", "ai.react.react_agent_multiaction", "off") or "off"
+        )
         if not self._env_present("REACT_WORKSPACE_GIT_REPO") and not self.REACT_WORKSPACE_GIT_REPO:
             self.REACT_WORKSPACE_GIT_REPO = self._assembly_str("storage.workspace.repo")
         if not self._env_present("CLAUDE_CODE_SESSION_STORE_IMPLEMENTATION"):

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py
@@ -1,0 +1,382 @@
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
+from kdcube_ai_app.infra.secrets import get_secrets_manager
+
+_ASSEMBLY_YAML_PATH = Path(os.getenv("ASSEMBLY_YAML_DESCRIPTOR_PATH") or "/config/assembly.yaml")
+_BUNDLES_YAML_PATH = Path(os.getenv("BUNDLES_YAML_DESCRIPTOR_PATH") or "/config/bundles.yaml")
+
+
+# ─── YAML helpers ─────────────────────────────────────────────────────────────
+
+def _descriptor_cache_token(path: Path) -> tuple[str, int, int] | None:
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return str(path), stat.st_mtime_ns, stat.st_size
+
+
+def _load_plain_yaml(path: Path) -> Any:
+    token = _descriptor_cache_token(path)
+    if token is None:
+        return None
+    return _load_plain_yaml_cached(*token)
+
+
+@lru_cache(maxsize=8)
+def _load_plain_yaml_cached(path_str: str, _mtime_ns: int, _size: int) -> Any:
+    path = Path(path_str)
+    try:
+        return yaml.safe_load(path.read_text()) if path.exists() else None
+    except Exception:
+        return None
+
+
+def _resolve_dotted_value(data: Any, dotted_path: str) -> Any:
+    if not dotted_path:
+        return data
+    cur: Any = data
+    segments = [part for part in dotted_path.split(".") if part]
+    idx = 0
+    while idx < len(segments):
+        segment = segments[idx]
+        if isinstance(cur, dict):
+            if segment in cur:
+                cur = cur.get(segment)
+                idx += 1
+                continue
+            matched = False
+            for end in range(len(segments), idx, -1):
+                compound = ".".join(segments[idx:end])
+                if compound in cur:
+                    cur = cur.get(compound)
+                    idx = end
+                    matched = True
+                    break
+            if not matched:
+                return None
+            continue
+        if isinstance(cur, list):
+            if not segment.isdigit():
+                return None
+            list_idx = int(segment)
+            if list_idx < 0 or list_idx >= len(cur):
+                return None
+            cur = cur[list_idx]
+            idx += 1
+            continue
+        return None
+    return cur
+
+
+def _load_assembly_plain(dotted_path: str) -> Any:
+    return _resolve_dotted_value(_load_plain_yaml(_ASSEMBLY_YAML_PATH), dotted_path)
+
+
+def _parse_plain_key(key: str) -> tuple[Path, str]:
+    raw = str(key or "").strip()
+    if not raw:
+        return _ASSEMBLY_YAML_PATH, ""
+    for prefix, path in {
+        "a:": _ASSEMBLY_YAML_PATH,
+        "assembly:": _ASSEMBLY_YAML_PATH,
+        "b:": _BUNDLES_YAML_PATH,
+        "bundles:": _BUNDLES_YAML_PATH,
+    }.items():
+        if raw.startswith(prefix):
+            return path, raw[len(prefix):]
+    return _ASSEMBLY_YAML_PATH, raw
+
+
+# ─── PLATFORM_CONFIG — base class with assembly + env helpers ─────────────────
+# Inherits BaseSettings to preserve backward compat: for cloud deployments env
+# vars are injected directly and BaseSettings picks them up automatically for
+# all flat attrs on Settings.  The _resolve_* helpers below implement the
+# canonical priority order:  assembly.yaml  >  env var  >  hard-coded default.
+
+class PLATFORM_CONFIG(BaseSettings):
+    GATEWAY_COMPONENT: str | None = None
+
+    # ── secret fetching ───────────────────────────────────────────────────────
+
+    def _fetch_secret(self, key: str) -> str | None:
+        try:
+            return get_secrets_manager(self).get_secret(key)
+        except Exception:
+            return None
+
+    # ── low-level env readers (typed, None when absent / unparseable) ─────────
+
+    def _env_present(self, name: str) -> bool:
+        return bool(str(os.getenv(name) or "").strip())
+
+    def _env_str(self, name: str) -> str | None:
+        val = os.getenv(name)
+        return val.strip() if val and val.strip() else None
+
+    def _env_int(self, name: str) -> int | None:
+        val = os.getenv(name)
+        if not val or not val.strip():
+            return None
+        try:
+            return int(val.strip())
+        except (ValueError, TypeError):
+            return None
+
+    def _env_float(self, name: str) -> float | None:
+        val = os.getenv(name)
+        if not val or not val.strip():
+            return None
+        try:
+            return float(val.strip())
+        except (ValueError, TypeError):
+            return None
+
+    def _env_bool(self, name: str) -> bool | None:
+        val = os.getenv(name)
+        if not val or not val.strip():
+            return None
+        return val.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+    # ── low-level assembly readers ────────────────────────────────────────────
+
+    def _assembly_str(self, path: str) -> str | None:
+        val = _load_assembly_plain(path)
+        s = str(val).strip() if val is not None else ""
+        return s or None
+
+    def _assembly_int(self, path: str) -> int | None:
+        val = _load_assembly_plain(path)
+        if val is None:
+            return None
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            return None
+
+    def _assembly_float(self, path: str) -> float | None:
+        val = _load_assembly_plain(path)
+        if val is None:
+            return None
+        try:
+            return float(val)
+        except (ValueError, TypeError):
+            return None
+
+    def _assembly_bool(self, path: str) -> bool | None:
+        val = _load_assembly_plain(path)
+        if val is None:
+            return None
+        if isinstance(val, bool):
+            return val
+        return str(val).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+    # ── high-level resolvers: assembly > env > default ────────────────────────
+    # Assembly descriptor wins when present; env var is the fallback for cloud
+    # deployments that inject env vars without a mounted descriptor; hard-coded
+    # default is the last resort.  This mirrors the old BaseSettings behaviour
+    # where model_post_init would override the env-read value with the assembly
+    # value whenever the key was present in the descriptor.
+
+    def _resolve_str(self, env_name: str, assembly_path: str, default: str | None = None) -> str | None:
+        v = self._assembly_str(assembly_path)
+        if v is not None:
+            return v
+        v = self._env_str(env_name)
+        return v if v is not None else default
+
+    def _resolve_int(self, env_name: str, assembly_path: str, default: int) -> int:
+        v = self._assembly_int(assembly_path)
+        if v is not None:
+            return v
+        v = self._env_int(env_name)
+        return v if v is not None else default
+
+    def _resolve_float(self, env_name: str, assembly_path: str, default: float) -> float:
+        v = self._assembly_float(assembly_path)
+        if v is not None:
+            return v
+        v = self._env_float(env_name)
+        return v if v is not None else default
+
+    def _resolve_bool(self, env_name: str, assembly_path: str, default: bool) -> bool:
+        # Check assembly first; only fall back to env when no assembly value is set.
+        # _env_present guard is required so that False from env is not skipped.
+        v = self._assembly_bool(assembly_path)
+        if v is not None:
+            return v
+        if self._env_present(env_name):
+            ev = self._env_bool(env_name)
+            return ev if ev is not None else default
+        return default
+
+
+# ─── PLATFORM.LOG ─────────────────────────────────────────────────────────────
+
+class LOGConfig(BaseModel):
+    LOG_LEVEL: str = "INFO"
+    LOG_MAX_MB: int = 20
+    LOG_BACKUP_COUNT: int = 10
+    LOG_DIR: str | None = None
+    LOG_FILE_PREFIX: str | None = None
+
+
+# ─── PLATFORM.SERVICE ─────────────────────────────────────────────────────────
+# Per-service runtime knobs (read from platform.services.<component>.service.*)
+
+class ServiceConfig(BaseModel):
+    UVICORN_RELOAD: bool = False
+    HEARTBEAT_INTERVAL: int = 5
+    CB_RELAY_IDENTITY: str | None = None
+    # Proc scheduler backend selector (legacy_lists | kafka | …)
+    CHAT_SCHEDULER_BACKEND: str = "legacy_lists"
+    # Task timeout knobs (proc)
+    CHAT_TASK_TIMEOUT_SEC: int = 600
+    CHAT_TASK_IDLE_TIMEOUT_SEC: int = 600
+    CHAT_TASK_MAX_WALL_TIME_SEC: int = 2400
+    CHAT_TASK_WATCHDOG_POLL_INTERVAL_SEC: float = 1.0
+
+
+# ─── PLATFORM.HOSTED_SERVICES ─────────────────────────────────────────────────
+# Component-hosted sidecar services (ingress: AV scanner, …)
+
+class AVConfig(BaseModel):
+    APP_AV_SCAN: bool = True
+    APP_AV_TIMEOUT_S: float = 3.0
+    CLAMAV_HOST: str = "localhost"
+    CLAMAV_PORT: int = 3310
+
+
+class HostedServicesConfig(BaseModel):
+    AV: AVConfig = Field(default_factory=AVConfig)
+
+
+# ─── PLATFORM.MONITORING ──────────────────────────────────────────────────────
+
+class MonitoringConfig(BaseModel):
+    MONITORING_BURST_ENABLE: bool = True
+
+
+# ─── PLATFORM.EXEC ────────────────────────────────────────────────────────────
+
+class PyExecConfig(BaseModel):
+    """Python sandboxed code execution settings (get_settings().PLATFORM.EXEC.PY)."""
+    PY_CODE_EXEC_IMAGE: str = "py-code-exec:latest"
+    PY_CODE_EXEC_TIMEOUT: int = 600
+    PY_CODE_EXEC_NETWORK_MODE: str = "host"
+
+
+class ExecConfig(BaseModel):
+    EXEC_WORKSPACE_ROOT: str | None = None
+    PY: PyExecConfig = Field(default_factory=PyExecConfig)
+
+
+# ─── PLATFORM.ACCOUNTING ──────────────────────────────────────────────────────
+
+class AccountingConfig(BaseModel):
+    # JSON string: per-tool tier metadata, e.g. {"web_search": {"brave": {"tier": "free"}}}
+    ACCOUNTING_SERVICES: str | None = None
+
+
+# ─── PLATFORM.APPLICATIONS ────────────────────────────────────────────────────
+
+class GitBundlesConfig(BaseModel):
+    BUNDLE_GIT_RESOLUTION_ENABLED: bool = True
+    BUNDLE_GIT_ATOMIC: bool = True
+    BUNDLE_GIT_ALWAYS_PULL: bool = False
+    BUNDLE_GIT_REDIS_LOCK: bool = True
+    BUNDLE_GIT_REDIS_LOCK_TTL_SECONDS: int = 300
+    BUNDLE_GIT_REDIS_LOCK_WAIT_SECONDS: int = 60
+    BUNDLE_GIT_PREFETCH_ENABLED: bool = True
+    BUNDLE_GIT_PREFETCH_INTERVAL_SECONDS: int = 15
+    BUNDLE_GIT_FAIL_BACKOFF_SECONDS: int = 60
+    BUNDLE_GIT_FAIL_MAX_BACKOFF_SECONDS: int = 300
+    BUNDLE_GIT_KEEP: int = 3
+    BUNDLE_GIT_TTL_HOURS: int = 0
+    GIT_SSH_KEY_PATH: str | None = None
+    GIT_SSH_KNOWN_HOSTS: str | None = None
+    GIT_SSH_STRICT_HOST_KEY_CHECKING: str = "yes"
+
+
+class ApplicationsConfig(BaseModel):
+    AGENTIC_BUNDLES_ROOT: str = "/bundles"
+    BUNDLE_STORAGE_ROOT: str | None = None
+    BUNDLES_INCLUDE_EXAMPLES: bool = True
+    BUNDLE_CLEANUP_ENABLED: bool = True
+    BUNDLE_CLEANUP_INTERVAL_SECONDS: int = 3600
+    BUNDLE_CLEANUP_LOCK_TTL_SECONDS: int = 900
+    BUNDLE_REF_TTL_SECONDS: int = 3600
+    BUNDLES_FORCE_ENV_ON_STARTUP: bool = False
+    BUNDLES_FORCE_ENV_LOCK_TTL_SECONDS: int = 60
+    BUNDLES_PRELOAD_ON_START: bool = False
+    BUNDLES_PRELOAD_LOCK_TTL_SECONDS: int = 900
+    GIT: GitBundlesConfig = Field(default_factory=GitBundlesConfig)
+
+
+# ─── PLATFORM (top-level nested config) ───────────────────────────────────────
+# Access via get_settings().PLATFORM.<sub>.<attr>
+
+class PlatformConfig(BaseModel):
+    LOG: LOGConfig = Field(default_factory=LOGConfig)
+    SERVICE: ServiceConfig = Field(default_factory=ServiceConfig)
+    HOSTED_SERVICES: HostedServicesConfig = Field(default_factory=HostedServicesConfig)
+    MONITORING: MonitoringConfig = Field(default_factory=MonitoringConfig)
+    EXEC: ExecConfig = Field(default_factory=ExecConfig)
+    ACCOUNTING: AccountingConfig = Field(default_factory=AccountingConfig)
+    APPLICATIONS: ApplicationsConfig = Field(default_factory=ApplicationsConfig)
+
+
+# ─── AUTH ─────────────────────────────────────────────────────────────────────
+
+class IDPLocalConfig(BaseModel):
+    """Local (simple-auth) identity provider settings."""
+    IDP_DB_PATH: str | None = None
+    IDP_IMPORT_ENABLED: bool = False
+    IDP_IMPORT_RUN_AT: str | None = None
+    IDP_IMPORT_SCRIPT_PATH: str | None = None
+
+
+class IDPConfig(BaseModel):
+    local: IDPLocalConfig = Field(default_factory=IDPLocalConfig)
+
+
+class AuthConfig(BaseModel):
+    """Auth settings.  Access via get_settings().AUTH.<attr>."""
+    COGNITO_REGION: str | None = None
+    COGNITO_USER_POOL_ID: str | None = None
+    COGNITO_APP_CLIENT_ID: str | None = None
+    COGNITO_SERVICE_CLIENT_ID: str | None = None
+    ID_TOKEN_HEADER_NAME: str = "X-ID-Token"
+    AUTH_TOKEN_COOKIE_NAME: str = "__Secure-LATC"
+    ID_TOKEN_COOKIE_NAME: str = "__Secure-LITC"
+    JWKS_CACHE_TTL_SECONDS: int = 86400
+    OIDC_SERVICE_USER_EMAIL: str | None = None
+    OIDC_SERVICE_ADMIN_USERNAME: str | None = None
+    OIDC_SERVICE_ADMIN_PASSWORD: str | None = None
+    IDP: IDPConfig = Field(default_factory=IDPConfig)
+
+
+# ─── SERVICES ─────────────────────────────────────────────────────────────────
+
+class ServicesConfig(BaseModel):
+    """External-service / model settings.  Access via get_settings().SERVICES.<attr>.
+    Gemini cache knobs are plain config — use get_plain("services.llm.gemini.<attr>").
+    """
+    DEFAULT_EMBEDDING_MODEL_ID: str | None = None
+
+
+# ─── RUNTIME_CONFIG (request-context headers — misc runtime wiring) ──────────
+# Access via get_settings().RUNTIME_CONFIG.<attr>.
+# Inherits PLATFORM_CONFIG (BaseSettings) so env vars are picked up automatically
+# as backward compat for cloud deployments.
+
+class RUNTIME_CONFIG(PLATFORM_CONFIG):
+    STREAM_ID_HEADER_NAME: str | None = Field(default="KDC-Stream-ID", alias="STREAM_ID_HEADER_NAME")
+    USER_TIMEZONE_HEADER_NAME: str | None = Field(default="X-User-Timezone", alias="USER_TIMEZONE_HEADER_NAME")
+    USER_UTC_OFFSET_MIN_HEADER_NAME: str | None = Field(default="X-User-UTC-Offset", alias="USER_UTC_OFFSET_MIN_HEADER_NAME")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/entrypoint.py
@@ -775,7 +775,7 @@ class ReactWorkflow(BaseEntrypoint):
         bundle_spec = getattr(getattr(self, "config", None), "ai_bundle_spec", None)
         rendered = patch_dashboard(
             input_content=content,
-            base_url=f"http://localhost:{os.environ.get('CHAT_APP_PORT') or '8010'}",
+            base_url=f"http://localhost:{self.settings.CHAT_APP_PORT}",
             default_tenant=getattr(actor, "tenant_id", None) or self.settings.TENANT,
             default_project=getattr(actor, "project_id", None) or self.settings.PROJECT,
             default_app_bundle_id=getattr(bundle_spec, "id", None) or BUNDLE_ID,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
@@ -195,7 +195,7 @@ class VersatileEntrypoint(BaseEntrypointWithEconomics):
             bundle_spec = getattr(getattr(self, "config", None), "ai_bundle_spec", None)
             rendered = patch_dashboard(
                 input_content=rendered,
-                base_url=f"http://localhost:{os.environ.get('CHAT_APP_PORT') or '8010'}",
+                base_url=f"http://localhost:{self.settings.CHAT_APP_PORT}",
                 default_tenant=getattr(actor, "tenant_id", None) or self.settings.TENANT,
                 default_project=getattr(actor, "project_id", None) or self.settings.PROJECT,
                 default_app_bundle_id=getattr(bundle_spec, "id", None) or BUNDLE_ID,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/execute_with_accounting.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/execute_with_accounting.py
@@ -50,7 +50,6 @@ def configure_env():
         openai_api_key=settings.OPENAI_API_KEY,
         claude_api_key=settings.ANTHROPIC_API_KEY,
         google_api_key=settings.GOOGLE_API_KEY,
-        selected_model=DEFAULT_MODEL,
         role_models={ ROLE_FRIENDLY_ASSISTANT: {"provider": "anthropic", "model": sonnet_45}},
     )
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/multimodal_streaming_with_accounting.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/multimodal_streaming_with_accounting.py
@@ -50,7 +50,6 @@ def configure_env():
         openai_api_key=settings.OPENAI_API_KEY,
         claude_api_key=settings.ANTHROPIC_API_KEY,
         google_api_key=settings.GOOGLE_API_KEY,
-        selected_model=DEFAULT_MODEL,
         role_models={
             ROLE_FRIENDLY_ASSISTANT: {"provider": "google", "model": gemini_25_pro},
             ROLE_DOCUMENT_ANALYZER: {"provider": "anthropic", "model": haiku_4},

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/summary_multimodal_examples.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/summary_multimodal_examples.py
@@ -68,7 +68,6 @@ def configure_env() -> ModelServiceBase:
         openai_api_key=settings.OPENAI_API_KEY,
         claude_api_key=settings.ANTHROPIC_API_KEY,
         google_api_key=settings.GOOGLE_API_KEY,
-        selected_model=DEFAULT_MODEL,
         role_models={
             # ROLE_SUMMARIZER: {"provider": "anthropic", "model": CLAUDE_HAIKU45},
             ROLE_SUMMARIZER: {"provider": "openai", "model": OPENAI_GPT5_MINI},

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/versatile_streaming.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/versatile_streaming.py
@@ -34,7 +34,6 @@ def configure_env() -> ModelServiceBase:
         openai_api_key=settings.OPENAI_API_KEY,
         claude_api_key=settings.ANTHROPIC_API_KEY,
         google_api_key=settings.GOOGLE_API_KEY,
-        selected_model=DEFAULT_MODEL,
         role_models={
             ROLE_GATE: {"provider": "anthropic", "model": DEFAULT_MODEL},
         },

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/external/docker.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/external/docker.py
@@ -26,8 +26,8 @@ from kdcube_ai_app.infra.config import (
 )
 from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
-_DEFAULT_IMAGE = os.environ.get("PY_CODE_EXEC_IMAGE", "py-code-exec:latest")
-_DEFAULT_TIMEOUT_S = int(os.environ.get("PY_CODE_EXEC_TIMEOUT", "600"))  # 10min default
+_DEFAULT_IMAGE = get_settings().PLATFORM.EXEC.PY.PY_CODE_EXEC_IMAGE
+_DEFAULT_TIMEOUT_S = get_settings().PLATFORM.EXEC.PY.PY_CODE_EXEC_TIMEOUT
 
 _PROC_VISIBLE_ROOTS = (
     "/exec-workspace",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/iso_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/iso_runtime.py
@@ -14,6 +14,7 @@ import pathlib
 import tokenize
 from typing import Dict, Any, List, Tuple, Optional, Literal
 
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from kdcube_ai_app.apps.chat.sdk.runtime.exec_runtime_config import resolve_exec_runtime_profile
 from kdcube_ai_app.apps.chat.sdk.util import strip_lone_surrogates
 from kdcube_ai_app.infra.service_hub.inventory import AgentLogger
@@ -1800,7 +1801,7 @@ class _InProcessRuntime:
                     "docker_network_mode",
                     "PY_CODE_EXEC_NETWORK_MODE",
                 )
-                or os.environ.get("PY_CODE_EXEC_NETWORK_MODE", "host")
+                or get_settings().PLATFORM.EXEC.PY.PY_CODE_EXEC_NETWORK_MODE
             ).strip() or "host"
             docker_extra_args: List[str] = []
             docker_cpus = _pick_runtime_cfg(exec_runtime_cfg, "cpus", "docker_cpus")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/mcp/mcp_tools_subsystem.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/mcp/mcp_tools_subsystem.py
@@ -25,7 +25,7 @@ from kdcube_ai_app.infra.service_hub.cache import (
     ensure_namespaced_cache,
 )
 from kdcube_ai_app.infra.namespaces import REDIS
-from kdcube_ai_app.apps.chat.sdk.config import get_settings
+from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_plain
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ class MCPToolsSubsystem:
                     namespace=namespace,
                     tenant=settings.TENANT,
                     project=settings.PROJECT,
-                    default_ttl_seconds=int(os.getenv("MCP_CACHE_TTL_SECONDS", "3600")),
+                    default_ttl_seconds=int(get_plain("a:platform.services.proc.tools.mcp_cache_ttl_seconds", 3600)),
                 )
             except Exception:
                 cache = None
@@ -143,7 +143,7 @@ class MCPToolsSubsystem:
             tenant = settings.TENANT
             project = settings.PROJECT
             namespace = f"{REDIS.CACHE.MCP}:{tenant}:{project}:{self.bundle_id}"
-            default_ttl = int(os.getenv("MCP_CACHE_TTL_SECONDS", "3600"))
+            default_ttl = int(get_plain("a:platform.services.proc.tools.mcp_cache_ttl_seconds", 3600))
             cfg = NamespacedKVCacheConfig(
                 redis_url=settings.REDIS_URL,
                 namespace=namespace,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/mcp/mcp_tools_subsystem_bckp.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/mcp/mcp_tools_subsystem_bckp.py
@@ -22,7 +22,7 @@ from kdcube_ai_app.infra.service_hub.cache import (
     create_namespaced_kv_cache_from_config,
 )
 from kdcube_ai_app.infra.namespaces import REDIS
-from kdcube_ai_app.apps.chat.sdk.config import get_settings
+from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_plain
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ class MCPToolsSubsystem:
             tenant = settings.TENANT
             project = settings.PROJECT
             namespace = f"{REDIS.CACHE.MCP}:{tenant}:{project}:{self.bundle_id}"
-            default_ttl = int(os.getenv("MCP_CACHE_TTL_SECONDS", "3600"))
+            default_ttl = int(get_plain("a:platform.services.proc.tools.mcp_cache_ttl_seconds", 3600))
             cfg = NamespacedKVCacheConfig(
                 redis_url=settings.REDIS_URL,
                 namespace=namespace,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/portable_spec.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/portable_spec.py
@@ -11,8 +11,6 @@ class ModelConfigSpec:
     # mirrors ConfigRequest fields you already have
     openai_api_key: Optional[str] = None
     claude_api_key: Optional[str] = None
-    selected_model: Optional[str] = None
-    selected_embedder: str = "openai-text-embedding-3-small"
     custom_embedding_endpoint: Optional[str] = None
     custom_embedding_model: Optional[str] = "sentence-transformers/all-MiniLM-L6-v2"
     custom_embedding_size: Optional[int] = 384

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/snapshot.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/snapshot.py
@@ -175,8 +175,6 @@ def _config_to_model_config_spec(cfg: Config) -> ModelConfigSpec:
     return ModelConfigSpec(
         openai_api_key=cfg.openai_api_key or None,
         claude_api_key=cfg.claude_api_key or None,
-        selected_model=_pick_selected_model_name(cfg.default_llm_model),
-        selected_embedder=cfg.selected_embedder,
         custom_embedding_endpoint=cfg.custom_embedding_endpoint,
         custom_embedding_model=cfg.custom_embedding_model,
         custom_embedding_size=cfg.custom_embedding_size,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/test_fargate_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/test_fargate_runtime.py
@@ -120,8 +120,6 @@ def test_prepare_external_runtime_globals_compacts_payload_for_remote_runtime():
             "PORTABLE_SPEC_JSON": json.dumps(
                 {
                     "model_config": {
-                        "selected_model": "o3-mini",
-                        "selected_embedder": "openai-text-embedding-3-small",
                         "custom_embedding_endpoint": None,
                     },
                     "comm": {

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/test_local_sidecars.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/test_local_sidecars.py
@@ -49,7 +49,7 @@ class _DummyConfig:
         self.role_models = {}
         self.embedder_config = {}
         self.embedding_model = "text-embedding-3-small"
-        self.selected_embedder = None
+        #self.selected_embedder = None
         self.custom_embedding_endpoint = None
         self.custom_embedding_size = None
         self.openai_api_key = "test-openai-key"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
@@ -792,7 +792,7 @@ class BaseEntrypoint:
                 content = fallback_path.read_text(encoding="utf-8")
                 output_content = patch_dashboard(
                     input_content=content,
-                    base_url=f"http://localhost:{os.environ.get('CHAT_APP_PORT') or '8010'}",
+                    base_url=f"http://localhost:{get_settings().CHAT_APP_PORT}",
                     access_token=None,
                     default_tenant=self.settings.TENANT,
                     default_project=self.settings.PROJECT,
@@ -830,7 +830,7 @@ class BaseEntrypoint:
                 content = fallback_path.read_text(encoding="utf-8")
                 output_content = patch_dashboard(
                     input_content=content,
-                    base_url=f"http://localhost:{os.environ.get('CHAT_APP_PORT') or '8010'}",
+                    base_url=f"http://localhost:{get_settings().CHAT_APP_PORT}",
                     access_token=None,
                     default_tenant=self.settings.TENANT,
                     default_project=self.settings.PROJECT,
@@ -871,7 +871,7 @@ class BaseEntrypoint:
 
                 output_content = patch_dashboard(
                     input_content=content,
-                    base_url=f"http://localhost:{os.environ.get('CHAT_APP_PORT') or '8010'}",
+                    base_url=f"http://localhost:{get_settings().CHAT_APP_PORT}",
                     access_token=None,
                     default_tenant=self.settings.TENANT,
                     default_project=self.settings.PROJECT,
@@ -913,7 +913,7 @@ class BaseEntrypoint:
 
                 output_content = patch_dashboard(
                     input_content=content,
-                    base_url=f"http://localhost:{os.environ.get('CHAT_APP_PORT') or '8010'}",
+                    base_url=f"http://localhost:{get_settings().CHAT_APP_PORT}",
                     access_token=None,
                     default_tenant=self.settings.TENANT,
                     default_project=self.settings.PROJECT,
@@ -951,7 +951,7 @@ class BaseEntrypoint:
                 content = fallback_path.read_text(encoding="utf-8")
                 output_content = patch_dashboard(
                     input_content=content,
-                    base_url=f"http://localhost:{os.environ.get('CHAT_APP_PORT') or '8010'}",
+                    base_url=f"http://localhost:{get_settings().CHAT_APP_PORT}",
                     access_token=None,
                     default_tenant=self.settings.TENANT,
                     default_project=self.settings.PROJECT,
@@ -989,13 +989,13 @@ class BaseEntrypoint:
 
             output_content = patch_dashboard(
                 input_content=content,
-                base_url=f"http://localhost:{os.environ.get('CHAT_APP_PORT') or '8010'}",
+                base_url=f"http://localhost:{get_settings().CHAT_APP_PORT}",
                 access_token=None,
                 default_tenant=self.settings.TENANT,
                 default_project=self.settings.PROJECT,
                 default_app_bundle_id=self.config.ai_bundle_spec.id,
                 host_bundles_path=os.environ.get("HOST_BUNDLES_PATH"),
-                agentic_bundles_root=os.environ.get("AGENTIC_BUNDLES_ROOT"),
+                agentic_bundles_root=get_settings().PLATFORM.APPLICATIONS.AGENTIC_BUNDLES_ROOT,
             )
             html = self._render_dashboard_html(content=output_content, title="AI Bundles")
             return [html]
@@ -1029,7 +1029,7 @@ class BaseEntrypoint:
 
             output_content = patch_dashboard(
                 input_content=content,
-                base_url=f"http://localhost:{os.environ.get('CHAT_APP_PORT') or '8010'}",
+                base_url=f"http://localhost:{get_settings().CHAT_APP_PORT}",
                 access_token=None,
                 default_tenant=self.settings.TENANT,
                 default_project=self.settings.PROJECT,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/infra.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/infra.py
@@ -7,6 +7,7 @@ from typing import Callable, Awaitable,Any, Dict, List
 import pathlib, json, os
 
 from kdcube_ai_app.apps.chat.emitters import ChatCommunicator
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 
 class ExecWorkspaceError(RuntimeError):
@@ -113,7 +114,7 @@ def get_exec_workspace_root() -> pathlib.Path:
     that's accessible to sibling containers when running Docker-in-Docker.
     """
     # Allow explicit override for dev setups (e.g., Docker Desktop file sharing)
-    env_root = os.environ.get("EXEC_WORKSPACE_ROOT")
+    env_root = get_settings().PLATFORM.EXEC.EXEC_WORKSPACE_ROOT
     if env_root:
         # Keep this log minimal to avoid noise
         try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tests/bundle/test_storage_integration.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tests/bundle/test_storage_integration.py
@@ -43,20 +43,13 @@ class TestStorageFallbackChain:
             if old2:
                 os.environ["BUNDLE_SHARED_STORAGE_ROOT"] = old2
 
-    def test_bundle_storage_root_respects_env_var(self, tmp_path):
-        """resolve_bundle_storage_root() uses BUNDLE_STORAGE_ROOT when set."""
-        import os
+    def test_bundle_storage_root_respects_config(self, tmp_path, monkeypatch):
+        """resolve_bundle_storage_root() uses BUNDLE_STORAGE_ROOT from settings when set."""
         from kdcube_ai_app.infra.plugin.bundle_storage import resolve_bundle_storage_root
-        old = os.environ.get("BUNDLE_STORAGE_ROOT")
-        try:
-            os.environ["BUNDLE_STORAGE_ROOT"] = str(tmp_path)
-            root = resolve_bundle_storage_root()
-            assert root == tmp_path.resolve()
-        finally:
-            if old is None:
-                os.environ.pop("BUNDLE_STORAGE_ROOT", None)
-            else:
-                os.environ["BUNDLE_STORAGE_ROOT"] = old
+        from kdcube_ai_app.apps.chat.sdk.config import get_settings
+        monkeypatch.setattr(get_settings().PLATFORM.APPLICATIONS, "BUNDLE_STORAGE_ROOT", str(tmp_path))
+        root = resolve_bundle_storage_root()
+        assert root == tmp_path.resolve()
 
 
 class TestStorageContextIsolation:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/search_backends.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/search_backends.py
@@ -46,7 +46,7 @@ import aiohttp
 from kdcube_ai_app.apps.chat.sdk.tools.backends.web.inventory import compose_search_results_html, SearchRequest, \
     make_hit, clamp_max_results, SearchBackendError, _claim_sid_block, _normalize_url, dedup_round_robin_ranked, \
     PROVIDERS_AUTHORITY_RANK
-from kdcube_ai_app.apps.chat.sdk.config import get_settings
+from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_plain
 from kdcube_ai_app.apps.chat.sdk.tools.web.favicon_cache import enrich_sources_pool_with_favicons
 from kdcube_ai_app.apps.chat.sdk.tools.web.with_llm import sources_reconciler, \
     filter_search_results_by_content
@@ -498,7 +498,7 @@ def get_search_backend(name: Optional[str] = None) -> SearchBackend:
     Uses env WEB_SEARCH_BACKEND if name not provided.
     Supported: duckduckgo|ddg, brave
     """
-    n = (name or os.environ.get("WEB_SEARCH_BACKEND") or "duckduckgo").strip().lower()
+    n = (name or get_plain("a:platform.services.proc.tools.web_search.web_search_backend") or "duckduckgo").strip().lower()
 
     if n in ("duckduckgo", "ddg"):
         return DDGSearchBackend()
@@ -528,14 +528,14 @@ def get_search_backend_or_hybrid(
         SearchBackend or HybridSearchBackend instance
     """
     if not backend_name:
-        backend_name = os.environ.get("WEB_SEARCH_BACKEND", "duckduckgo").strip().lower()
+        backend_name = (get_plain("a:platform.services.proc.tools.web_search.web_search_backend") or "duckduckgo").strip().lower()
     else:
         backend_name = backend_name.strip().lower()
 
     # Explicit hybrid mode via backend name
     if backend_name == "hybrid":
         from kdcube_ai_app.apps.chat.sdk.tools.backends.web.hybrid_search_backend import get_hybrid_search_backend, HybridMode
-        primary_name = os.environ.get("WEB_SEARCH_PRIMARY_BACKEND", "brave")
+        primary_name = get_plain("a:platform.services.proc.tools.web_search.web_search_primary_backend") or "brave"
         mode = HybridMode(hybrid_mode) if hybrid_mode in ("sequential", "parallel") else HybridMode.SEQUENTIAL
         return get_hybrid_search_backend(primary_name, spare_backend, mode)
 
@@ -593,7 +593,7 @@ async def web_search(
     Results are CLEAN - no provider metadata returned to LLM.
     """
 
-    WEB_SEARCH_AGENTIC_THINKING_BUDGET = int(os.getenv("WEB_SEARCH_AGENTIC_THINKING_BUDGET") or 0)
+    WEB_SEARCH_AGENTIC_THINKING_BUDGET = int(get_plain("a:platform.services.proc.tools.web_search.web_search_agentic_thinking_budget") or 0)
     refinement = (refinement or "balanced").lower()
     if refinement not in ("none", "balanced", "recall", "precision"):
         refinement = "balanced"
@@ -706,7 +706,7 @@ async def web_search(
     #     spare_backend="duckduckgo"
     # )
     enable_hybrid = False
-    primary_backend_name = (os.environ.get("WEB_SEARCH_BACKEND") or "brave").strip().lower()
+    primary_backend_name = (get_plain("a:platform.services.proc.tools.web_search.web_search_backend") or "brave").strip().lower()
     search_backend = get_search_backend_or_hybrid(
         backend_name=primary_backend_name,
         enable_hybrid=enable_hybrid,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/web/with_llm.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/web/with_llm.py
@@ -424,10 +424,11 @@ async def sources_filter_and_segment(
     from datetime import datetime, timezone
     import logging
     import os
+    from kdcube_ai_app.apps.chat.sdk.config import get_plain
     logger = logging.getLogger(__name__)
 
     import kdcube_ai_app.apps.chat.sdk.tools.web.content_filters as content_filters
-    if (os.getenv("WEB_SEARCH_SEGMENTER") or "").strip().lower() == "fast":
+    if (get_plain("a:platform.services.proc.tools.web_search.web_search_segmenter") or "").strip().lower() == "fast":
         from kdcube_ai_app.apps.chat.sdk.tools.web.filter_segmenter_fast import (
             filter_and_segment_stream,
         )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_integrations_stream_id.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_integrations_stream_id.py
@@ -15,7 +15,7 @@ from kdcube_ai_app.apps.chat.sdk.runtime.comm_ctx import (
 )
 from kdcube_ai_app.infra.plugin import bundle_storage
 from kdcube_ai_app.infra.plugin.agentic_loader import api
-from kdcube_ai_app.infra.namespaces import CONFIG
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from kdcube_ai_app.apps.middleware.gateway import (
     STATE_STREAM_ID,
     bind_stream_id_to_request_state,
@@ -36,7 +36,7 @@ def _session() -> SimpleNamespace:
 
 
 def _request(*, stream_id: str | None = None) -> SimpleNamespace:
-    headers = Headers({CONFIG.STREAM_ID_HEADER_NAME: stream_id} if stream_id else {})
+    headers = Headers({get_settings().RUNTIME_CONFIG.STREAM_ID_HEADER_NAME: stream_id} if stream_id else {})
     return SimpleNamespace(
         headers=headers,
         state=SimpleNamespace(**({STATE_STREAM_ID: stream_id} if stream_id else {})),
@@ -51,7 +51,7 @@ def test_bind_stream_id_to_request_state_extracts_header():
             "method": "GET",
             "path": "/api/integrations/demo",
             "query_string": b"",
-            "headers": [(CONFIG.STREAM_ID_HEADER_NAME.lower().encode("utf-8"), b"stream-123")],
+            "headers": [(get_settings().RUNTIME_CONFIG.STREAM_ID_HEADER_NAME.lower().encode("utf-8"), b"stream-123")],
             "scheme": "http",
             "server": ("testserver", 80),
             "client": ("127.0.0.1", 12345),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_processor.py
@@ -458,15 +458,9 @@ async def test_prefetch_git_bundles_resolves_missing_paths_and_collects_errors(m
 
     monkeypatch.setattr(processor_mod, "ensure_git_bundle_async", _ensure_git_bundle_async)
 
-    old_atomic = os.environ.get("BUNDLE_GIT_ATOMIC")
-    try:
-        os.environ["BUNDLE_GIT_ATOMIC"] = "1"
-        errors = await processor_mod.prefetch_git_bundles()
-    finally:
-        if old_atomic is None:
-            os.environ.pop("BUNDLE_GIT_ATOMIC", None)
-        else:
-            os.environ["BUNDLE_GIT_ATOMIC"] = old_atomic
+    from kdcube_ai_app.apps.chat.sdk.config import get_settings
+    monkeypatch.setattr(get_settings().PLATFORM.APPLICATIONS.GIT, "BUNDLE_GIT_ATOMIC", True)
+    errors = await processor_mod.prefetch_git_bundles()
 
     assert errors == {
         "bundle.cooldown": "cooldown",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_singleton_request_context.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_singleton_request_context.py
@@ -29,7 +29,7 @@ class _DummyConfig:
         self.role_models = {}
         self.embedder_config = {}
         self.embedding_model = "text-embedding-3-small"
-        self.selected_embedder = None
+        #self.selected_embedder = None
         self.custom_embedding_endpoint = None
         self.custom_embedding_size = None
         self.openai_api_key = "test-openai-key"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/integrations/kb/rest_client.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/integrations/kb/rest_client.py
@@ -6,18 +6,20 @@ import os
 from botocore.config import Config as BotoConfig
 from kdcube_ai_app.auth.service_auth.base import IdpConfig
 from kdcube_ai_app.auth.service_auth.factory import create_service_idp
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 def build_service_idp_from_env():
     provider = os.getenv("IDP_PROVIDER", "cognito")
     if provider == "cognito":
+        _auth = get_settings().AUTH
         cfg = IdpConfig(
             "cognito",
-            region=os.getenv("COGNITO_REGION"),
-            user_pool_id=os.getenv("COGNITO_USER_POOL_ID"),
-            client_id=os.getenv("COGNITO_SERVICE_CLIENT_ID"),
+            region=_auth.COGNITO_REGION,
+            user_pool_id=_auth.COGNITO_USER_POOL_ID,
+            client_id=_auth.COGNITO_SERVICE_CLIENT_ID,
             client_secret=os.getenv("COGNITO_SERVICE_CLIENT_SECRET", None),  # ok if None
-            username=os.getenv("OIDC_SERVICE_ADMIN_USERNAME"),
-            password=os.getenv("OIDC_SERVICE_ADMIN_PASSWORD"),
+            username=_auth.OIDC_SERVICE_ADMIN_USERNAME,
+            password=_auth.OIDC_SERVICE_ADMIN_PASSWORD,
             new_password=os.getenv("OIDC_SERVICE_ADMIN_NEW_PASSWORD", None),  # <- only if first-login
             use_admin_api=True,
             boto_cfg=BotoConfig(retries={"max_attempts": 3, "mode": "standard"}),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/integrations/kb/socket_client.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/integrations/kb/socket_client.py
@@ -7,6 +7,7 @@ import os
 import time
 import uuid
 from typing import Optional, Dict, Any
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 import socketio
 
@@ -216,14 +217,15 @@ async def _demo():
 
     # Build IdP config from env (Cognito example; swap if you add other providers)
     from botocore.config import Config as BotoConfig
+    _auth = get_settings().AUTH
     idp_cfg = IdpConfig(
         "cognito",
-        region=os.getenv("COGNITO_REGION"),
-        user_pool_id=os.getenv("COGNITO_USER_POOL_ID"),
-        client_id=os.getenv("COGNITO_SERVICE_CLIENT_ID"),
+        region=_auth.COGNITO_REGION,
+        user_pool_id=_auth.COGNITO_USER_POOL_ID,
+        client_id=_auth.COGNITO_SERVICE_CLIENT_ID,
         client_secret=os.getenv("COGNITO_SERVICE_CLIENT_SECRET") or None,
-        username=os.getenv("OIDC_SERVICE_ADMIN_USERNAME"),
-        password=os.getenv("OIDC_SERVICE_ADMIN_PASSWORD"),
+        username=_auth.OIDC_SERVICE_ADMIN_USERNAME,
+        password=_auth.OIDC_SERVICE_ADMIN_PASSWORD,
         use_admin_api=True,
         boto_cfg=BotoConfig(retries={"max_attempts": 3, "mode": "standard"}),
     )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/knowledge_base/api/resolvers.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/knowledge_base/api/resolvers.py
@@ -6,6 +6,7 @@
 from fastapi import Request, Depends
 import os
 import logging
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 from kdcube_ai_app.apps.knowledge_base.core import KnowledgeBase
 from kdcube_ai_app.apps.middleware.accounting import MiddlewareAuthWithAccounting
@@ -29,9 +30,10 @@ from kdcube_ai_app.infra.llm.llm_data_model import AIProvider, ModelRecord, AIPr
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_PROJECT = os.environ.get("DEFAULT_PROJECT_NAME", None)
-DEFAULT_TENANT_ID = os.environ.get("DEFAULT_PROJECT_NAME", None)
-TENANT_ID = os.environ.get("TENANT_ID", DEFAULT_TENANT_ID)
+_settings = get_settings()
+DEFAULT_PROJECT = _settings.PROJECT
+DEFAULT_TENANT_ID = _settings.PROJECT
+TENANT_ID = _settings.TENANT
 
 def get_project(request: Request) -> str:
     """Look for a `project` path-param; if absent, return your default_project."""
@@ -43,7 +45,7 @@ def get_tenant_dep(request: Request) -> str:
 
 
 # Environment configuration
-KDCUBE_STORAGE_PATH = os.environ.get("KDCUBE_STORAGE_PATH")
+KDCUBE_STORAGE_PATH = _settings.STORAGE_PATH
 
 REDIS_URL = get_settings().REDIS_URL
 
@@ -122,12 +124,11 @@ def get_orchestrator() -> IOrchestrator:
 
 # System configuration
 ENABLE_DATABASE = os.environ.get("ENABLE_DATABASE", "true").lower() == "true"
-INSTANCE_ID = os.environ.get("INSTANCE_ID", "home-instance-1")
+INSTANCE_ID = _settings.INSTANCE_ID
 KB_PORT = int(os.environ.get("KB_PORT", 8000))
 KB_PARALLELISM = int(os.environ.get("KB_PARALLELISM", 1))
-HEARTBEAT_INTERVAL = int(os.environ.get("HEARTBEAT_INTERVAL", 10))
+HEARTBEAT_INTERVAL = get_settings().PLATFORM.SERVICE.HEARTBEAT_INTERVAL
 
-DEFAULT_PROJECT = os.environ.get("DEFAULT_PROJECT_NAME", None)
 # Database setup
 _tenant_db = TenantDB(tenant_id=TENANT_ID) if ENABLE_DATABASE else None
 
@@ -208,7 +209,7 @@ def get_heartbeats_mgr_and_middleware(service_type: str = "kb",
                                       port: int = 8000,
                                       redis_client=None):
 
-    instance_id = instance_id or os.getenv("INSTANCE_ID")
+    instance_id = instance_id or _settings.INSTANCE_ID
     middleware = MultiprocessDistributedMiddleware(
         REDIS_URL,
         instance_id=instance_id,
@@ -245,7 +246,7 @@ def create_auth_manager():
     """Create the authentication manager"""
     # You can switch between different auth managers here:
 
-    provider = os.getenv("AUTH_PROVIDER", "simple").lower()
+    provider = (_settings.AUTH_PROVIDER or "simple").lower()
     if provider == "cognito":
         from kdcube_ai_app.auth.implementations.cognito import CognitoAuthManager
         logger.info("Using CognitoAuthManager for authentication")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/knowledge_base/modules/enrichment.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/knowledge_base/modules/enrichment.py
@@ -75,7 +75,6 @@ class EnrichmentModule(ProcessingModule):
             req = ConfigRequest(
                 openai_api_key=kwargs.get("openai_api_key"),
                 claude_api_key=kwargs.get("claude_api_key"),
-                selected_model=kwargs.get("selected_model") or "claude-3-7-sonnet-20250219",
                 role_models={role: kwargs.get("segment_enrichment_role",
                                               {"provider": "anthropic", "model": "claude-3-7-sonnet-20250219"})},
             )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/auth.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/auth.py
@@ -17,7 +17,7 @@ from starlette.status import HTTP_400_BAD_REQUEST
 from kdcube_ai_app.auth.AuthManager import AuthManager, RequirementBase, AuthenticationError, AuthorizationError, \
     HTTP_401_UNAUTHORIZED, PRIVILEGED_ROLES
 from kdcube_ai_app.auth.sessions import RequestContext, UserType
-from kdcube_ai_app.infra.namespaces import CONFIG
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from kdcube_ai_app.apps.middleware.token_extract import (
     extract_auth_tokens_from_cookies,
     resolve_auth_from_headers_and_cookies,
@@ -62,10 +62,11 @@ class FastAPIAuthAdapter:
 
     def _extract_context(self, request: Request) -> RequestContext:
         """Extract request context from FastAPI request"""
+        _auth_cfg = get_settings().AUTH
         auth_header, id_token = resolve_auth_from_headers_and_cookies(
             request.headers.get("authorization"),
-            request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME)
-            or request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME.lower()),
+            request.headers.get(_auth_cfg.ID_TOKEN_HEADER_NAME)
+            or request.headers.get(_auth_cfg.ID_TOKEN_HEADER_NAME.lower()),
             request.cookies,
         )
         if _auth_debug_enabled():
@@ -73,9 +74,9 @@ class FastAPIAuthAdapter:
                 "Auth context: has_auth=%s has_id=%s id_hdr=%s cookie_auth=%s cookie_id=%s path=%s",
                 bool(auth_header),
                 bool(id_token),
-                bool(request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME) or request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME.lower())),
-                bool(request.cookies.get(CONFIG.AUTH_TOKEN_COOKIE_NAME)),
-                bool(request.cookies.get(CONFIG.ID_TOKEN_COOKIE_NAME)),
+                bool(request.headers.get(_auth_cfg.ID_TOKEN_HEADER_NAME) or request.headers.get(_auth_cfg.ID_TOKEN_HEADER_NAME.lower())),
+                bool(request.cookies.get(_auth_cfg.AUTH_TOKEN_COOKIE_NAME)),
+                bool(request.cookies.get(_auth_cfg.ID_TOKEN_COOKIE_NAME)),
                 request.url.path if request else "",
             )
         return RequestContext(
@@ -95,9 +96,10 @@ class FastAPIAuthAdapter:
             if not credentials and not cookie_token:
                 raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="No authentication credentials provided")
 
+            _id_hdr = get_settings().AUTH.ID_TOKEN_HEADER_NAME
             id_token = (
-                request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME)
-                or request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME.lower())
+                request.headers.get(_id_hdr)
+                or request.headers.get(_id_hdr.lower())
                 or cookie_id_token
             )
 
@@ -133,9 +135,10 @@ class FastAPIAuthAdapter:
             if not credentials and not cookie_token:
                 raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="No authentication credentials provided")
 
+            _id_hdr = get_settings().AUTH.ID_TOKEN_HEADER_NAME
             id_token = (
-                request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME)
-                or request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME.lower())
+                request.headers.get(_id_hdr)
+                or request.headers.get(_id_hdr.lower())
                 or cookie_id_token
             )
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/gateway.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/gateway.py
@@ -19,7 +19,7 @@ from kdcube_ai_app.infra.gateway.definitions import GatewayError
 from kdcube_ai_app.auth.sessions import UserType, UserSession, RequestContext
 from kdcube_ai_app.auth.AuthManager import RequirementBase, AuthenticationError, AuthorizationError, RequireUser, \
     RequireRoles
-from kdcube_ai_app.infra.namespaces import CONFIG
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from kdcube_ai_app.apps.middleware.token_extract import resolve_auth_from_headers_and_cookies
 import logging
 import os
@@ -58,7 +58,7 @@ STATE_FLAG = "_gw_processed"
 STATE_SESSION = "user_session"
 STATE_USER_TYPE = "user_type"
 STATE_STREAM_ID = "stream_id"
-STREAM_ID_HEADER = CONFIG.STREAM_ID_HEADER_NAME
+STREAM_ID_HEADER = get_settings().RUNTIME_CONFIG.STREAM_ID_HEADER_NAME
 
 
 def extract_stream_id(request: Request) -> Optional[str]:
@@ -95,10 +95,12 @@ class FastAPIGatewayAdapter:
             except Exception:
                 return None
 
+        _auth_cfg = get_settings().AUTH
+        _rc = get_settings().RUNTIME_CONFIG
         auth_header, id_token = resolve_auth_from_headers_and_cookies(
             request.headers.get("authorization"),
-            request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME)
-            or request.headers.get(CONFIG.ID_TOKEN_HEADER_NAME.lower()),
+            request.headers.get(_auth_cfg.ID_TOKEN_HEADER_NAME)
+            or request.headers.get(_auth_cfg.ID_TOKEN_HEADER_NAME.lower()),
             request.cookies,
         )
         if _auth_debug_enabled():
@@ -114,8 +116,8 @@ class FastAPIGatewayAdapter:
             user_agent=request.headers.get("user-agent", ""),
             authorization_header=auth_header,
             id_token=id_token,
-            user_timezone= request.headers.get(CONFIG.USER_TIMEZONE_HEADER_NAME) or request.headers.get(CONFIG.USER_TIMEZONE_HEADER_NAME.lower()),
-            user_utc_offset_min=_parse_int(request.headers.get(CONFIG.USER_UTC_OFFSET_MIN_HEADER_NAME) or request.headers.get(CONFIG.USER_UTC_OFFSET_MIN_HEADER_NAME.lower()),)
+            user_timezone=request.headers.get(_rc.USER_TIMEZONE_HEADER_NAME) or request.headers.get(_rc.USER_TIMEZONE_HEADER_NAME.lower()),
+            user_utc_offset_min=_parse_int(request.headers.get(_rc.USER_UTC_OFFSET_MIN_HEADER_NAME) or request.headers.get(_rc.USER_UTC_OFFSET_MIN_HEADER_NAME.lower()),)
         )
 
     def _extract_user_session_id(self, request: Request) -> Optional[str]:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/simple_idp.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/simple_idp.py
@@ -10,10 +10,11 @@ import os
 from typing import Dict, Optional
 
 from kdcube_ai_app.auth.AuthManager import AuthManager, User, AuthenticationError
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 
 # Simple user database - stored as JSON file
-IDP_DB_PATH = os.getenv("IDP_DB_PATH", "./idp_users.json")
+IDP_DB_PATH = get_settings().AUTH.IDP.local.IDP_DB_PATH or "./idp_users.json"
 
 # Default users
 DEFAULT_USERS = {

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/token_extract.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/token_extract.py
@@ -8,7 +8,7 @@ from typing import Mapping, Optional, Tuple, Any
 import logging
 import os
 
-from kdcube_ai_app.infra.namespaces import CONFIG
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +21,8 @@ def extract_auth_tokens_from_cookies(
 ) -> Tuple[Optional[str], Optional[str]]:
     if not cookies:
         return None, None
-    bearer = cookies.get(CONFIG.AUTH_TOKEN_COOKIE_NAME)
-    id_token = cookies.get(CONFIG.ID_TOKEN_COOKIE_NAME)
+    bearer = cookies.get(get_settings().AUTH.AUTH_TOKEN_COOKIE_NAME)
+    id_token = cookies.get(get_settings().AUTH.ID_TOKEN_COOKIE_NAME)
     return bearer or None, id_token or None
 
 
@@ -33,8 +33,8 @@ def extract_auth_tokens_from_cookie_header(
         return None, None
     cookies = SimpleCookie()
     cookies.load(cookie_header)
-    bearer = cookies.get(CONFIG.AUTH_TOKEN_COOKIE_NAME)
-    id_token = cookies.get(CONFIG.ID_TOKEN_COOKIE_NAME)
+    bearer = cookies.get(get_settings().AUTH.AUTH_TOKEN_COOKIE_NAME)
+    id_token = cookies.get(get_settings().AUTH.ID_TOKEN_COOKIE_NAME)
     return (bearer.value if bearer and bearer.value else None,
             id_token.value if id_token and id_token.value else None)
 
@@ -95,8 +95,8 @@ def resolve_auth_from_headers_and_cookies(
             "Auth resolve: header_auth=%s header_id=%s cookie_auth=%s cookie_id=%s final_auth=%s final_id=%s",
             bool(authorization_header),
             bool(id_token_header),
-            bool(cookies and cookies.get(CONFIG.AUTH_TOKEN_COOKIE_NAME)),
-            bool(cookies and cookies.get(CONFIG.ID_TOKEN_COOKIE_NAME)),
+            bool(cookies and cookies.get(get_settings().AUTH.AUTH_TOKEN_COOKIE_NAME)),
+            bool(cookies and cookies.get(get_settings().AUTH.ID_TOKEN_COOKIE_NAME)),
             bool(auth_header),
             bool(id_token),
         )
@@ -109,7 +109,7 @@ def inject_auth_tokens_into_headers(
     bearer_token: Optional[str],
     id_token: Optional[str],
     *,
-    id_header_name: str = CONFIG.ID_TOKEN_HEADER_NAME,
+    id_header_name: str = get_settings().AUTH.ID_TOKEN_HEADER_NAME,
 ) -> dict:
     if not bearer_token and not id_token:
         return dict(headers)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/utils/logging_config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/utils/logging_config.py
@@ -7,6 +7,7 @@ import os
 from logging.handlers import RotatingFileHandler
 from datetime import datetime
 from pathlib import Path
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 
 def _to_level(name: str, default: int) -> int:
@@ -17,8 +18,9 @@ def _to_level(name: str, default: int) -> int:
 
 
 def configure_logging():
-    # --- Global settings from env ---
-    log_level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    # --- Global settings from config ---
+    _log = get_settings().PLATFORM.LOG
+    log_level_name = (_log.LOG_LEVEL or "INFO").upper()
     log_format = os.getenv(
         "LOG_FORMAT",
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -31,14 +33,14 @@ def configure_logging():
     console_handler.setFormatter(logging.Formatter(log_format))
 
     # ---- File handler with rotation ----
-    log_dir = Path(os.getenv("LOG_DIR", "logs"))
+    log_dir = Path(_log.LOG_DIR or "logs")
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    file_prefix = os.getenv("LOG_FILE_PREFIX", "kdcube")
+    file_prefix = _log.LOG_FILE_PREFIX or "kdcube"
     base_log_path = log_dir / f"{file_prefix}.log"
 
-    max_mb = int(os.getenv("LOG_MAX_MB", "20"))          # 20 MB default
-    backup_count = int(os.getenv("LOG_BACKUP_COUNT", "10"))
+    max_mb = _log.LOG_MAX_MB
+    backup_count = _log.LOG_BACKUP_COUNT
 
     file_handler = RotatingFileHandler(
         base_log_path,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/auth/OAuthManager.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/auth/OAuthManager.py
@@ -13,6 +13,8 @@ import logging
 import os
 from typing import Optional, Dict, Any, Tuple
 
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
+
 import httpx
 import jwt
 from jwt import PyJWTError
@@ -107,7 +109,7 @@ class OAuthManager(AuthManager):
         self._jwks_cache_exp: float = 0.0
         self._jwks_lock: Optional[asyncio.Lock] = None
         try:
-            self._jwks_cache_ttl = int(os.getenv("JWKS_CACHE_TTL_SECONDS", "3600") or "3600")
+            self._jwks_cache_ttl = get_settings().AUTH.JWKS_CACHE_TTL_SECONDS
         except Exception:
             self._jwks_cache_ttl = 3600
         try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/auth/implementations/cognito.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/auth/implementations/cognito.py
@@ -7,6 +7,7 @@ import os
 import logging
 from kdcube_ai_app.auth.AuthManager import AuthenticationError, User
 from kdcube_ai_app.auth.OAuthManager import OAuthManager, OAuth2Config
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +19,10 @@ class CognitoUser(User):
     preferred_username: Optional[str] = None
 
 def _cfg() -> OAuth2Config:
-    region    = os.getenv("COGNITO_REGION")
-    pool_id   = os.getenv("COGNITO_USER_POOL_ID")
-    client_id = os.getenv("COGNITO_APP_CLIENT_ID")
+    _auth = get_settings().AUTH
+    region    = _auth.COGNITO_REGION
+    pool_id   = _auth.COGNITO_USER_POOL_ID
+    client_id = _auth.COGNITO_APP_CLIENT_ID
     hosted_ui = os.getenv("COGNITO_HOSTED_UI_DOMAIN")
 
     if not (region and pool_id and client_id):

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/calculator.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/calculator.py
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, asdict
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from datetime import datetime, date, timedelta
 from typing import Any, Dict, Iterable, List, Optional, Tuple, AsyncIterator
 
@@ -2345,7 +2346,7 @@ class RateCalculator(AccountingCalculator):
         # 6. Calculate overall cost breakdown
         # Load ACCOUNTING_SERVICES config if not provided
         if accounting_services_config is None:
-            config_str = os.environ.get("ACCOUNTING_SERVICES", "{}")
+            config_str = get_settings().PLATFORM.ACCOUNTING.ACCOUNTING_SERVICES or "{}"
             try:
                 accounting_services_config = json.loads(config_str)
             except json.JSONDecodeError:
@@ -2526,8 +2527,7 @@ def _calculate_agent_costs(
     """
 
     if accounting_services_config is None:
-        # Load from environment
-        config_str = os.environ.get("ACCOUNTING_SERVICES", "{}")
+        config_str = get_settings().PLATFORM.ACCOUNTING.ACCOUNTING_SERVICES or "{}"
         try:
             accounting_services_config = json.loads(config_str)
         except json.JSONDecodeError:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py
@@ -5,6 +5,7 @@ import math
 from dataclasses import dataclass
 from typing import Dict, Any, Optional, List
 import logging, json, os
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from decimal import Decimal, ROUND_FLOOR
 
 logger = logging.getLogger(__name__)
@@ -427,8 +428,8 @@ def price_table():
     }
 
 def load_accounting_services_config() -> Dict[str, Any]:
-    """Load ACCOUNTING_SERVICES from environment variable."""
-    config_str = os.environ.get("ACCOUNTING_SERVICES", "{}")
+    """Load ACCOUNTING_SERVICES from config."""
+    config_str = get_settings().PLATFORM.ACCOUNTING.ACCOUNTING_SERVICES or "{}"
     try:
         return json.loads(config_str)
     except json.JSONDecodeError:
@@ -771,8 +772,7 @@ def _find_web_search_price(provider: str,
 
 def _get_accounting_services_config(accounting_services_config=None):
     if not accounting_services_config:
-        # Load from environment
-        config_str = os.environ.get("ACCOUNTING_SERVICES", "{}")
+        config_str = get_settings().PLATFORM.ACCOUNTING.ACCOUNTING_SERVICES or "{}"
         try:
             accounting_services_config = json.loads(config_str)
         except json.JSONDecodeError:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/availability/health_and_heartbeat.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/availability/health_and_heartbeat.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, asdict
 import logging
 from enum import Enum
 
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from kdcube_ai_app.infra.namespaces import REDIS, ns_key
 from kdcube_ai_app.infra.redis.client import get_async_redis_client
 
@@ -435,7 +436,7 @@ class ServiceHealthChecker:
 
     async def _check_service_health(self):
         """Check health of all services on this instance"""
-        component = (os.getenv("GATEWAY_COMPONENT") or "ingress").strip().lower()
+        component = (get_settings().GATEWAY_COMPONENT or "ingress").strip().lower()
         if component in {"proc", "processor", "worker"}:
             expected_services = [("chat", "proc")]
         else:
@@ -474,14 +475,14 @@ def get_expected_services(INSTANCE_ID) -> Dict[str, List[ServiceConfig]]:
     """
     Define expected services per instance based on gateway config and environment variables
     """
-    component = (os.getenv("GATEWAY_COMPONENT") or "ingress").strip().lower()
+    component = (get_settings().GATEWAY_COMPONENT or "ingress").strip().lower()
     try:
         from kdcube_ai_app.infra.gateway.config import get_gateway_config
         chat_workers = max(1, int(get_gateway_config().service_capacity.processes_per_instance or 1))
     except Exception:
         chat_workers = 1
 
-    chat_port = int(os.getenv("CHAT_APP_PORT", "8010"))
+    chat_port = get_settings().CHAT_APP_PORT
     service_name = "proc" if component in {"proc", "processor", "worker"} else "rest"
 
     expected_services = {

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/availability/tests/budget_aware_load_tests.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/availability/tests/budget_aware_load_tests.py
@@ -293,10 +293,7 @@ class BudgetAwareLoadTester:
         payload = {
             "message": f"Test message from {user_type} at {time.time()}",
             "session_id": session_id,
-            "config": {
-                "selected_model": "gpt-4o",
-                "selected_embedder": "openai-text-embedding-3-small"
-            }
+            "config": {}
         }
 
         try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/availability/tests/gateway_policy_tests.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/availability/tests/gateway_policy_tests.py
@@ -275,10 +275,7 @@ class PolicyTester:
         payload = {
             "message": f"Policy test from {user_type} at {time.time()}",
             "session_id": session_id,
-            "config": {
-                "selected_model": "gpt-4o",
-                "selected_embedder": "openai-text-embedding-3-small"
-            }
+            "config": {}
         }
 
         try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/availability/tests/load_tests.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/availability/tests/load_tests.py
@@ -160,10 +160,7 @@ class GatewayLoadTester:
         payload = {
             "message": message or f"Load test message from {user_type} at {time.time()}",
             "session_id": session_id or str(uuid.uuid4()),
-            "config": {
-                "selected_model": "gpt-4o",
-                "selected_embedder": "openai-text-embedding-3-small"
-            }
+            "config": {}
         }
 
         try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/aws/task_protection.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/aws/task_protection.py
@@ -11,6 +11,7 @@ import urllib.request
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Optional
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 import fcntl
 
@@ -74,12 +75,13 @@ class EcsTaskScaleInProtection:
             1.0,
             float(request_timeout_sec or os.getenv("ECS_TASK_PROTECTION_REQUEST_TIMEOUT_SEC", "5")),
         )
+        _svc = get_settings().PLATFORM.SERVICE
         effective_task_timeout_sec = max(
             60,
             int(
                 task_timeout_sec
-                or os.getenv("CHAT_TASK_MAX_WALL_TIME_SEC")
-                or os.getenv("CHAT_TASK_TIMEOUT_SEC", "600")
+                or _svc.CHAT_TASK_MAX_WALL_TIME_SEC
+                or _svc.CHAT_TASK_TIMEOUT_SEC
             ),
         )
         default_expires = max(5, min(120, math.ceil(effective_task_timeout_sec / 60) + 5))

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/config/platform_env.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/config/platform_env.py
@@ -98,7 +98,7 @@ PLATFORM_ENV_GROUPS: dict[str, tuple[str, ...]] = {
         "COGNITO_REGION",
         "COGNITO_SERVICE_CLIENT_ID",
         "COGNITO_USER_POOL_ID",
-        "ODIC_SERVICE_USER_EMAIL",
+        "OIDC_SERVICE_USER_EMAIL",
         "OIDC_SERVICE_ADMIN_PASSWORD",
         "OIDC_SERVICE_ADMIN_USERNAME",
     ),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/gateway/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/gateway/config.py
@@ -377,6 +377,19 @@ class GatewayConfigFactory:
             except Exception as e:
                 logger.warning(f"Failed to parse GATEWAY_CONFIG_JSON: {e}. Falling back to env defaults.")
 
+        # YAML descriptor (GATEWAY_YAML_PATH) — used when GATEWAY_CONFIG_JSON is absent
+        yaml_data = _load_gateway_yaml()
+        if yaml_data is not None:
+            try:
+                cfg = _config_from_dict(yaml_data)
+                settings = get_settings()
+                if not cfg.redis_url:
+                    cfg.redis_url = settings.REDIS_URL or ""
+                cfg.instance_id = os.getenv("INSTANCE_ID", cfg.instance_id or "default-instance")
+                return cfg
+            except Exception as e:
+                logger.warning("Failed to build gateway config from GATEWAY_YAML_PATH: %s. Falling back to env defaults.", e)
+
         # Auto-detect profile if not specified
         if profile is None:
             env_profile = os.getenv("GATEWAY_PROFILE", "development").lower()
@@ -1107,6 +1120,40 @@ def _env_truthy(name: str) -> bool:
     return str(raw).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
+def _load_gateway_yaml() -> Optional[Dict[str, Any]]:
+    """Load gateway config from GATEWAY_YAML_PATH if set.
+
+    gateway.yaml is expected to have a top-level ``gateway:`` key whose
+    contents are the same shape as the dict accepted by ``_config_from_dict``.
+    Returns the ``gateway`` section dict, or ``None`` if the variable is unset,
+    the file is missing, or parsing fails.
+    """
+    path_str = (os.getenv("GATEWAY_YAML_PATH") or "").strip()
+    if not path_str:
+        return None
+    try:
+        import yaml
+        from pathlib import Path
+        path = Path(path_str)
+        if not path.exists():
+            logger.warning("GATEWAY_YAML_PATH set but file not found: %s", path_str)
+            return None
+        with open(path, "r") as fh:
+            data = yaml.safe_load(fh)
+        if not isinstance(data, dict):
+            logger.warning("GATEWAY_YAML_PATH: not a valid YAML mapping: %s", path_str)
+            return None
+        # Accept both a bare dict and a file with a top-level "gateway:" key.
+        gateway_section = data.get("gateway") if "gateway" in data else data
+        if not isinstance(gateway_section, dict):
+            logger.warning("GATEWAY_YAML_PATH: no usable gateway section in %s", path_str)
+            return None
+        return gateway_section
+    except Exception as exc:
+        logger.warning("Failed to load GATEWAY_YAML_PATH %s: %s", path_str, exc)
+        return None
+
+
 def should_force_gateway_config_from_env() -> bool:
     return _env_truthy("GATEWAY_CONFIG_FORCE_ENV_ON_STARTUP")
 
@@ -1118,6 +1165,9 @@ def load_gateway_config_raw_from_env() -> Dict[str, Any]:
             return json.loads(cfg_json)
         except Exception as e:
             logger.warning("Failed to parse GATEWAY_CONFIG_JSON: %s", e)
+    yaml_data = _load_gateway_yaml()
+    if yaml_data is not None:
+        return yaml_data
     return _serialize_gateway_config(GatewayConfigFactory.create_from_env())
 
 
@@ -1188,6 +1238,9 @@ async def load_gateway_config_raw(
             return json.loads(cfg_json)
         except Exception:
             pass
+    yaml_data = _load_gateway_yaml()
+    if yaml_data is not None:
+        return yaml_data
     # Fallback to current component config serialized (flat)
     return _serialize_gateway_config(get_gateway_config())
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/gateway/safe_preflight.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/gateway/safe_preflight.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import io, re, asyncio, zipfile, time, os
 from dataclasses import dataclass, field
 from typing import Optional, Dict, Any, List
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 from kdcube_ai_app.infra.service_hub.multimodality import MODALITY_IMAGE_MIME, MODALITY_DOC_MIME
 
@@ -125,8 +126,9 @@ async def av_scan_bytes_async(data: bytes, timeout_s: float) -> tuple[bool, str]
     def _scan_blocking() -> tuple[bool, str]:
         try:
             import clamd  # type: ignore
-            host = os.getenv("CLAMAV_HOST", "127.0.0.1")
-            port = int(os.getenv("CLAMAV_PORT", "3310"))
+            _av = get_settings().PLATFORM.HOSTED_SERVICES.AV
+            host = _av.CLAMAV_HOST
+            port = _av.CLAMAV_PORT
             try:
                 cd = clamd.ClamdUnixSocket()
                 cd.ping()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/llm/batching.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/llm/batching.py
@@ -18,7 +18,7 @@ import openai
 from kdcube_ai_app.infra.llm.llm_data_model import (AIProviderName, Message,
                                                     ModelRecord, AIProvider,
                                                     wrap_batch_results)
-from kdcube_ai_app.infra.llm.util import apply_cache_strategy
+from kdcube_ai_app.infra.llm.util import apply_cache_strategy, get_service_key_fn
 
 logger = logging.getLogger(__name__)
 
@@ -831,7 +831,7 @@ async def try_batch():
         systemName="gpt-4o-mini",
         provider=AIProvider(
             provider=AIProviderName.open_ai,
-            apiToken=os.getenv("OPENAI_API_KEY"),
+            apiToken=get_service_key_fn(AIProviderName.open_ai),
         ),
     )
 
@@ -840,7 +840,7 @@ async def try_batch():
         systemName="claude-3-5-haiku-20241022",
         provider=AIProvider(
             provider=AIProviderName.anthropic,
-            apiToken=os.getenv("ANTHROPIC_API_KEY"),
+            apiToken=get_service_key_fn(AIProviderName.anthropic),
         ),
     )
 
@@ -920,7 +920,7 @@ async def try_batch():
     # else:
     #     print("Skipping OpenAI test - no OPENAI_API_KEY found")
 
-    if os.getenv("ANTHROPIC_API_KEY"):
+    if get_service_key_fn(AIProviderName.anthropic):
         await process(model_record_anthropic, "Anthropic")
     else:
         print("Skipping Anthropic test - no ANTHROPIC_API_KEY found")
@@ -939,7 +939,7 @@ async def try_get_batch():
         systemName="gpt-4o-mini",
         provider=AIProvider(
             provider=provider,
-            apiToken=os.getenv("OPENAI_API_KEY"),
+            apiToken=get_service_key_fn(AIProviderName.open_ai),
         ),
     )
 
@@ -948,7 +948,7 @@ async def try_get_batch():
         systemName="claude-3-5-haiku-20241022",
         provider=AIProvider(
             provider=provider,
-            apiToken=os.getenv("ANTHROPIC_API_KEY"),
+            apiToken=get_service_key_fn(AIProviderName.anthropic),
         ),
     )
     batch_id = openai_batch_id

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/llm/streaming.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/llm/streaming.py
@@ -21,7 +21,8 @@ from kdcube_ai_app.infra.llm.util import (get_system_message,
                                           rate_limiter, rate_limited_request,
                                           fix_invalid_json,
                                           fix_invalid_boolean_and_null,
-                                          apply_cache_strategy)
+                                          apply_cache_strategy,
+                                          get_service_key_fn)
 from kdcube_ai_app.storage.storage import create_storage_backend
 
 
@@ -734,7 +735,7 @@ def test_platform_streaming():
         systemName="gpt-4o-mini",
         provider=AIProvider(
             provider=provider,
-            apiToken=os.getenv("OPENAI_API_KEY"),
+            apiToken=get_service_key_fn(AIProviderName.open_ai),
         ),
     )
 
@@ -743,7 +744,7 @@ def test_platform_streaming():
         systemName="claude-3-5-haiku-20241022",
         provider=AIProvider(
             provider=provider,
-            apiToken=os.getenv("ANTHROPIC_API_KEY"),
+            apiToken=get_service_key_fn(AIProviderName.anthropic),
         ),
     )
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/namespaces.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/namespaces.py
@@ -2,10 +2,6 @@
 # Copyright (c) 2026 Elena Viter
 
 # infra/namespaces.py
-import os
-
-from kdcube_ai_app.apps.chat.reg import MODEL_CONFIGS, EMBEDDERS, DEFAULT_MODEL_CONFIG, DEFAULT_EMBEDDER_CONFIG
-
 
 def tp_prefix(tenant: str | None = None, project: str | None = None) -> str:
     from kdcube_ai_app.apps.chat.sdk.config import get_settings
@@ -91,13 +87,6 @@ class REDIS:
         REGISTRY = "kdcube:registry"
 
 class CONFIG:
-    ID_TOKEN_HEADER_NAME = os.getenv("ID_TOKEN_HEADER_NAME", "X-ID-Token")
-    STREAM_ID_HEADER_NAME = os.getenv("STREAM_ID_HEADER_NAME", "KDC-Stream-ID")
-    USER_TIMEZONE_HEADER_NAME = os.getenv("USER_TIMEZONE_HEADER_NAME", "X-User-Timezone")
-    USER_UTC_OFFSET_MIN_HEADER_NAME = os.getenv("USER_UTC_OFFSET_MIN_HEADER_NAME", "X-User-UTC-Offset")
-    AUTH_TOKEN_COOKIE_NAME = os.getenv("AUTH_TOKEN_COOKIE_NAME", "__Secure-LATC")
-    ID_TOKEN_COOKIE_NAME = os.getenv("ID_TOKEN_COOKIE_NAME", "__Secure-LITC")
-
     class BUNDLES:
         BUNDLE_MAPPING_KEY_FMT = "kdcube:config:bundles:mapping:{tenant}:{project}"
         UPDATE_CHANNEL = "kdcube:config:bundles:update:{tenant}:{project}"
@@ -117,11 +106,3 @@ class CONFIG:
         NAMESPACE = "kdcube:config:gateway"
         UPDATE_CHANNEL = "kdcube:config:gateway:update"
         CURRENT_KEY = "current"
-
-    class AGENTIC:
-        DEFAULT_LLM_MODEL_CONFIG = MODEL_CONFIGS.get(os.getenv("DEFAULT_LLM_MODEL_ID")) or DEFAULT_MODEL_CONFIG
-        DEFAULT_EMBEDDING_MODEL_CONFIG = EMBEDDERS.get(os.getenv("DEFAULT_EMBEDDING_MODEL_ID")) or DEFAULT_EMBEDDER_CONFIG
-
-        SUGGESTIONS_PREFIX = "kdcube:agentic:suggestions:{tenant}:{project}:{bundle_id}"
-
-    KDCUBE_STORAGE_PATH = os.environ.get("KDCUBE_STORAGE_PATH") or os.environ.get("STORAGE_PATH")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/orchestration/app/communicator.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/orchestration/app/communicator.py
@@ -12,6 +12,7 @@ from typing import Callable, Iterable, Optional, Union, AsyncIterator, List, Any
 import redis.asyncio as aioredis
 
 from dotenv import load_dotenv, find_dotenv
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from kdcube_ai_app.infra.redis.client import get_async_redis_client
@@ -57,9 +58,10 @@ class ServiceCommunicator:
         if not orchestrator_identity:
             ORCHESTRATOR_TYPE = os.environ.get("CB_ORCHESTRATOR_TYPE", "chatbot")
             DEFAULT_ORCHESTRATOR_IDENTITY = f"kdcube.relay.{ORCHESTRATOR_TYPE}"
-            ORCHESTRATOR_IDENTITY = os.environ.get("CB_RELAY_IDENTITY", DEFAULT_ORCHESTRATOR_IDENTITY)
-
-            orchestrator_identity = ORCHESTRATOR_IDENTITY
+            orchestrator_identity = (
+                get_settings().PLATFORM.SERVICE.CB_RELAY_IDENTITY
+                or DEFAULT_ORCHESTRATOR_IDENTITY
+            )
 
         self.orchestrator_identity = orchestrator_identity
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/orchestration/app/dramatiq/resolver.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/orchestration/app/dramatiq/resolver.py
@@ -5,6 +5,6 @@ from kdcube_ai_app.apps.chat.sdk.config import get_settings
 REDIS_URL = get_settings().REDIS_URL
 
 INSTANCE_ID = os.environ.get("INSTANCE_ID", "home-instance-1")
-HEARTBEAT_INTERVAL = int(os.environ.get("HEARTBEAT_INTERVAL", 10))  # seconds
+HEARTBEAT_INTERVAL = get_settings().PLATFORM.SERVICE.HEARTBEAT_INTERVAL
 TENANT_ID = os.environ.get("TENANT_ID", "home")
 PROJECT_ID = os.environ.get("DEFAULT_PROJECT_NAME", "home")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_refs.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_refs.py
@@ -9,13 +9,15 @@ import time
 from typing import Optional, Iterable, Set, Dict, Any
 
 import kdcube_ai_app.infra.namespaces as namespaces
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 _LOCAL_ACTIVE: Dict[str, float] = {}
 
 
 def _tp_from_env() -> tuple[str, str]:
-    tenant = os.getenv("DEFAULT_TENANT") or os.getenv("TENANT_ID") or "default-tenant"
-    project = os.getenv("DEFAULT_PROJECT_NAME") or os.getenv("CHAT_WEB_APP_PROJECT") or "default-project"
+    s = get_settings()
+    tenant = s.TENANT or "default-tenant"
+    project = s.PROJECT or "default-project"
     return tenant, project
 
 
@@ -29,11 +31,7 @@ def refs_key(tenant: Optional[str] = None, project: Optional[str] = None) -> str
 
 
 def _ttl_seconds() -> int:
-    try:
-        from kdcube_ai_app.apps.chat.sdk.config import get_settings
-        return int(get_settings().BUNDLE_REF_TTL_SECONDS)
-    except Exception:
-        return int(os.environ.get("BUNDLE_REF_TTL_SECONDS", "3600") or "3600")
+    return int(get_settings().PLATFORM.APPLICATIONS.BUNDLE_REF_TTL_SECONDS)
 
 
 def _touch_local(path: str) -> None:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_registry.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_registry.py
@@ -11,6 +11,7 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Dict, Any
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 _REG_LOCK = threading.RLock()
 _REGISTRY: Dict[str, Dict[str, Any]] = {}
@@ -134,7 +135,7 @@ def _apply_git_resolution(reg: Dict[str, Dict[str, Any]], source: str = "unknown
             )
         _warn_missing_local_path_bundles(reg, source=source)
         return reg
-    enabled = os.environ.get("BUNDLE_GIT_RESOLUTION_ENABLED", "1").lower() in {"1", "true", "yes", "on"}
+    enabled = get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_RESOLUTION_ENABLED
     repo_count = sum(1 for entry in reg.values() if entry.get("repo"))
     if not enabled:
         if any(entry.get("repo") for entry in reg.values()):
@@ -153,8 +154,9 @@ def _apply_git_resolution(reg: Dict[str, Dict[str, Any]], source: str = "unknown
     except Exception:
         return reg
 
-    atomic = os.environ.get("BUNDLE_GIT_ATOMIC", "1").lower() in {"1", "true", "yes"}
-    force_pull = os.environ.get("BUNDLE_GIT_ALWAYS_PULL", "0").lower() in {"1", "true", "yes"}
+    _git = get_settings().PLATFORM.APPLICATIONS.GIT
+    atomic = _git.BUNDLE_GIT_ATOMIC
+    force_pull = _git.BUNDLE_GIT_ALWAYS_PULL
     out = dict(reg)
     total = 0
     resolved = 0

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_storage.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_storage.py
@@ -9,6 +9,7 @@ import pathlib
 from typing import Optional
 
 from kdcube_ai_app.infra.service_hub.inventory import AgentLogger
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 from kdcube_ai_app.infra.plugin.git_bundle import resolve_bundles_root
 
@@ -24,7 +25,7 @@ def resolve_bundle_storage_root() -> pathlib.Path:
     Resolve the shared storage root for bundle-managed assets (indexes, repos, etc).
     Prefer explicit env, otherwise default under bundles root.
     """
-    root = os.environ.get("BUNDLE_SHARED_STORAGE_ROOT") or os.environ.get("BUNDLE_STORAGE_ROOT")
+    root = os.environ.get("BUNDLE_SHARED_STORAGE_ROOT") or get_settings().PLATFORM.APPLICATIONS.BUNDLE_STORAGE_ROOT
     if root:
         # Accept plain filesystem paths. If a file:// URI is provided, normalize to path.
         if isinstance(root, str) and root.startswith("file://"):

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_store.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_store.py
@@ -65,7 +65,7 @@ def _current_platform_ref() -> Optional[str]:
     if direct:
         return _sanitize_example_version_part(direct)
 
-    image_ref = (os.getenv("PY_CODE_EXEC_IMAGE") or "").strip()
+    image_ref = (get_settings().PLATFORM.EXEC.PY.PY_CODE_EXEC_IMAGE or "").strip()
     if image_ref and ":" in image_ref:
         tail = image_ref.rsplit(":", 1)[-1].strip()
         if tail and "/" not in tail:
@@ -90,8 +90,8 @@ def cleanup_old_shared_example_bundles(
     if not root.exists():
         return 0
 
-    keep = keep if keep is not None else int(os.environ.get("BUNDLE_GIT_KEEP", "3") or "3")
-    ttl_hours = ttl_hours if ttl_hours is not None else int(os.environ.get("BUNDLE_GIT_TTL_HOURS", "0") or "0")
+    keep = keep if keep is not None else get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_KEEP
+    ttl_hours = ttl_hours if ttl_hours is not None else get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_TTL_HOURS
     active_set: set[Path] = set()
     for ap in active_paths or ():
         try:
@@ -188,15 +188,10 @@ def _ensure_example_bundle_shared(bundle_root: Path) -> Path:
         return bundle_root
 
 def _examples_enabled() -> bool:
-    component = (os.getenv("GATEWAY_COMPONENT") or "ingress").strip().lower()
+    component = (get_settings().GATEWAY_COMPONENT or "ingress").strip().lower()
     if component != "proc":
         return False
-    try:
-        settings = get_settings()
-        return bool(settings.BUNDLES_INCLUDE_EXAMPLES)
-    except Exception:
-        raw = os.getenv("BUNDLES_INCLUDE_EXAMPLES", "1").lower()
-        return raw in {"1", "true", "yes", "on"}
+    return bool(get_settings().PLATFORM.APPLICATIONS.BUNDLES_INCLUDE_EXAMPLES)
 
 def _load_example_bundles() -> Dict[str, "BundleEntry"]:
     if not _examples_enabled():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/git_bundle.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/git_bundle.py
@@ -13,6 +13,7 @@ import time
 from contextlib import contextmanager
 import uuid
 import fcntl
+from kdcube_ai_app.apps.chat.sdk.config import get_settings
 
 from kdcube_ai_app.infra.service_hub.inventory import AgentLogger
 from kdcube_ai_app.apps.chat.sdk.config import get_secret
@@ -40,14 +41,14 @@ def _fail_key(*, git_url: str, bundle_id: str, git_ref: Optional[str]) -> str:
 
 def _fail_backoff_initial() -> int:
     try:
-        return int(os.environ.get("BUNDLE_GIT_FAIL_BACKOFF_SECONDS", "60") or "60")
+        return get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_FAIL_BACKOFF_SECONDS
     except Exception:
         return 60
 
 
 def _fail_backoff_max() -> int:
     try:
-        return int(os.environ.get("BUNDLE_GIT_FAIL_MAX_BACKOFF_SECONDS", "300") or "300")
+        return get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_FAIL_MAX_BACKOFF_SECONDS
     except Exception:
         return 300
 
@@ -85,7 +86,7 @@ def resolve_bundles_root() -> pathlib.Path:
     Prefer HOST_BUNDLES_PATH (host filesystem), then AGENTIC_BUNDLES_ROOT.
     """
     host_root = os.environ.get("HOST_BUNDLES_PATH")
-    agentic_root = os.environ.get("AGENTIC_BUNDLES_ROOT")
+    agentic_root = get_settings().PLATFORM.APPLICATIONS.AGENTIC_BUNDLES_ROOT
     if host_root:
         host_path = pathlib.Path(host_root).expanduser()
         try:
@@ -189,17 +190,17 @@ def _bundle_lock(*, bundle_id: str, git_ref: Optional[str], bundles_root: pathli
             fcntl.flock(fh, fcntl.LOCK_UN)
 
 def _redis_lock_enabled() -> bool:
-    return os.environ.get("BUNDLE_GIT_REDIS_LOCK", "0").lower() in {"1", "true", "yes", "on"}
+    return get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_REDIS_LOCK
 
 def _redis_lock_ttl() -> int:
     try:
-        return int(os.environ.get("BUNDLE_GIT_REDIS_LOCK_TTL_SECONDS", "300") or "300")
+        return get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_REDIS_LOCK_TTL_SECONDS
     except Exception:
         return 300
 
 def _redis_lock_wait() -> int:
     try:
-        return int(os.environ.get("BUNDLE_GIT_REDIS_LOCK_WAIT_SECONDS", "60") or "60")
+        return get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_REDIS_LOCK_WAIT_SECONDS
     except Exception:
         return 60
 
@@ -462,7 +463,7 @@ def ensure_git_bundle(
     root = bundles_root or resolve_git_bundles_root()
     fail_key = _fail_key(git_url=git_url, bundle_id=bundle_id, git_ref=git_ref)
     _check_fail_cooldown(fail_key)
-    force_pull = os.environ.get("BUNDLE_GIT_ALWAYS_PULL", "0").lower() in {"1", "true", "yes"}
+    force_pull = get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_ALWAYS_PULL
     with _redis_bundle_lock(bundle_id=bundle_id, git_ref=git_ref):
         with _bundle_lock(bundle_id=bundle_id, git_ref=git_ref, bundles_root=root):
             try:
@@ -597,8 +598,8 @@ def cleanup_old_git_bundles(
     """
     log = logger or AgentLogger("git.bundle")
     root = bundles_root or resolve_git_bundles_root()
-    keep = keep if keep is not None else int(os.environ.get("BUNDLE_GIT_KEEP", "3") or "3")
-    ttl_hours = ttl_hours if ttl_hours is not None else int(os.environ.get("BUNDLE_GIT_TTL_HOURS", "0") or "0")
+    keep = keep if keep is not None else get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_KEEP
+    ttl_hours = ttl_hours if ttl_hours is not None else get_settings().PLATFORM.APPLICATIONS.GIT.BUNDLE_GIT_TTL_HOURS
     prefix = f"{bundle_id}__"
     if not root.exists():
         return 0

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/relational/psql/psql_base.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/relational/psql/psql_base.py
@@ -6,6 +6,7 @@
 import os
 import urllib
 import psycopg2
+
 from psycopg2.extras import execute_values, register_default_json, register_default_jsonb
 import json
 
@@ -18,18 +19,20 @@ register_default_jsonb(loads=json.loads)
 
 class PostgreSqlDbMgr:
     def __init__(self, connection_params: Optional[Dict[str, str]] = None):
+        from kdcube_ai_app.apps.chat.sdk.config import get_settings
         connection_params = connection_params or {}
-        self.host = connection_params.get("host") or os.environ.get("POSTGRES_HOST")
-        self.port = connection_params.get("port") or os.environ.get("POSTGRES_PORT")
-        self.database = connection_params.get("database") or os.environ.get("POSTGRES_DATABASE")
+        _s = get_settings()
+        self.host = connection_params.get("host") or _s.PGHOST
+        self.port = connection_params.get("port") or str(_s.PGPORT)
+        self.database = connection_params.get("database") or _s.PGDATABASE
 
-        self.username = connection_params.get("username") or os.environ.get("POSTGRES_USER")
-        self.password = connection_params.get("password") or os.environ.get("POSTGRES_PASSWORD")
+        self.username = connection_params.get("username") or _s.PGUSER
+        self.password = connection_params.get("password") or _s.PGPASSWORD
 
-        # Optional tuning knobs via env
-        self.ssl = (os.environ.get("POSTGRES_SSL", "false").lower() == "true")
-        self.sslmode = os.environ.get("POSTGRES_SSL_MODE") or ("require" if self.ssl else "disable")
-        self.sslrootcert = os.environ.get("POSTGRES_SSL_ROOT_CERT")
+        # Optional tuning knobs
+        self.ssl = _s.PGSSL
+        self.sslmode = _s.PGSSL_MODE or ("require" if self.ssl else "disable")
+        self.sslrootcert = _s.PGSSL_ROOT_CERT
         self.appname = connection_params.get("application_name") or os.environ.get("POSTGRES_APPNAME", "kdcube-psql")
         self.statement_timeout_ms = int(os.environ.get("POSTGRES_STATEMENT_TIMEOUT_MS", "60000"))  # 60s
         self.search_path = connection_params.get("search_path") or os.environ.get("POSTGRES_SEARCH_PATH")  # optional

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/service_hub/inventory.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/service_hub/inventory.py
@@ -36,7 +36,7 @@ from kdcube_ai_app.infra.embedding.embedding import get_embedding
 from kdcube_ai_app.infra.plugin.bundle_registry import BundleSpec
 import kdcube_ai_app.infra.service_hub.errors as service_errors
 import kdcube_ai_app.apps.chat.sdk.tools.citations as citation_utils
-from kdcube_ai_app.apps.chat.sdk.config import get_settings
+from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_plain
 from kdcube_ai_app.infra.service_hub.message_utils import (
     extract_message_blocks,
     normalize_blocks,
@@ -525,11 +525,8 @@ class ConfigRequest(BaseModel):
     claude_api_key: Optional[str] = None
     google_api_key: Optional[str] = None
 
-    # Global defaults
-    selected_model: str = None   # used for default role mapping if role_models not provided
 
     # RAG embeddings
-    selected_embedder: str = "openai-text-embedding-3-small"
     custom_embedding_endpoint: Optional[str] = None
     custom_embedding_model: Optional[str] = "sentence-transformers/all-MiniLM-L6-v2"
     custom_embedding_size: Optional[int] = 384
@@ -578,24 +575,24 @@ class Config:
                  role_models: Optional[Dict[str, Dict[str, str]]] = None):
         # keys (prefer Settings/sidecar, fall back to env)
         settings = get_settings()
-        self.openai_api_key = openai_api_key or settings.OPENAI_API_KEY or os.getenv("OPENAI_API_KEY", "")
-        self.claude_api_key = claude_api_key or settings.ANTHROPIC_API_KEY or os.getenv("ANTHROPIC_API_KEY", "")
-        self.google_api_key = google_api_key or settings.GOOGLE_API_KEY or os.getenv("GEMINI_API_KEY", "")
+        self.openai_api_key = openai_api_key or settings.OPENAI_API_KEY or ""
+        self.claude_api_key = claude_api_key or settings.ANTHROPIC_API_KEY or ""
+        self.google_api_key = google_api_key or settings.GOOGLE_API_KEY or ""
 
-        # Gemini cache options (env or defaults)
-        self.gemini_cache_enabled: bool = bool(int(os.getenv("GEMINI_CACHE_ENABLED", "0")))
-        self.gemini_cache_ttl_seconds: int = int(os.getenv("GEMINI_CACHE_TTL_SECONDS", "3600"))
+        # Gemini cache options
+        self.gemini_cache_enabled: bool = bool(get_plain("a:services.llm.gemini.gemini_cache_enabled", False))
+        self.gemini_cache_ttl_seconds: int = int(get_plain("a:services.llm.gemini.gemini_cache_ttl_seconds", 3600))
 
         # embeddings (declarative)
-        self.selected_embedder = "openai-text-embedding-3-small"
-        self.embedder_config = EMBEDDERS.get(self.selected_embedder, EMBEDDERS["openai-text-embedding-3-small"])
-        self.embedding_model = embedding_model or "text-embedding-3-small"
+        #self.selected_embedder = "openai-text-embedding-3-small"
+        self.embedder_config = EMBEDDERS.get(get_settings().DEFAULT_EMBEDDER, EMBEDDERS["openai-text-embedding-3-small"])
+        self.embedding_model = embedding_model or get_settings().DEFAULT_EMBEDDER
         self.custom_embedding_endpoint = None
         self.custom_embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
         self.custom_embedding_size = 384
 
         # logging
-        self.log_level = os.getenv("LOG_LEVEL", "INFO")
+        self.log_level = get_settings().PLATFORM.LOG.LOG_LEVEL
 
         # format fix (Claude by default)
         self.format_fixer_model = "claude-3-haiku-20240307"
@@ -615,10 +612,10 @@ class Config:
         self.kb_search_url = os.getenv("KB_SEARCH_URL", None)
 
         # CB, bundles
-        self.bundle_storage_url = getattr(get_settings(), "BUNDLE_STORAGE_URL", None)
+        self.bundle_storage_url = get_settings().BUNDLE_STORAGE_URL
 
-        self.tenant = os.getenv("TENANT_ID", None)
-        self.project = os.getenv("DEFAULT_PROJECT_NAME", None)
+        self.tenant = get_settings().TENANT
+        self.project = get_settings().PROJECT
 
         self.ai_bundle_spec: Optional[BundleSpec] = None
 
@@ -626,7 +623,7 @@ class Config:
     def set_embedder(self, embedder_id: str, custom_endpoint: str | None = None):
         if embedder_id not in EMBEDDERS:
             raise ValueError(f"Unknown embedder: {embedder_id}")
-        self.selected_embedder = embedder_id
+        #self.selected_embedder = embedder_id
         self.embedder_config = EMBEDDERS[embedder_id]
         if self.embedder_config["provider"] == "custom":
             if not custom_endpoint:
@@ -744,7 +741,7 @@ class Config:
 # Config factory (accept bundle template or fill defaults)
 # =========================
 def create_workflow_config(config_request: ConfigRequest) -> Config:
-    cfg = Config(default_llm_model=config_request.selected_model)
+    cfg = Config(default_llm_model=get_settings().DEFAULT_MODEL_LLM_ID)
 
     # keys
     if config_request.openai_api_key:
@@ -763,15 +760,15 @@ def create_workflow_config(config_request: ConfigRequest) -> Config:
     cfg.format_fix_enabled = bool(config_request.format_fix_enabled)
 
     # embeddings
-    try:
-        cfg.set_embedder(config_request.selected_embedder, config_request.custom_embedding_endpoint)
-    except ValueError:
-        if config_request.custom_embedding_endpoint:
-            cfg.set_custom_embedding_endpoint(
-                config_request.custom_embedding_endpoint,
-                config_request.custom_embedding_model or "sentence-transformers/all-MiniLM-L6-v2",
-                int(config_request.custom_embedding_size or 384),
-                )
+    # try:
+    #     cfg.set_embedder(config_request.selected_embedder, config_request.custom_embedding_endpoint)
+    # except ValueError:
+    #     if config_request.custom_embedding_endpoint:
+    #         cfg.set_custom_embedding_endpoint(
+    #             config_request.custom_embedding_endpoint,
+    #             config_request.custom_embedding_model or "sentence-transformers/all-MiniLM-L6-v2",
+    #             int(config_request.custom_embedding_size or 384),
+    #             )
 
     # role models (template-filled or defaults)
     cfg.set_role_models(config_request.role_models)
@@ -800,11 +797,7 @@ def _build_model_service_from_env() -> "ModelServiceBase":
     Used by MCP servers and other lightweight entrypoints.
     """
     settings = get_settings()
-    selected_model = (
-        os.getenv("DEFAULT_LLM_MODEL_ID")
-        or os.getenv("SELECTED_MODEL")
-        or "o3-mini"
-    )
+
     role_models = None
     role_models_json = os.getenv("ROLE_MODELS_JSON")
     if role_models_json:
@@ -814,13 +807,12 @@ def _build_model_service_from_env() -> "ModelServiceBase":
             role_models = None
 
     req = ConfigRequest(
-        openai_api_key=settings.OPENAI_API_KEY or os.environ.get("OPENAI_API_KEY"),
-        claude_api_key=settings.ANTHROPIC_API_KEY or os.environ.get("ANTHROPIC_API_KEY"),
-        google_api_key=settings.GOOGLE_API_KEY or os.environ.get("GEMINI_API_KEY"),
-        selected_model=selected_model,
+        openai_api_key=settings.OPENAI_API_KEY,
+        claude_api_key=settings.ANTHROPIC_API_KEY,
+        google_api_key=settings.GOOGLE_API_KEY,
         role_models=role_models,
-        tenant=settings.TENANT or os.environ.get("TENANT_ID"),
-        project=settings.PROJECT or os.environ.get("DEFAULT_PROJECT_NAME"),
+        tenant=settings.TENANT,
+        project=settings.PROJECT,
     )
     cfg = create_workflow_config(req)
     return ModelServiceBase(cfg)
@@ -1116,8 +1108,6 @@ class ModelServiceBase:
         provider_id = (embedder_config.get("provider") or "openai").lower()
         model_name = embedder_config.get("model_name") or self.config.embedding_model
         if provider_id == "custom":
-            if not self.config.custom_embedding_endpoint:
-                raise ValueError(f"Custom embedder {self.config.selected_embedder} requires an endpoint")
             size = int(embedder_config.get("dim") or self.config.custom_embedding_size or 0)
             self._custom_embeddings = CustomEmbeddings(
                 endpoint=self.config.custom_embedding_endpoint,
@@ -2971,28 +2961,6 @@ def export_execution_logs(execution_data: Dict[str, Any], filename: str | None =
     except Exception as e:
         return f"Failed to export logs: {str(e)}"
 
-def probe_embeddings(config_request: ConfigRequest) -> Dict[str, Any]:
-    cfg = create_workflow_config(config_request)
-    ecfg = cfg.embedder_config
-    if ecfg["provider"] == "openai":
-        embeddings = OpenAIEmbeddings(model=ecfg["model_name"], openai_api_key=cfg.openai_api_key)
-        test_text = "This is a test embedding query"
-        embedding = embeddings.embed_query(test_text)
-        return {"status": "success", "embedder_id": cfg.selected_embedder, "provider": "openai",
-                "model": ecfg["model_name"], "embedding_size": len(embedding),
-                "test_text": test_text, "embedding_preview": embedding[:5]}
-    if ecfg["provider"] == "custom":
-        if not config_request.custom_embedding_endpoint:
-            raise Exception("Custom embedder requires an endpoint")
-        embeddings = CustomEmbeddings(endpoint=config_request.custom_embedding_endpoint,
-                                      model=ecfg["model_name"], size=ecfg["dim"])
-        test_text = "This is a test embedding query"
-        embedding = embeddings.embed_query(test_text)
-        return {"status": "success" if embedding else "failed", "embedder_id": cfg.selected_embedder,
-                "provider": "custom", "endpoint": config_request.custom_embedding_endpoint,
-                "model": ecfg["model_name"], "embedding_size": len(embedding or []),
-                "test_text": test_text, "embedding_preview": (embedding or [])[:5]}
-    raise Exception(f"Unknown embedding provider: {ecfg['provider']}")
 
 class BundleState(TypedDict, total=False):
     request_id: str
@@ -3043,9 +3011,8 @@ if __name__ == "__main__":
         role = "segment_enrichment"
         settings = get_settings()
         req = ConfigRequest(
-            openai_api_key=settings.OPENAI_API_KEY or os.environ.get("OPENAI_API_KEY"),
-            claude_api_key=settings.ANTHROPIC_API_KEY or os.environ.get("ANTHROPIC_API_KEY"),
-            selected_model=m,
+            openai_api_key=settings.OPENAI_API_KEY,
+            claude_api_key=settings.ANTHROPIC_API_KEY,
             role_models={ role: {"provider": "anthropic", "model": m}},
         )
         ms = ModelServiceBase(create_workflow_config(req))

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/service_hub/openrouter.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/service_hub/openrouter.py
@@ -18,6 +18,8 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
+from kdcube_ai_app.apps.chat.sdk.config import get_secret
+
 import aiohttp
 
 from kdcube_ai_app.infra.accounting import track_llm
@@ -172,7 +174,7 @@ async def openrouter_completion(
         success : bool
         error : str | None
     """
-    resolved_key = api_key or os.getenv("OPENROUTER_API_KEY") or ""
+    resolved_key = api_key or get_secret("services.openrouter.api_key") or ""
     if not resolved_key:
         return {
             "text": "",


### PR DESCRIPTION
  Replace remaining os.getenv/os.environ reads with get_settings() or get_secret()
  across ingress, proc, infra, and knowledge_base layers so all config flows
  through the assembly/secrets descriptor pipeline instead of raw env vars.

  Changes:
  - ingress/resolvers.py: CHAT_APP_PORT, CHAT_PROCESSOR_PORT, AUTH_PROVIDER via get_settings()
  - ingress/monitoring/monitoring.py: AUTH_PROVIDER, INSTANCE_ID
  - ingress/opex/opex.py: GATEWAY_COMPONENT
  - ingress/opex/routines.py: OPEX_AGG_CRON and bundle cleanup settings via PLATFORM.APPLICATIONS.*
  - proc/web_app.py: bundle preload settings via PLATFORM.APPLICATIONS.*
  - emitters.py: CB_RELAY_IDENTITY via PLATFORM.SERVICE.*
  - external_events.py: INSTANCE_ID (3 sites)
  - ingress/sse/chat.py: INSTANCE_ID
  - infra/service_hub/inventory.py: API key fields via get_settings() attributes
  - infra/service_hub/openrouter.py: api_key via get_secret("services.openrouter.api_key")
  - infra/llm/streaming.py, batching.py: API tokens via get_service_key_fn()
  - infra/availability/health_and_heartbeat.py: GATEWAY_COMPONENT, CHAT_APP_PORT
  - infra/plugin/bundle_store.py: BUNDLES_INCLUDE_EXAMPLES, GATEWAY_COMPONENT
  - infra/plugin/bundle_refs.py: TENANT/PROJECT via get_settings(), BUNDLE_REF_TTL_SECONDS
  - infra/relational/psql/psql_base.py: all PG connection params via get_settings()
  - apps/knowledge_base/api/resolvers.py: TENANT, PROJECT, STORAGE_PATH, INSTANCE_ID, AUTH_PROVIDER
  - sdk/solutions/chatbot/entrypoint.py: CHAT_APP_PORT

  Fix circular import in psql_base.py (config→props/manager→psql_base→config)
  by moving get_settings() import inside PostgreSqlDbMgr.__init__.

  Extract PLATFORM_CONFIG base class and all config model definitions (LOGConfig,
  ServiceConfig, AVConfig, AuthConfig, PlatformConfig, etc.) into a new
  config_scopes.py module.  config.py now imports them from there, eliminating
  the monolithic single-file layout and breaking the circular import path that
  config.py → props/manager.py → psql_base.py → config.py created.