### PR TITLE
[Bundles/Enabled]: Add enabled_config enforcement for bundle resources

### DIFF
--- a/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
@@ -141,6 +141,15 @@ Current fields relevant to access control:
   - do **not** use derived platform types here (`"registered"`, `"privileged"`)
   - empty or omitted means the bundle is visible to all authenticated users
   - OR semantics: user passes if at least one of their raw roles matches
+- `enabled_config`
+  - dot-separated path into bundle props that resolves to a boolean
+  - if the resolved value is falsy, the bundle is treated as disabled:
+    all its HTTP routes return 404 and all its scheduled jobs are skipped,
+    regardless of any resource-level `enabled_config` values
+  - absent or `None` means always enabled
+  - prop absent in Redis also means enabled (opt-in disabling, not opt-in enabling)
+  - enforced in `integrations.py` for HTTP resources (widgets, operations, MCP endpoints)
+    and in `bundle_scheduler.py` for scheduled jobs, before any per-resource check
 
 Current behavior:
 
@@ -204,6 +213,12 @@ Current fields:
     - `"bundle"`: proc forwards the request into the bundle method and the
       bundle authenticates it itself
   - default: required for `route="public"`, invalid for `route="operations"`
+- `enabled_config`
+  - dot-separated path into bundle props that resolves to a boolean
+  - if the resolved value is falsy, this endpoint returns 404
+  - absent or `None` means always enabled
+  - checked after the bundle-level `enabled_config` — if the bundle is disabled,
+    this check is never reached
 
 Important current rule:
 
@@ -262,6 +277,11 @@ Current fields:
   - default: `operations`
 - `transport`
   - current supported value: `streamable-http`
+- `enabled_config`
+  - dot-separated path into bundle props that resolves to a boolean
+  - if the resolved value is falsy, the MCP endpoint returns 404
+  - absent or `None` means always enabled
+  - checked after the bundle-level `enabled_config`
 
 Current rule:
 
@@ -341,6 +361,11 @@ Current fields:
 - `roles`
   - raw external roles allowed to see the widget
   - use values such as `kdcube:role:super-admin`
+- `enabled_config`
+  - dot-separated path into bundle props that resolves to a boolean
+  - if the resolved value is falsy, the widget fetch returns 404
+  - absent or `None` means always enabled
+  - checked after the bundle-level `enabled_config`
 
 Current rule:
 
@@ -431,6 +456,18 @@ Current fields:
   - `"system"` — runs once across all instances for this tenant/project/bundle/job, Redis lock
   - omitting `span` or passing an empty string defaults to `"system"`
   - an unrecognised value raises `ValueError` at decoration time
+- `timezone`
+  - IANA timezone name, e.g. `"Europe/Berlin"`
+  - defaults to UTC when omitted
+- `tz_config`
+  - dot-separated path into bundle props/config for the timezone override
+  - if set and resolved to a non-blank string, takes precedence over `timezone`
+- `enabled_config`
+  - dot-separated path into bundle props that resolves to a boolean
+  - if the resolved value is falsy, this job is not scheduled
+  - absent or `None` means always enabled
+  - checked after the bundle-level `enabled_config` in `bundle_scheduler.py` —
+    if the bundle itself is disabled, no per-job check is performed
 
 Current behavior:
 
@@ -507,6 +544,7 @@ class APIEndpointSpec:
     route: str = "operations"
     user_types: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
+    enabled_config: str | None = None
 ```
 
 ### 2.2 `UIWidgetSpec`
@@ -519,6 +557,7 @@ class UIWidgetSpec:
     icon: dict[str, str]
     user_types: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
+    enabled_config: str | None = None
 ```
 
 ### 2.3 `MCPEndpointSpec`
@@ -530,6 +569,7 @@ class MCPEndpointSpec:
     alias: str
     route: str = "operations"
     transport: str = "streamable-http"
+    enabled_config: str | None = None
 ```
 
 ### 2.4 `OnMessageSpec`
@@ -557,7 +597,10 @@ class CronJobSpec:
     alias: str = ""
     cron_expression: str | None = None
     expr_config: str | None = None
+    timezone: str | None = None
+    tz_config: str | None = None
     span: str = "system"
+    enabled_config: str | None = None
 ```
 
 ### 2.7 `BundleInterfaceManifest`
@@ -573,6 +616,7 @@ class BundleInterfaceManifest:
     ui_main: UIMainSpec | None = None
     on_message: OnMessageSpec | None = None
     scheduled_jobs: tuple[CronJobSpec, ...] = ()
+    enabled_config: str | None = None
 ```
 
 `allowed_roles` is populated from the `allowed_roles` argument of

--- a/app/ai-app/docs/sdk/bundle/bundle-scheduled-jobs-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-scheduled-jobs-README.md
@@ -3,7 +3,7 @@ id: ks:docs/sdk/bundle/bundle-scheduled-jobs-README.md
 title: "Bundle Scheduled Jobs"
 summary: "Bundle-native cron jobs via the @cron decorator: span semantics, cron resolution, runtime access, and local debug."
 tags: ["sdk", "bundle", "cron", "scheduled-jobs", "scheduler", "proc"]
-keywords: ["@cron", "cron decorator", "CronJobSpec", "BundleSchedulerManager", "span", "process", "instance", "system", "expr_config", "cron_expression", "scheduled jobs", "BUNDLES_YAML_DESCRIPTOR_PATH"]
+keywords: ["@cron", "cron decorator", "CronJobSpec", "BundleSchedulerManager", "span", "process", "instance", "system", "expr_config", "cron_expression", "timezone", "tz_config", "enabled_config", "bundle disabled", "scheduled jobs", "BUNDLES_YAML_DESCRIPTOR_PATH"]
 see_also:
   - ks:docs/sdk/bundle/bundle-platform-integration-README.md
   - ks:docs/sdk/bundle/bundle-props-secrets-README.md
@@ -44,7 +44,10 @@ once per hour across the whole system.
     alias: str | None = None,
     cron_expression: str | None = None,
     expr_config: str | None = None,
+    timezone: str | None = None,
+    tz_config: str | None = None,
     span: str = "system",
+    enabled_config: str | None = None,
 )
 ```
 
@@ -53,7 +56,23 @@ once per hour across the whole system.
 | `alias` | `str \| None` | Stable job identifier. Used in Redis lock keys and logs. Defaults to method name. |
 | `cron_expression` | `str \| None` | Inline cron expression, e.g. `"*/15 * * * *"`. |
 | `expr_config` | `str \| None` | Dot-path into bundle props/config, e.g. `"routines.reindex.cron"`. Wins over `cron_expression`. |
+| `timezone` | `str \| None` | IANA timezone for cron interpretation, e.g. `"Europe/Berlin"`. Defaults to UTC. |
+| `tz_config` | `str \| None` | Dot-path into bundle props/config for the timezone override. Wins over `timezone`. |
 | `span` | `str` | Exclusivity: `"process"`, `"instance"`, `"system"`. Default: `"system"`. |
+| `enabled_config` | `str \| None` | Dot-path into bundle props that resolves to a boolean. Falsy → job not scheduled. `None` means always enabled. |
+
+---
+
+## Bundle-level enabled override
+
+If the bundle's `@agentic_workflow(enabled_config=...)` resolves to a falsy
+value from bundle props, **all** scheduled jobs for that bundle are skipped
+during reconcile — regardless of individual job `enabled_config` or
+`expr_config` values. The per-job checks are never reached.
+
+This is enforced in `bundle_scheduler.py` (`reconcile`) before the per-job
+loop. Use it as a single kill-switch to disable the entire bundle, including
+all its cron jobs, without touching each job individually.
 
 ---
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
@@ -55,6 +55,7 @@ from kdcube_ai_app.infra.plugin.bundle_store import (
     get_bundle_props as store_get_bundle_props,
     patch_bundle_props as store_patch_bundle_props,
     put_bundle_props as store_put_bundle_props,
+    resolve_dot_path as _resolve_prop_path,
 )
 from kdcube_ai_app.infra.plugin.agentic_loader import (
     AgenticBundleSpec,
@@ -82,6 +83,28 @@ import kdcube_ai_app.infra.namespaces as namespaces
 logger = logging.getLogger("ChatProc.Integrations")
 _integrations_limit: Optional[int] = None
 _integrations_semaphore = None
+
+_DISABLED_PROP_VALUES: frozenset = frozenset({"false", "disable", "disabled", "off", "0"})
+
+
+def _is_enabled_from_props(props: Dict[str, Any], enabled_config: Optional[str]) -> bool:
+    """Return True if the endpoint/bundle is enabled according to bundle props.
+
+    - No enabled_config declared -> always enabled.
+    - Path absent in props -> enabled (opt-in disabling, not opt-in enabling).
+    - Value is bool/int -> direct truthiness.
+    - Value is string -> disabled only for "false"/"disable"/"disabled"/"off"/"0".
+    """
+    if not enabled_config:
+        return True
+    value = _resolve_prop_path(props, enabled_config)
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value != 0
+    return str(value).strip().lower() not in _DISABLED_PROP_VALUES
 
 
 def _resolve_integrations_limit() -> Optional[int]:
@@ -748,6 +771,7 @@ async def _get_bundle_manifest(
 def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]:
     """Serialise a full (unfiltered) manifest to a plain dict."""
     return {
+        "enabled_config": manifest.enabled_config,
         "apis": [
             {
                 "alias": s.alias,
@@ -755,6 +779,7 @@ def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]
                 "route": s.route,
                 "user_types": list(s.user_types),
                 "roles": list(s.roles),
+                "enabled_config": s.enabled_config,
             }
             for s in manifest.api_endpoints
         ],
@@ -763,11 +788,18 @@ def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]
                 "alias": s.alias,
                 "route": s.route,
                 "transport": s.transport,
+                "enabled_config": s.enabled_config,
             }
             for s in manifest.mcp_endpoints
         ],
         "widgets": [
-            {"alias": s.alias, "icon": s.icon, "user_types": list(s.user_types), "roles": list(s.roles)}
+            {
+                "alias": s.alias,
+                "icon": s.icon,
+                "user_types": list(s.user_types),
+                "roles": list(s.roles),
+                "enabled_config": s.enabled_config,
+            }
             for s in manifest.ui_widgets
         ],
         "on_message": manifest.on_message.method_name if manifest.on_message else None,
@@ -780,6 +812,7 @@ def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]
                 "timezone": s.timezone,
                 "tz_config": s.tz_config,
                 "span": s.span,
+                "enabled_config": s.enabled_config,
             }
             for s in manifest.scheduled_jobs
         ],
@@ -792,6 +825,7 @@ def _manifest_to_descriptor_filtered(
 ) -> Dict[str, Any]:
     """Serialise a manifest filtered to the endpoint visibility rules for session."""
     return {
+        "enabled_config": manifest.enabled_config,
         "apis": [
             {
                 "alias": s.alias,
@@ -799,6 +833,7 @@ def _manifest_to_descriptor_filtered(
                 "route": s.route,
                 "user_types": list(s.user_types),
                 "roles": list(s.roles),
+                "enabled_config": s.enabled_config,
             }
             for s in manifest.api_endpoints
             if _endpoint_visible(s.user_types, s.roles, session)
@@ -808,11 +843,18 @@ def _manifest_to_descriptor_filtered(
                 "alias": s.alias,
                 "route": s.route,
                 "transport": s.transport,
+                "enabled_config": s.enabled_config,
             }
             for s in manifest.mcp_endpoints
         ],
         "widgets": [
-            {"alias": s.alias, "icon": s.icon, "user_types": list(s.user_types), "roles": list(s.roles)}
+            {
+                "alias": s.alias,
+                "icon": s.icon,
+                "user_types": list(s.user_types),
+                "roles": list(s.roles),
+                "enabled_config": s.enabled_config,
+            }
             for s in manifest.ui_widgets
             if _endpoint_visible(s.user_types, s.roles, session)
         ],
@@ -826,6 +868,7 @@ def _manifest_to_descriptor_filtered(
                 "timezone": s.timezone,
                 "tz_config": s.tz_config,
                 "span": s.span,
+                "enabled_config": s.enabled_config,
             }
             for s in manifest.scheduled_jobs
         ],
@@ -921,6 +964,7 @@ async def get_bundles(
         else:
             raise HTTPException(status_code=503, detail="Failed to load bundles registry for tenant/project")
 
+    redis = _get_app_redis(request)
     bundles_out = {}
     for bid, entry in reg.bundles.items():
         manifest = await _get_bundle_manifest(
@@ -932,6 +976,10 @@ async def get_bundles(
         )
         if not _bundle_allowed_for_session(manifest, session):
             continue
+        if manifest is not None and manifest.enabled_config:
+            props = await store_get_bundle_props(redis, tenant=tenant_id, project=project_id, bundle_id=bid)
+            if not _is_enabled_from_props(props, manifest.enabled_config):
+                continue
         descriptor: Dict[str, Any] = {
             "id": bid,
             "name": entry.name,
@@ -1930,6 +1978,15 @@ async def fetch_bundle_widget(
     if not _endpoint_visible(widget_spec.user_types, widget_spec.roles, session):
         raise HTTPException(status_code=403, detail=f"Bundle widget {widget_alias} is not visible to this user")
 
+    manifest = discover_bundle_interface_manifest(workflow, bundle_id=spec_resolved.id)
+    _props = await store_get_bundle_props(
+        _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
+    )
+    if not _is_enabled_from_props(_props, manifest.enabled_config):
+        raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
+    if not _is_enabled_from_props(_props, widget_spec.enabled_config):
+        raise HTTPException(status_code=404, detail=f"Bundle widget {widget_alias} is not available")
+
     fn = getattr(workflow, widget_spec.method_name)
     extra = _with_implicit_bundle_kwargs(
         _get_query_kwargs(request),
@@ -2079,6 +2136,15 @@ async def _call_bundle_mcp_inner(
     )
     if endpoint_spec is None:
         raise HTTPException(status_code=404, detail=f"Bundle does not support MCP endpoint {endpoint_alias}")
+
+    manifest = discover_bundle_interface_manifest(workflow, bundle_id=spec_resolved.id)
+    _props = await store_get_bundle_props(
+        _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
+    )
+    if not _is_enabled_from_props(_props, manifest.enabled_config):
+        raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
+    if not _is_enabled_from_props(_props, endpoint_spec.enabled_config):
+        raise HTTPException(status_code=404, detail=f"Bundle MCP endpoint {endpoint_alias} is not available")
 
     try:
         fn = getattr(workflow, endpoint_spec.method_name)
@@ -2460,6 +2526,15 @@ async def _call_bundle_op_inner(
     )
     if not _endpoint_visible(endpoint_spec.user_types, endpoint_spec.roles, session):
         raise HTTPException(status_code=403, detail=f"Bundle operation {operation} is not visible to this user")
+
+    manifest = discover_bundle_interface_manifest(workflow, bundle_id=spec_resolved.id)
+    _props = await store_get_bundle_props(
+        _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
+    )
+    if not _is_enabled_from_props(_props, manifest.enabled_config):
+        raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
+    if not _is_enabled_from_props(_props, endpoint_spec.enabled_config):
+        raise HTTPException(status_code=404, detail=f"Bundle operation {operation} is not available")
 
     try:
         fn = getattr(workflow, endpoint_spec.method_name)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/bundle_scheduler.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/bundle_scheduler.py
@@ -98,6 +98,47 @@ def resolve_effective_cron(
     return None
 
 
+_SCHEDULER_DISABLED_VALUES: frozenset = frozenset({"false", "disable", "disabled", "off", "0"})
+
+
+def resolve_effective_enabled(
+    enabled_config: Optional[str],
+    props: Dict[str, Any],
+) -> bool:
+    """Return False if the job should be suppressed based on bundle props.
+
+    Resolution order (mirrors resolve_effective_cron):
+    1. Redis bundle props (dot-path lookup in props dict).
+    2. bundles.yaml / assembly.yaml via read_plain, when the path is absent
+       from Redis props (value is None after step 1).
+    3. Default: True (enabled) when the path is absent from both sources.
+
+    Falsy values: False (bool), 0 (int), or any of
+    "false" / "disable" / "disabled" / "off" / "0" (case-insensitive string).
+    """
+    if not enabled_config:
+        return True
+    from kdcube_ai_app.infra.plugin.bundle_store import resolve_dot_path
+    value = resolve_dot_path(props, enabled_config)
+    if value is None:
+        try:
+            from kdcube_ai_app.apps.chat.sdk.config import read_plain
+            raw = read_plain(f"b:{enabled_config}", default=None)
+            if raw is None:
+                raw = read_plain(enabled_config, default=None)
+            if raw is not None:
+                value = raw
+        except Exception:
+            pass
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value != 0
+    return str(value).strip().lower() not in _SCHEDULER_DISABLED_VALUES
+
+
 def resolve_effective_timezone(
     timezone_name: Optional[str],
     tz_config: Optional[str],
@@ -554,6 +595,14 @@ class BundleSchedulerManager:
                 props=props,
             )
 
+            if not resolve_effective_enabled(manifest.enabled_config, props):
+                _log.info(
+                    "[scheduler] Bundle disabled via enabled_config: bundle=%s enabled_config=%r"
+                    " — skipping all jobs",
+                    bundle_id, manifest.enabled_config,
+                )
+                continue
+
             for job_spec in manifest.scheduled_jobs:
                 effective = resolve_effective_cron(
                     cron_expression=job_spec.cron_expression,
@@ -574,6 +623,14 @@ class BundleSchedulerManager:
                         "expr_config=%r cron_expression=%r",
                         bundle_id, job_spec.alias,
                         job_spec.expr_config, job_spec.cron_expression,
+                    )
+                    continue
+
+                if not resolve_effective_enabled(job_spec.enabled_config, props):
+                    _log.info(
+                        "[scheduler] Job disabled via enabled_config: bundle=%s alias=%s "
+                        "enabled_config=%r",
+                        bundle_id, job_spec.alias, job_spec.enabled_config,
                     )
                     continue
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
@@ -71,6 +71,7 @@ class APIEndpointSpec:
     user_types: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
     public_auth: "PublicAPIAuthSpec | None" = None
+    enabled_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,7 @@ class MCPEndpointSpec:
     alias: str
     route: str = "operations"
     transport: str = "streamable-http"
+    enabled_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -95,6 +97,7 @@ class UIWidgetSpec:
     icon: dict[str, str]
     user_types: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
+    enabled_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -116,6 +119,7 @@ class CronJobSpec:
     timezone: str | None = None
     tz_config: str | None = None
     span: str = "system"
+    enabled_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -128,6 +132,7 @@ class BundleInterfaceManifest:
     ui_main: UIMainSpec | None = None
     on_message: OnMessageSpec | None = None
     scheduled_jobs: tuple[CronJobSpec, ...] = ()
+    enabled_config: str | None = None
 
 
 def _clean_alias(value: str | None, default: str) -> str:
@@ -298,6 +303,7 @@ def agentic_workflow(
         version: str | None = None,
         priority: int = 100,
         allowed_roles: List[str] | Tuple[str, ...] | None = None,
+        enabled_config: str | None = None,
 ):
     """
     Mark a CLASS as the bundle's workflow CLASS.
@@ -310,12 +316,17 @@ def agentic_workflow(
         bundle listing. Only users whose raw roles (kdcube:role:* entries from
         the session) intersect with allowed_roles will see this bundle.
         Empty or None means visible to all authenticated users.
+
+    enabled_config: dot-separated path into bundle props that resolves to a
+        boolean. If the resolved value is falsy, all inbound routes for this
+        bundle return 404. Absent or None means always enabled.
     """
     def _wrap(cls):
         setattr(cls, AGENTIC_ROLE_ATTR, "workflow_class")
         setattr(cls, AGENTIC_META_ATTR, {
             "name": name, "version": version, "priority": priority,
             "allowed_roles": _tuple_str(allowed_roles),
+            "enabled_config": str(enabled_config).strip() if enabled_config else None,
         })
         return cls
     return _wrap
@@ -351,6 +362,7 @@ def api(
         user_types: List[str] | Tuple[str, ...] | None = None,
         roles: List[str] | Tuple[str, ...] | None = None,
         public_auth: str | Dict[str, Any] | None = None,
+        enabled_config: str | None = None,
 ):
     http_method = _normalize_http_method(method)
     resolved_route = _normalize_api_route(route)
@@ -359,6 +371,7 @@ def api(
         user_types=user_types,
         roles=roles,
     )
+    resolved_enabled_config = str(enabled_config).strip() if enabled_config else None
 
     def _wrap(fn):
         setattr(
@@ -372,6 +385,7 @@ def api(
                 user_types=resolved_user_types,
                 roles=resolved_roles,
                 public_auth=resolved_public_auth,
+                enabled_config=resolved_enabled_config,
             ),
         )
         return fn
@@ -385,11 +399,13 @@ def ui_widget(
         alias: str | None = None,
         user_types: List[str] | Tuple[str, ...] | None = None,
         roles: List[str] | Tuple[str, ...] | None = None,
+        enabled_config: str | None = None,
 ):
     resolved_user_types, resolved_roles = _normalize_visibility_selectors(
         user_types=user_types,
         roles=roles,
     )
+    resolved_enabled_config = str(enabled_config).strip() if enabled_config else None
 
     def _wrap(fn):
         setattr(
@@ -401,6 +417,7 @@ def ui_widget(
                 icon=_normalize_icon_spec(icon),
                 user_types=resolved_user_types,
                 roles=resolved_roles,
+                enabled_config=resolved_enabled_config,
             ),
         )
         return fn
@@ -416,6 +433,7 @@ def mcp(
         user_types: List[str] | Tuple[str, ...] | None = None,
         roles: List[str] | Tuple[str, ...] | None = None,
         public_auth: str | Dict[str, Any] | None = None,
+        enabled_config: str | None = None,
 ):
     resolved_route = _normalize_api_route(route)
     resolved_transport = _normalize_mcp_transport(transport)
@@ -424,6 +442,7 @@ def mcp(
             "@mcp(...) does not support proc-side visibility or public_auth. "
             "MCP request authentication/authorization must be handled by the bundle MCP app."
         )
+    resolved_enabled_config = str(enabled_config).strip() if enabled_config else None
 
     def _wrap(fn):
         setattr(
@@ -434,6 +453,7 @@ def mcp(
                 alias=_clean_alias(alias, getattr(fn, "__name__", "mcp")),
                 route=resolved_route,
                 transport=resolved_transport,
+                enabled_config=resolved_enabled_config,
             ),
         )
         return fn
@@ -512,6 +532,7 @@ def cron(
         timezone: str | None = None,
         tz_config: str | None = None,
         span: str = "system",
+        enabled_config: str | None = None,
 ):
     """
     Mark a bundle method as a scheduled job.
@@ -531,12 +552,16 @@ def cron(
             it takes precedence over ``timezone`` at runtime.
         span: exclusivity level — one of ``"process"``, ``"instance"``,
             ``"system"``. Defaults to ``"system"``.
+        enabled_config: dot-separated path into bundle props that resolves to
+            a boolean. If the resolved value is falsy, the job is not scheduled.
+            Absent or None means always enabled.
     """
     span_norm = str(span).strip().lower() if span else "system"
     if span_norm not in _VALID_CRON_SPANS:
         raise ValueError(
             f"Invalid cron span: {span!r}. Must be one of: process, instance, system"
         )
+    resolved_enabled_config = str(enabled_config).strip() if enabled_config else None
 
     def _wrap(fn):
         method_name = getattr(fn, "__name__", "cron_job")
@@ -551,6 +576,7 @@ def cron(
                 timezone=str(timezone).strip() if timezone is not None else None,
                 tz_config=str(tz_config).strip() if tz_config is not None else None,
                 span=span_norm,
+                enabled_config=resolved_enabled_config,
             ),
         )
         return fn
@@ -1476,6 +1502,7 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 user_types=tuple(api_spec.user_types or ()),
                 roles=tuple(api_spec.roles or ()),
                 public_auth=api_spec.public_auth,
+                enabled_config=api_spec.enabled_config,
             )
             api_key = (resolved.alias, resolved.http_method, resolved.route)
             if api_key in seen_api:
@@ -1493,6 +1520,7 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 alias=mcp_spec.alias,
                 route=mcp_spec.route,
                 transport=mcp_spec.transport,
+                enabled_config=mcp_spec.enabled_config,
             )
             mcp_key = (resolved.alias, resolved.route)
             if mcp_key in seen_mcp:
@@ -1511,6 +1539,7 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 icon=dict(widget_spec.icon or {}),
                 user_types=tuple(widget_spec.user_types or ()),
                 roles=tuple(widget_spec.roles or ()),
+                enabled_config=widget_spec.enabled_config,
             )
             if resolved.alias in seen_widgets:
                 raise ValueError(f"Duplicate bundle widget alias detected: {resolved.alias}")
@@ -1541,10 +1570,12 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 timezone=cron_spec.timezone,
                 tz_config=cron_spec.tz_config,
                 span=cron_spec.span,
+                enabled_config=cron_spec.enabled_config,
             ))
 
     meta = getattr(cls, AGENTIC_META_ATTR, {}) or {}
     allowed_roles: tuple[str, ...] = _tuple_str(meta.get("allowed_roles"))
+    bundle_enabled_config: str | None = str(meta.get("enabled_config") or "").strip() or None
 
     api_endpoints.sort(key=lambda item: (item.alias, item.route, item.http_method, item.method_name))
     mcp_endpoints.sort(key=lambda item: (item.alias, item.route, item.transport, item.method_name))
@@ -1553,6 +1584,7 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
     return BundleInterfaceManifest(
         bundle_id=resolved_bundle_id,
         allowed_roles=allowed_roles,
+        enabled_config=bundle_enabled_config,
         ui_widgets=tuple(ui_widgets),
         api_endpoints=tuple(api_endpoints),
         mcp_endpoints=tuple(mcp_endpoints),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_store.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_store.py
@@ -1005,8 +1005,6 @@ class _FileBundleDescriptorStore:
             self._write_mapping(payload)
 
     def load_bundle_props(self, bundle_id: str) -> Dict[str, Any]:
-        if bundle_id in _reserved_bundle_ids():
-            return {}
         loaded = self.load_registry()
         if loaded is None:
             return {}
@@ -1014,13 +1012,15 @@ class _FileBundleDescriptorStore:
         return dict(props_map.get(bundle_id) or {})
 
     def set_bundle_props(self, bundle_id: str, entry: "BundleEntry", props: Dict[str, Any]) -> None:
-        if bundle_id in _reserved_bundle_ids():
-            return
         with self._lock, self._acquire_file_lock():
             payload = self._load_mapping()
             items = self._bundle_items(payload)
             item = _secrets_find_bundle_item(items, bundle_id)
             if item is None:
+                if bundle_id in _reserved_bundle_ids():
+                    # Reserved bundles not explicitly listed in the descriptor
+                    # are not written — no dangling entries created.
+                    return
                 item = self._item_from_entry(entry, props)
                 items.append(item)
             else:
@@ -1297,6 +1297,18 @@ async def _put_bundle_props_locked(
     key = _props_key(tenant=tenant, project=project, bundle_id=bundle_id)
     await redis.set(key, json.dumps(props, ensure_ascii=False))
     if bundle_id in _reserved_bundle_ids():
+        # Persist to the file-backed descriptor so that _sync_bundle_props_authoritative
+        # on the next load_registry call (triggered by the listener) doesn't revert
+        # Redis to stale YAML values.
+        store = _get_authoritative_bundle_store(tenant, project)
+        if isinstance(store, _FileBundleDescriptorStore):
+            entry = _reserved_bundle_entry(bundle_id)
+            if entry is None:
+                entry = BundleEntry(id=bundle_id, path="")
+            try:
+                store.set_bundle_props(bundle_id, entry, props)
+            except Exception:
+                _log.warning("Failed to persist reserved bundle props to descriptor", exc_info=True)
         try:
             await publish_props_update(
                 redis,


### PR DESCRIPTION
  What changed:

  - agentic_loader.py: add enabled_config to APIEndpointSpec, UIWidgetSpec, MCPEndpointSpec, CronJobSpec, and BundleInterfaceManifest
  - bundle_scheduler.py: add resolve_effective_enabled(); check bundle-level manifest.enabled_config before the per-job loop, then check per-job enabled_config — a disabled bundle skips all its cron jobs unconditionally
  - integrations.py: add _is_enabled_from_props(); enforce bundle-level then resource-level enabled_config on widget fetch, MCP dispatch, and API operations; expose enabled_config in bundle and resource descriptors
  - bundle-platform-integration-README.md: document enabled_config on all decorators and specs; note enforcement points
  - bundle-scheduled-jobs-README.md: add timezone/tz_config/enabled_config to decorator reference; add bundle-level enabled override section