### PR TITLE
[CLI]: Subcommands, deployment guard, operator defaults

### DIFF
--- a/app/ai-app/docs/configuration/bundle-runtime-configuration-and-secrets-README.md
+++ b/app/ai-app/docs/configuration/bundle-runtime-configuration-and-secrets-README.md
@@ -87,9 +87,9 @@ Those remain deployment-owned.
 
 | Data class | Read API | Write API from bundle code | Ownership boundary | Live authority today | Export / ejection path |
 |---|---|---|---|---|---|
-| platform/global props | `get_settings()` for effective values; `get_plain("...")` for raw descriptor inspection | none supported | tenant + project deployment | promoted runtime config assembled from env plus descriptor files such as `assembly.yaml` and `gateway.yaml` | outside `kdcube --export-live-bundles`; manage through deployment descriptors |
-| platform/global secrets | `get_secret("canonical.key")` | none supported | tenant + project deployment | configured secrets provider; in local `secrets-file` mode this is `secrets.yaml` | outside `kdcube --export-live-bundles`; manage through deployment secret workflows |
-| deployment-scoped bundle props | `self.bundle_prop(...)`, `self.bundle_props` | `await set_bundle_prop(...)` | tenant + project + bundle | configured bundle descriptor authority; Redis is the runtime cache. Recommended cloud mode is writable mounted `bundles.yaml` with `BUNDLES_DESCRIPTOR_PROVIDER=file`. | exported to `bundles.yaml`; `kdcube --export-live-bundles` includes it |
+| platform/global props | `get_settings()` for effective values; `get_plain("...")` for raw descriptor inspection | none supported | tenant + project deployment | promoted runtime config assembled from env plus descriptor files such as `assembly.yaml` and `gateway.yaml` | outside `kdcube export`; manage through deployment descriptors |
+| platform/global secrets | `get_secret("canonical.key")` | none supported | tenant + project deployment | configured secrets provider; in local `secrets-file` mode this is `secrets.yaml` | outside `kdcube export`; manage through deployment secret workflows |
+| deployment-scoped bundle props | `self.bundle_prop(...)`, `self.bundle_props` | `await set_bundle_prop(...)` | tenant + project + bundle | configured bundle descriptor authority; Redis is the runtime cache. Recommended cloud mode is writable mounted `bundles.yaml` with `BUNDLES_DESCRIPTOR_PROVIDER=file`. | exported to `bundles.yaml`; `kdcube export` includes it |
 | deployment-scoped bundle secrets | `get_secret("b:...")` | `await set_bundle_secret(...)` | tenant + project + bundle | configured secrets provider; in local `secrets-file` mode this is `bundles.secrets.yaml` | exported to `bundles.secrets.yaml` when the provider/export flow can reconstruct them |
 | user-scoped bundle props | `get_user_prop(...)`, `get_user_props()` | `set_user_prop(...)`, `delete_user_prop(...)` | tenant + project + bundle + user | PostgreSQL `<SCHEMA>.user_bundle_props` | never exported to descriptors or bundle export |
 | user-scoped bundle secrets | `get_user_secret(...)` | `set_user_secret(...)`, `delete_user_secret(...)` | tenant + project + bundle + user | configured secrets provider; in local `secrets-file` mode this is `secrets.yaml` | never exported to descriptors or bundle export |
@@ -222,7 +222,7 @@ Important ownership rule:
 
 ## Export and ejection rules
 
-`kdcube --export-live-bundles` is bundle-state export only.
+`kdcube export` is bundle-state export only.
 
 It exports:
 

--- a/app/ai-app/docs/configuration/bundles-descriptor-README.md
+++ b/app/ai-app/docs/configuration/bundles-descriptor-README.md
@@ -242,7 +242,7 @@ Reload workflow:
 - run:
 
 ```bash
-kdcube --bundle-reload <bundle_id> --workdir <runtime-workdir> --path <repo-root>
+kdcube reload <bundle_id> --workdir <runtime-workdir> --path <repo-root>
 ```
 
 That reapplies the mounted descriptor and clears proc bundle caches.
@@ -294,7 +294,7 @@ For local development with code edits on the host:
 - define the bundle in `bundles.yaml` with `path: /bundles/...`
 - set `assembly.paths.host_bundles_path` to the matching host root
 - run KDCube via the CLI compose path
-- use `kdcube --bundle-reload <bundle_id>` after code changes
+- use `kdcube reload <bundle_id>` after code changes
 
 That is the correct local dev contract.
 

--- a/app/ai-app/docs/configuration/runtime-configuration-and-secrets-store-README.md
+++ b/app/ai-app/docs/configuration/runtime-configuration-and-secrets-store-README.md
@@ -24,7 +24,7 @@ Use this page when you need to know:
 - what Redis does and does not own
 - what changes in local file mode vs `aws-sm`
 - where bundle prop writes persist
-- what `kdcube --export-live-bundles` can reconstruct
+- what `kdcube export` can reconstruct
 
 If you are deciding where a value belongs as a bundle author, start with:
 
@@ -150,7 +150,7 @@ User-scoped bundle state is intentionally outside descriptors.
 
 That is why:
 
-- user state is not exported by `kdcube --export-live-bundles`
+- user state is not exported by `kdcube export`
 - user state is not reconstructed into `bundles.yaml`
 - user state is not reconstructed into `bundles.secrets.yaml`
 
@@ -174,7 +174,7 @@ So `aws-sm` is not “one single JSON blob for everything”.
 
 ## Export and ejection behavior
 
-`kdcube --export-live-bundles` is bundle-state export only.
+`kdcube export` is bundle-state export only.
 
 It reconstructs:
 

--- a/app/ai-app/docs/quick-start-README.md
+++ b/app/ai-app/docs/quick-start-README.md
@@ -123,10 +123,10 @@ If you are developing a mounted local bundle:
 4. after bundle code or descriptor changes, reload:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime --bundle-reload <bundle_id>
+kdcube reload <bundle_id> --workdir ~/.kdcube/kdcube-runtime
 ```
 
-`--bundle-reload`:
+`reload`:
 
 - reapplies the bundle registry from the active descriptor/env state
 - rebuilds descriptor-backed bundle props from `bundles.yaml`
@@ -141,13 +141,13 @@ Bundle docs:
 ## 6. Stop the local stack
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime --stop
+kdcube stop --workdir ~/.kdcube/kdcube-runtime
 ```
 
 Remove local volumes too:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime --stop --remove-volumes
+kdcube stop --workdir ~/.kdcube/kdcube-runtime --remove-volumes
 ```
 
 ## Quick mental model

--- a/app/ai-app/docs/sdk/bundle/build/how-to-configure-and-run-bundle-README.md
+++ b/app/ai-app/docs/sdk/bundle/build/how-to-configure-and-run-bundle-README.md
@@ -36,7 +36,7 @@ Use it when you need to answer questions like:
 - what does `--workdir` really point to
 - where are the active descriptor files after install
 - how do I point a bundle at my local source tree
-- when should I rerun install vs `--bundle-reload`
+- when should I rerun install vs `kdcube reload`
 - how do I avoid overwriting live bundle props/secrets with stale descriptor copies
 
 This page is not the primary source for bundle design or test strategy.
@@ -129,7 +129,7 @@ Use this page to answer:
 
 - how to point one deployment at one bundle path or git ref
 - how `--workdir` resolves
-- when to rerun install versus using `--bundle-reload`
+- when to rerun install versus using `kdcube reload`
 - how to inspect one runtime and how to avoid changing the wrong deployment
 - how to think about one active local deployment versus many runtime snapshots
 
@@ -379,16 +379,16 @@ For the exact helper contract and cloud-mode differences, use:
 
 | Scope | Typical examples | Read / write API | Live authority in the local runtime | Export / ejection path |
 |---|---|---|---|---|
-| platform/global props | ports, auth ids, storage backends, path roots | `get_settings()` for effective values; `get_plain("...")` for raw descriptor inspection; no supported write API from bundle code | staged `assembly.yaml` and `gateway.yaml` under `workdir/config/`, plus env | not part of `kdcube --export-live-bundles`; manage through the deployment descriptor set |
-| platform/global secrets | deployment-wide API keys, auth secrets | `get_secret("canonical.key")`; no supported write API from bundle code | `secrets.yaml` only when `secrets-file` is active; otherwise the configured secrets provider | not part of `kdcube --export-live-bundles`; manage through deployment secret workflows |
-| deployment-scoped bundle props | feature flags, cron expressions, model selection, bundle UI config | read: `self.bundle_prop(...)`; write: `await set_bundle_prop(...)` | `workdir/config/bundles.yaml` when file-backed descriptor mode is active, with Redis as runtime cache | exported by `kdcube --export-live-bundles` to `bundles.yaml` |
-| deployment-scoped bundle secrets | webhook secrets, shared API tokens, bundle-specific credentials | read: `get_secret("b:...")`; write: `await set_bundle_secret(...)` | `workdir/config/bundles.secrets.yaml` only in local `secrets-file` mode; otherwise the configured secrets provider | exported by `kdcube --export-live-bundles` to `bundles.secrets.yaml` when the provider/export flow can reconstruct them |
+| platform/global props | ports, auth ids, storage backends, path roots | `get_settings()` for effective values; `get_plain("...")` for raw descriptor inspection; no supported write API from bundle code | staged `assembly.yaml` and `gateway.yaml` under `workdir/config/`, plus env | not part of `kdcube export`; manage through the deployment descriptor set |
+| platform/global secrets | deployment-wide API keys, auth secrets | `get_secret("canonical.key")`; no supported write API from bundle code | `secrets.yaml` only when `secrets-file` is active; otherwise the configured secrets provider | not part of `kdcube export`; manage through deployment secret workflows |
+| deployment-scoped bundle props | feature flags, cron expressions, model selection, bundle UI config | read: `self.bundle_prop(...)`; write: `await set_bundle_prop(...)` | `workdir/config/bundles.yaml` when file-backed descriptor mode is active, with Redis as runtime cache | exported by `kdcube export` to `bundles.yaml` |
+| deployment-scoped bundle secrets | webhook secrets, shared API tokens, bundle-specific credentials | read: `get_secret("b:...")`; write: `await set_bundle_secret(...)` | `workdir/config/bundles.secrets.yaml` only in local `secrets-file` mode; otherwise the configured secrets provider | exported by `kdcube export` to `bundles.secrets.yaml` when the provider/export flow can reconstruct them |
 | user-scoped bundle props | one user's preferences or bundle-managed non-secret state | read/write: `get_user_prop(...)`, `set_user_prop(...)`, `delete_user_prop(...)` | PostgreSQL user bundle props table | never exported |
 | user-scoped bundle secrets | one user's personal tokens or credentials managed by the bundle | read/write: `get_user_secret(...)`, `set_user_secret(...)`, `delete_user_secret(...)` | configured secrets provider; in local `secrets-file` mode this is `secrets.yaml` | never exported |
 
 Two hard rules:
 
-- `kdcube --export-live-bundles` is a bundle-state export only. It exports `bundles.yaml` and `bundles.secrets.yaml`. It does not export `assembly.yaml`, `gateway.yaml`, `secrets.yaml`, user props, or user secrets.
+- `kdcube export` is a bundle-state export only. It exports `bundles.yaml` and `bundles.secrets.yaml`. It does not export `assembly.yaml`, `gateway.yaml`, `secrets.yaml`, user props, or user secrets.
 - Bundle Admin writes live deployment-scoped bundle state only. It does not rewrite platform/global deployment descriptors.
 
 ## One Environment Can Host Many Bundles
@@ -571,7 +571,7 @@ Use this when you are validating current platform source, not when you only need
 ### Show active runtime info
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject --info
+kdcube --info --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject
 ```
 
 This prints:
@@ -590,13 +590,13 @@ Use `--info` whenever you are not sure which runtime or mount mapping you are ac
 ### Stop the runtime
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject --stop
+kdcube stop --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject
 ```
 
 With volumes removed:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject --stop --remove-volumes
+kdcube stop --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject --remove-volumes
 ```
 
 ## Local Path Bundles vs Git Bundles
@@ -704,7 +704,7 @@ kdcube \
   --descriptors-location /abs/path/to/descriptors
 ```
 
-This is required because `--bundle-reload` does not read arbitrary external descriptor directories. It reuses the runtime’s staged descriptor files.
+This is required because `kdcube reload` does not read arbitrary external descriptor directories. It reuses the runtime’s staged descriptor files.
 
 ### If you changed `bundles.yaml` or `bundles.secrets.yaml` inside the active runtime
 
@@ -718,10 +718,10 @@ After editing:
 apply the change with:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject --bundle-reload my.bundle@1-0
+kdcube reload my.bundle@1-0 --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject
 ```
 
-`--bundle-reload`:
+`reload`:
 
 - validates that the bundle id exists in the active runtime descriptor
 - requires `chat-proc` to be running
@@ -743,7 +743,7 @@ It does not reload:
 
 ### If you changed platform/runtime topology
 
-Rerun install, not only `--bundle-reload`.
+Rerun install, not only `kdcube reload`.
 
 Typical cases:
 
@@ -759,7 +759,7 @@ Typical cases:
 If the bundle is already mounted as a local path bundle, you often only need a reload:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject --bundle-reload my.bundle@1-0
+kdcube reload my.bundle@1-0 --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject
 ```
 
 Use a full reinstall only when code changes depend on wider runtime/platform changes.
@@ -821,7 +821,7 @@ Operational behavior:
 After changing the prop, apply it with:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject --bundle-reload my.bundle@1-0
+kdcube reload my.bundle@1-0 --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject
 ```
 
 ## What Happens When Bundle Admin Changes Props Or Secrets
@@ -849,9 +849,8 @@ That is why you should export live bundle state before replacing runtime descrip
 To export the current effective bundle descriptors:
 
 ```bash
-kdcube \
+kdcube export \
   --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject \
-  --export-live-bundles \
   --out-dir /tmp/live-bundles
 ```
 
@@ -927,7 +926,7 @@ But for normal bundle development, prefer a descriptor-driven initialized runtim
 - Mixing `path` with `repo`/`ref`/`subdir` in the same bundle entry.
 - Using `--upstream` without `--build`.
 - Assuming the base `--workdir` is the concrete runtime when the CLI has resolved a namespaced runtime under it.
-- Using `--bundle-reload` before the stack is running.
+- Using `kdcube reload` before the stack is running.
 - Overwriting live bundle-admin changes with stale descriptor source files.
 
 ## What To Remember
@@ -940,9 +939,9 @@ If you only remember the essentials, remember these:
 - `bundles.secrets.yaml` owns deployment-scoped bundle secrets
 - local path bundles should use runtime-visible `/bundles/...` paths
 - rerun install when you changed the canonical source descriptor set or runtime topology
-- use `--bundle-reload` when you changed active runtime bundle descriptors or need proc cache eviction
-- use `--info` to inspect the runtime you are actually using
-- use `--export-live-bundles` before overwriting runtime bundle state with older descriptor copies
+- use `kdcube reload <bundle_id>` when you changed active runtime bundle descriptors or need proc cache eviction
+- use `kdcube --info --workdir <path>` to inspect the runtime you are actually using
+- use `kdcube export` before overwriting runtime bundle state with older descriptor copies
 
 For the exact read/write helper contract behind those rules, use:
 

--- a/app/ai-app/docs/sdk/bundle/build/how-to-test-bundle-README.md
+++ b/app/ai-app/docs/sdk/bundle/build/how-to-test-bundle-README.md
@@ -630,7 +630,7 @@ kdcube --descriptors-location <dir> --build
 Then after code/descriptor changes:
 
 ```bash
-kdcube --workdir <runtime-workdir> --bundle-reload <bundle_id>
+kdcube reload <bundle_id> --workdir <runtime-workdir>
 ```
 
 This is important because a bundle may pass tests but still fail during descriptor-driven runtime resolution.

--- a/app/ai-app/docs/sdk/bundle/bundle-delivery-and-update-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-delivery-and-update-README.md
@@ -43,16 +43,16 @@ kdcube --descriptors-location <dir> --build
 4. after code or descriptor changes:
 
 ```bash
-kdcube --workdir <runtime-workdir> --bundle-reload <bundle_id>
+kdcube reload <bundle_id> --workdir <runtime-workdir>
 ```
 
 Example:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime --bundle-reload versatile@2026-03-31-13-36
+kdcube reload versatile@2026-03-31-13-36 --workdir ~/.kdcube/kdcube-runtime
 ```
 
-`--bundle-reload` is descriptor-authoritative:
+`kdcube reload` is descriptor-authoritative:
 
 - reapplies the bundle registry from descriptor/env state
 - rebuilds descriptor-backed bundle props from `bundles.yaml`
@@ -73,7 +73,7 @@ Local mode is the only mode where editing mounted descriptors directly is the no
 Typical change:
 
 1. edit `bundles.yaml` and/or `bundles.secrets.yaml`
-2. run `kdcube --bundle-reload <bundle_id>`
+2. run `kdcube reload <bundle_id>`
 
 ### Runtime-only override
 

--- a/app/ai-app/docs/sdk/bundle/bundle-developer-guide-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-developer-guide-README.md
@@ -352,10 +352,10 @@ kdcube --descriptors-location <dir> --build
 4. after each code or descriptor change, reload:
 
 ```bash
-kdcube --workdir <runtime-workdir> --bundle-reload my.bundle@1.0.0
+kdcube reload my.bundle@1.0.0 --workdir <runtime-workdir>
 ```
 
-What `--bundle-reload` does:
+What `kdcube reload` does:
 
 - reapplies the bundle registry from descriptor/env state
 - rebuilds descriptor-backed bundle props from `bundles.yaml`
@@ -367,7 +367,7 @@ Use this when you changed:
 - `bundles.yaml`
 - `bundles.secrets.yaml`
 
-If your bundle uses local bundle storage, `--bundle-reload` does not wipe that storage automatically.
+If your bundle uses local bundle storage, `kdcube reload` does not wipe that storage automatically.
 Design your subsystem roots intentionally:
 - stable bundle root for all bundle-managed local data
 - explicit `_subsystem` roots for mutable local working state

--- a/app/ai-app/docs/sdk/bundle/bundle-lifecycle-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-lifecycle-README.md
@@ -195,12 +195,12 @@ Three classes of changes matter during bundle development:
 
 2. **Descriptor-backed bundle config**
    - comes from `bundles.yaml`
-   - affects new requests after proc reapplies the descriptor (`reset-env` / CLI `--bundle-reload`)
+   - affects new requests after proc reapplies the descriptor (`reset-env` / `kdcube reload`)
 
 3. **Bundle code changes**
    - require proc cache eviction before the next request should load the updated module
    - for local development, the intended path is:
-     - `kdcube --workdir <runtime-workdir> --bundle-reload <bundle_id>`
+     - `kdcube reload <bundle_id> --workdir <runtime-workdir>`
 
 4. **`@venv` requirements changes**
    - if only `requirements.txt` changed, the next call to the decorated function will rebuild the cached venv automatically

--- a/app/ai-app/docs/sdk/bundle/bundle-reserved-platform-properties-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-reserved-platform-properties-README.md
@@ -170,7 +170,7 @@ Storage summary:
 | Where do I set it? | `config.embedding` in bundle props |
 | Is it in secrets? | no |
 | Is it in PostgreSQL `user_bundle_props`? | no |
-| Is it exportable by `kdcube --export-live-bundles`? | yes |
+| Is it exportable by `kdcube export`? | yes |
 
 ## `economics.reservation_amount_dollars`
 
@@ -337,7 +337,7 @@ Storage summary:
 |---|---|
 | Where is it configured? | `config.execution.runtime` in bundle props |
 | Where is it persisted on `aws-sm`? | bundle descriptor doc in AWS SM |
-| Where is it exported from? | `kdcube --export-live-bundles` reconstructs it into `bundles.yaml` |
+| Where is it exported from? | `kdcube export` reconstructs it into `bundles.yaml` |
 
 ## `mcp.services`
 
@@ -401,8 +401,7 @@ Reserved platform properties are not exported separately. They are exported as
 part of the bundle descriptor `config`:
 
 ```bash
-kdcube \
-  --export-live-bundles \
+kdcube export \
   --tenant <tenant> \
   --project <project> \
   --aws-region <region> \

--- a/app/ai-app/docs/sdk/bundle/bundle-venv-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-venv-README.md
@@ -96,7 +96,7 @@ Changing only `requirements.txt`:
 Typical local loop:
 
 ```bash
-kdcube --workdir <runtime-workdir> --bundle-reload <bundle_id>
+kdcube reload <bundle_id> --workdir <runtime-workdir>
 ```
 
 That reload is for bundle code and descriptor-backed config. The venv cache is separate.

--- a/app/ai-app/docs/service/cicd/cli-README.md
+++ b/app/ai-app/docs/service/cicd/cli-README.md
@@ -304,8 +304,7 @@ For ECS / `aws-sm` deployments, the current effective live deployment-scoped
 bundle state can be exported directly from AWS Secrets Manager:
 
 ```bash
-kdcube \
-  --export-live-bundles \
+kdcube export \
   --tenant <tenant> \
   --project <project> \
   --aws-region <region> \
@@ -391,7 +390,7 @@ It is separate from the broader descriptor mounts used by `read_plain(...)`.
 
 In `aws-sm` deployments, `bundles.yaml` is the descriptor/export shape, but the
 live authoritative deployment-scoped bundle state is stored in grouped AWS SM
-documents and can be exported back with `--export-live-bundles`. In that mode,
+documents and can be exported back with `kdcube export`. In that mode,
 mounted `/config/bundles.yaml` is only a deploy snapshot, not the live
 authoritative store.
 
@@ -547,14 +546,138 @@ This is intended for **local development** only.
 
 ## 9) Operational commands
 
+Inspect global CLI state (defaults + running deployment):
+
+```bash
+kdcube --info
+```
+
+Inspect a specific workdir deployment:
+
+```bash
+kdcube --info --workdir ~/.kdcube/kdcube-runtime/acme__prod
+```
+
+Initialize a workdir without starting Docker:
+
+```bash
+kdcube init \
+  --workdir ~/.kdcube/kdcube-runtime \
+  --descriptors-location /path/to/descriptors \
+  --latest
+```
+
+Start the stack for an already-initialized workdir:
+
+```bash
+kdcube start --workdir ~/.kdcube/kdcube-runtime/acme__prod
+```
+
+Reload a bundle after descriptor changes:
+
+```bash
+kdcube reload <bundle_id> --workdir ~/.kdcube/kdcube-runtime/acme__prod
+```
+
+Export live bundle descriptors:
+
+```bash
+kdcube export --workdir ~/.kdcube/kdcube-runtime/acme__prod --out-dir /tmp/export
+```
+
 Stop the local workdir stack:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime --stop
+kdcube stop --workdir ~/.kdcube/kdcube-runtime
 ```
 
 Stop and remove volumes too:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime --stop --remove-volumes
+kdcube stop --workdir ~/.kdcube/kdcube-runtime --remove-volumes
 ```
+
+Save operator defaults:
+
+```bash
+kdcube defaults \
+  --default-workdir ~/.kdcube/kdcube-runtime \
+  --default-tenant acme \
+  --default-project prod
+```
+
+---
+
+## 10) Operator defaults (`kdcube defaults`)
+
+`kdcube defaults` persists values to `~/.kdcube/cli-defaults.json`:
+
+| Field | Flag | Purpose |
+|---|---|---|
+| `default_workdir` | `--default-workdir` | Fallback workdir when `--workdir` is omitted from a subcommand |
+| `default_tenant` | `--default-tenant` | Displayed in global `--info`; used by `kdcube export` as fallback tenant |
+| `default_project` | `--default-project` | Displayed in global `--info`; used by `kdcube export` as fallback project |
+
+`kdcube start`, `kdcube stop`, `kdcube reload`, and `kdcube export` resolve the
+target workdir with the following precedence:
+
+1. `--workdir` passed explicitly → use it.
+2. `--workdir` omitted, `default_workdir` present in `cli-defaults.json` → use
+   that.
+3. Neither provided → error:
+   ```
+   No target workdir specified.
+   Pass --workdir explicitly or configure a default:
+     kdcube defaults --default-workdir <path>
+   ```
+
+`kdcube --info` (without `--workdir`) reads `cli-defaults.json` and displays the
+configured values, or reports that no defaults are set.
+
+---
+
+## 11) Single-deployment guard (`cli-lock.json`)
+
+The file `~/.kdcube/cli-lock.json` is a per-machine deployment lock.
+
+It is written when a deployment starts and cleared when it stops.
+
+Format:
+
+```json
+{
+  "tenant": "...",
+  "project": "...",
+  "workdir": "...",
+  "docker_dir": "...",
+  "env_file": "..."
+}
+```
+
+### Guard at start (`kdcube start`)
+
+Before starting, the CLI reads the lock and runs `docker compose ps` against it:
+
+- No lock → proceed normally.
+- Lock matches the target `tenant/project` → proceed (same deployment restart).
+- Lock points to a **different** deployment and services are **live** → abort with
+  a message showing which deployment is running and how to stop it first.
+- Lock points to a different deployment but services are **not live** (stale) →
+  lock is cleared automatically, start proceeds.
+
+### Guard at stop (`kdcube stop`)
+
+Before stopping, the CLI checks:
+
+1. `docker compose ps` for the target workdir — if nothing is running →
+   `"Deployment is not running"`.
+2. If something is running and the lock matches the target `tenant/project` →
+   stop and clear the lock.
+3. If something is running but the lock points to a **different** deployment →
+   abort with a message identifying the running deployment.
+
+### `kdcube --info` and stale locks
+
+Global `kdcube --info` (without `--workdir`) verifies the recorded lock via
+`docker compose ps`. If the recorded deployment is no longer running, the lock
+is considered stale, reported as such, and cleared automatically.

--- a/app/ai-app/docs/service/content-properties-secrets-mgmt-README.md
+++ b/app/ai-app/docs/service/content-properties-secrets-mgmt-README.md
@@ -267,8 +267,7 @@ Build from:
 The CLI can export the current live state with IAM only:
 
 ```bash
-kdcube \
-  --export-live-bundles \
+kdcube export \
   --tenant <tenant> \
   --project <project> \
   --aws-region <region> \

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/README.md
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/README.md
@@ -7,13 +7,6 @@ repository (if needed) and launches the guided setup wizard.
 
 This README describes the current implemented CLI behavior.
 
-It does not describe the planned deployment-first CLI redesign with
-`kdcube init`, `kdcube defaults`, `kdcube start/stop`, `kdcube reload`, and
-profile-driven local/cloud targeting. That future model is design-only today
-and is tracked in:
-
-- `app/ai-app/docs/service/cicd/design/cli--as-control-plane-README.md`
-
 Short version of the current model:
 
 - the CLI bootstraps or reuses a concrete runtime snapshot under a namespaced
@@ -241,8 +234,7 @@ For `aws-sm` deployments, you can also export the current effective live
 deployment-scoped bundle descriptors directly from AWS Secrets Manager:
 
 ```bash
-kdcube \
-  --export-live-bundles \
+kdcube export \
   --tenant <tenant> \
   --project <project> \
   --aws-region <region> \
@@ -307,16 +299,8 @@ what is incomplete.
 | `--latest` | With `--descriptors-location`, resolve the latest platform release instead of using `assembly.yaml -> platform.ref`. |
 | `--upstream` | With `--build`, use the latest upstream repo state (`origin/main`) instead of a released platform ref. Requires either `--descriptors-location` or an initialized runtime with the canonical descriptor set under `config/`. |
 | `--release <ref>` | With `--descriptors-location`, use the given platform release instead of `assembly.yaml -> platform.ref`. |
-| `--bundle-reload <bundle_id>` | Reapply `config/bundles.yaml` from the active runtime workspace and clear proc bundle caches for local development. |
-| `--info` | Print resolved runtime info for the selected workdir, including descriptor paths, install metadata, and host/container bundle mount mappings. |
-| `--export-live-bundles` | Export effective live `bundles.yaml` and `bundles.secrets.yaml` from the active bundle authority: workspace descriptors when present, otherwise AWS SM grouped bundle docs. |
-| `--tenant <id>` / `--project <id>` | Scope for `--export-live-bundles` when exporting from AWS SM. Ignored when workspace descriptors are exported directly. |
-| `--out-dir <dir>` | Output directory for `--export-live-bundles`. |
-| `--aws-region <region>` | AWS region for `--export-live-bundles` when exporting from AWS SM. |
-| `--aws-profile <profile>` | AWS profile for `--export-live-bundles` when exporting from AWS SM. |
-| `--aws-sm-prefix <prefix>` | Explicit AWS SM prefix for `--export-live-bundles` when exporting from AWS SM. |
-| `--stop` | Stop the local Docker Compose stack for the selected workdir. |
-| `--remove-volumes` | With `--stop`, also remove local volumes. |
+| `--info` | Print global CLI state (defaults, running deployment). With `--workdir`, print resolved runtime info for that workdir: descriptor paths, install metadata, and host/container bundle mount mappings. |
+| `--remove-volumes` | With `kdcube stop`, also remove local volumes. |
 | `--reset-config` | Re‑prompt for config values without deleting files. |
 | `--reset` | Alias for `--reset-config`. |
 | `--clean` | Clean local Docker cache and unused KDCube images. |
@@ -326,6 +310,75 @@ what is incomplete.
 | `--no-proxy-ssl` | Force non‑SSL proxy config (overrides assembly descriptor). |
 | `--dry-run` | Generate env files and print their paths without running Docker. |
 | `--dry-run-print-env` | With `--dry-run`, also print the full env file contents. |
+
+### Subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `kdcube init [--workdir <path>] [--descriptors-location <dir>] [--latest\|--upstream\|--release <ref>\|--build] [-i]` | Initialize a workdir (stage descriptors, generate env files) **without** starting Docker. |
+| `kdcube start [--workdir <path>] [--build]` | Start the Docker Compose stack for an already-initialized workdir. |
+| `kdcube stop [--workdir <path>] [--remove-volumes]` | Stop the local Docker Compose stack. |
+| `kdcube reload <bundle_id> [--workdir <path>]` | Reapply `bundles.yaml` from the active runtime and clear proc bundle caches. |
+| `kdcube export [--workdir <path>] [--tenant <id>] [--project <id>] [--out-dir <dir>] [--aws-region <region>]` | Export effective live `bundles.yaml` and `bundles.secrets.yaml`. |
+| `kdcube defaults [--default-workdir <path>] [--default-tenant <t>] [--default-project <p>]` | Save persistent operator defaults to `~/.kdcube/cli-defaults.json`. |
+
+### Operator defaults (`kdcube defaults`)
+
+`kdcube defaults` persists values to `~/.kdcube/cli-defaults.json`:
+
+| Field | Flag | Purpose |
+|---|---|---|
+| `default_workdir` | `--default-workdir` | Fallback workdir when `--workdir` is omitted from a subcommand |
+| `default_tenant` | `--default-tenant` | Displayed in global `--info`; used by `kdcube export` as fallback tenant |
+| `default_project` | `--default-project` | Displayed in global `--info`; used by `kdcube export` as fallback project |
+
+`kdcube start`, `kdcube stop`, `kdcube reload`, and `kdcube export` resolve the
+target workdir with the following precedence:
+
+1. `--workdir` passed explicitly → use it.
+2. `--workdir` omitted, `default_workdir` present in `cli-defaults.json` → use that.
+3. Neither provided → error with a hint to run `kdcube defaults --default-workdir <path>`.
+
+`kdcube --info` (without `--workdir`) reads `cli-defaults.json` and displays the
+configured values, or reports that no defaults are set.
+
+### Single-deployment guard (`cli-lock.json`)
+
+`~/.kdcube/cli-lock.json` is a per-machine deployment lock written on start and
+cleared on stop.
+
+Format:
+
+```json
+{
+  "tenant": "...",
+  "project": "...",
+  "workdir": "...",
+  "docker_dir": "...",
+  "env_file": "..."
+}
+```
+
+**Guard at start (`kdcube start`)** — reads the lock and runs `docker compose ps`:
+
+- No lock → proceed.
+- Lock matches the target `tenant/project` → proceed (same deployment restart).
+- Lock points to a **different** deployment and services are **live** → abort with
+  a message showing what is running and how to stop it first.
+- Lock exists but services are **not live** (stale) → lock cleared automatically,
+  start proceeds.
+
+**Guard at stop (`kdcube stop`)** — before stopping:
+
+1. Runs `docker compose ps` for the target workdir — nothing running →
+   `"Deployment is not running"`.
+2. Something running and lock matches the target `tenant/project` → stop and
+   clear the lock.
+3. Something running but lock points to a **different** deployment → abort.
+
+**`kdcube --info` and stale locks** — global `--info` verifies the lock via
+`docker compose ps`. If the recorded deployment is no longer running, the lock is
+reported as stale and cleared automatically.
 
 ### Use a local checkout (dev)
 
@@ -351,22 +404,28 @@ kdcube --clean
 Stop the local stack:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime --stop
+kdcube stop --workdir ~/.kdcube/kdcube-runtime
 ```
 
 Stop and remove volumes:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime --stop --remove-volumes
+kdcube stop --workdir ~/.kdcube/kdcube-runtime --remove-volumes
+```
+
+Inspect global CLI state (defaults + running deployment):
+
+```bash
+kdcube --info
 ```
 
 Inspect the resolved runtime, including how local non-git bundles are mounted:
 
 ```bash
-kdcube --workdir ~/.kdcube/kdcube-runtime/acme__prod_demo --info
+kdcube --info --workdir ~/.kdcube/kdcube-runtime/acme__prod_demo
 ```
 
-When `--workdir` points at the base workspace root, `--stop` resolves the
+When `--workdir` points at the base workspace root, `kdcube stop` resolves the
 single matching runtime namespace automatically. If there are multiple runtime
 namespaces under that base workspace, pass the concrete namespaced runtime path
 explicitly.
@@ -708,7 +767,7 @@ For local host-edited bundle development:
 - define the bundle with `path: /bundles/...`
 - set `assembly.paths.host_bundles_path` to the matching host root
 - run KDCube through the CLI compose path
-- use `kdcube --bundle-reload <bundle_id>` after code changes
+- use `kdcube reload <bundle_id>` after code changes
 
 For AWS deployment:
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -1207,6 +1207,27 @@ def _save_cli_defaults(data: dict) -> None:
     DEFAULT_DEFAULTS_FILE.write_text(json.dumps(data, indent=2))
 
 
+def _check_targeted_command_has_workdir(
+    *,
+    is_targeted_command: bool,
+    workdir_arg: bool,
+    cli_defaults: dict,
+) -> None:
+    """Raise SystemExit when a targeted command has no resolvable workdir.
+
+    Targeted commands (--stop, --info, --bundle-reload, --export-live-bundles)
+    require an explicit --workdir or a configured default_workdir.  Without
+    either, the CLI would silently fall back to DEFAULT_WORKDIR and either
+    pick the wrong deployment or emit a confusing "multiple candidates" error.
+    """
+    if is_targeted_command and not workdir_arg and "default_workdir" not in cli_defaults:
+        raise SystemExit(
+            "No target workdir specified.\n"
+            "Pass --workdir explicitly or configure a default:\n"
+            "  kdcube --set-defaults --default-workdir <path>"
+        )
+
+
 def _check_no_other_local_stack_running(
     console: Console,
     *,
@@ -1499,6 +1520,16 @@ def main() -> None:
         if args.clean:
             clean_docker_images(console)
             return
+        _check_targeted_command_has_workdir(
+            is_targeted_command=bool(
+                args.stop
+                or args.info
+                or str(args.bundle_reload or "").strip()
+                or args.export_live_bundles
+            ),
+            workdir_arg=workdir_arg,
+            cli_defaults=cli_defaults,
+        )
         if args.export_live_bundles:
             workdir = _resolve_cli_workdir(workdir)
             out_dir = Path(os.path.expanduser(args.out_dir or os.getcwd())).expanduser().resolve()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -1194,6 +1194,35 @@ def run_installer(
     )
 
 
+def _bootstrap_repo_for_defaults(
+    console: Console,
+    *,
+    repo: str,
+    repo_path: Path,
+    path_provided: bool,
+) -> tuple[Path, Path]:
+    """Ensure the platform repo exists and return (repo_path, descriptors_location).
+
+    Used when --descriptors-location is omitted but a source selector (--latest,
+    --upstream, --release, --build) implies non-interactive mode.  The repo's
+    deployment/ directory is used as the implicit descriptor source so that a
+    plain ``kdcube --build --upstream`` works without pre-prepared descriptors.
+    """
+    if path_provided:
+        if not _is_git_repo(repo_path):
+            raise SystemExit(f"Provided --path is not a git repo: {repo_path}")
+    else:
+        ensure_repo(console, repo, repo_path)
+
+    descriptors_location = repo_path / "app" / "ai-app" / "deployment"
+    if not descriptors_location.is_dir() or not (descriptors_location / "assembly.yaml").exists():
+        raise SystemExit(
+            f"Could not find deployment descriptors under {descriptors_location}. "
+            "Ensure the platform repo contains app/ai-app/deployment/assembly.yaml."
+        )
+    return repo_path, descriptors_location
+
+
 def main() -> None:
     console = Console()
     print_cli_banner()
@@ -1402,11 +1431,6 @@ def main() -> None:
         selected_version_flags = int(bool(args.latest)) + int(bool(args.upstream)) + int(bool(str(args.release or "").strip()))
         if selected_version_flags > 1:
             raise SystemExit("Choose only one of --latest, --upstream, or --release.")
-        if args.upstream and effective_descriptors_location is None:
-            raise SystemExit(
-                "--upstream requires either --descriptors-location or an initialized workdir "
-                "with the canonical descriptor set under config/."
-            )
         if args.upstream and not args.build:
             raise SystemExit("--upstream requires --build because arbitrary upstream commits do not map to release images.")
         if args.proxy_ssl and args.no_proxy_ssl:
@@ -1453,6 +1477,29 @@ def main() -> None:
                 workdir=resolved_workdir,
             )
             return
+        # No-descriptors fast path: when a source selector is given without
+        # --descriptors-location (and no initialized workdir was found), bootstrap
+        # the platform repo and use its deployment/ directory as the descriptor
+        # source.  This lets operators run e.g. ``kdcube --build --upstream``
+        # without pre-preparing a descriptor set.
+        if (
+            effective_descriptors_location is None
+            and not args.secrets_set
+            and not args.secrets_prompt
+            and (args.latest or args.upstream or str(args.release or "").strip() or args.build)
+        ):
+            repo_path, effective_descriptors_location = _bootstrap_repo_for_defaults(
+                console,
+                repo=args.repo,
+                repo_path=repo_path,
+                path_provided=path_provided,
+            )
+            path_provided = True
+            console.print(
+                f"[dim]No --descriptors-location provided. "
+                f"Using repo defaults from:[/dim] {effective_descriptors_location}"
+            )
+
         if (
             not args.secrets_set
             and not args.secrets_prompt

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -34,6 +34,7 @@ DEFAULT_REPO = "https://github.com/kdcube/kdcube-ai-app.git"
 DEFAULT_DIR = Path.home() / ".kdcube" / "kdcube-ai-app"
 DEFAULT_WORKDIR = Path.home() / ".kdcube" / "kdcube-runtime"
 DEFAULT_DEFAULTS_FILE = Path.home() / ".kdcube" / "cli-defaults.json"
+CLI_LOCK_FILE = Path.home() / ".kdcube" / "cli-lock.json"
 DEFAULT_REPO_DIRNAME = "repo"
 KDCUBE_REPOS = {
     "kdcube-chat-ingress",
@@ -138,6 +139,8 @@ def stop_compose_stack(
             "Pass --workdir for the runtime you want to stop or re-run the installer first."
         )
 
+    _check_before_stop(workdir, env_file, ctx.docker_dir)
+
     cmd = [
         "docker",
         "compose",
@@ -150,10 +153,58 @@ def stop_compose_stack(
         cmd.append("-v")
 
     _run_compose(console, cmd, cwd=ctx.docker_dir)
+    _clear_cli_lock()
     console.print("[green]Docker compose stopped.[/green]")
     console.print(f"[dim]Workdir:[/dim] {workdir}")
     if not remove_volumes:
         console.print("[dim]Host data under the workdir was preserved.[/dim]")
+
+
+def start_compose_stack(
+    console: Console,
+    *,
+    repo_root: Path,
+    workdir: Path,
+    build: bool = False,
+) -> None:
+    ctx = _build_paths_for_repo(repo_root, workdir)
+    env_file = ctx.config_dir / ".env"
+    if not env_file.exists():
+        raise SystemExit(
+            f"Compose env file not found: {env_file}.\n"
+            "Initialize the workdir first:\n"
+            "  kdcube init"
+        )
+    env_main = installer_mod.load_env_file(env_file)
+    token_overrides = installer_mod.generate_runtime_tokens()
+    runtime_env = installer_mod.write_env_overlay(env_file, token_overrides)
+    _tenant, _project = _parse_workdir_namespace(workdir)
+    build_flag = ["--build"] if build else []
+    try:
+        _write_cli_lock(
+            tenant=_tenant, project=_project, workdir=workdir,
+            docker_dir=ctx.docker_dir, env_file=env_file,
+        )
+        _run_compose(
+            console,
+            ["docker", "compose", "--env-file", str(runtime_env), "up", "-d", *build_flag],
+            cwd=ctx.docker_dir,
+        )
+        console.print("[green]Docker compose started.[/green]")
+        proxy_http_port = (
+            env_main.entries.get("KDCUBE_PROXY_HTTP_PORT", (None, None))[1]
+            or env_main.entries.get("KDCUBE_UI_PORT", (None, None))[1]
+            or "80"
+        )
+        routes_prefix = installer_mod.resolve_frontend_routes_prefix(
+            env_main.entries.get("PATH_TO_FRONTEND_CONFIG_JSON", (None, None))[1]
+        )
+        proxy_url = installer_mod.build_ui_url(proxy_http_port, routes_prefix)
+        console.print("Open the UI:")
+        console.print(f"  [link={proxy_url}]{proxy_url}[/link]")
+    finally:
+        if runtime_env.exists():
+            runtime_env.unlink(missing_ok=True)
 
 
 def clean_docker_images(console: Console) -> None:
@@ -580,6 +631,41 @@ def print_runtime_info(console: Console, *, repo_root: Path, workdir: Path) -> N
             f"[dim]Example mapping:[/dim] {host_managed_bundles_path}/repo__bundle.demo__main "
             f"-> {container_managed_bundles_root}/repo__bundle.demo__main"
         )
+
+
+def print_global_info(console: Console, cli_defaults: dict) -> None:
+    console.print("[bold]KDCube Global Info[/bold]")
+
+    has_defaults = bool(cli_defaults)
+    if not has_defaults:
+        console.print("[dim]No defaults configured.[/dim]")
+        console.print(
+            "  Set defaults with: kdcube defaults --default-workdir <path> "
+            "--default-tenant <t> --default-project <p>"
+        )
+    else:
+        console.print(f"[dim]Default workdir:[/dim]  {cli_defaults.get('default_workdir') or '[not set]'}")
+        console.print(f"[dim]Default tenant:[/dim]   {cli_defaults.get('default_tenant') or '[not set]'}")
+        console.print(f"[dim]Default project:[/dim]  {cli_defaults.get('default_project') or '[not set]'}")
+
+    console.print()
+    lock = _read_cli_lock()
+    if lock is None:
+        console.print("[dim]No running deployment recorded.[/dim]")
+        return
+
+    running = _lock_running_services(lock)
+    if running:
+        console.print("[bold]Currently Running Deployment[/bold]")
+        console.print(f"  [dim]Tenant / project:[/dim] {lock.get('tenant') or '?'} / {lock.get('project') or '?'}")
+        console.print(f"  [dim]Workdir:[/dim]          {lock.get('workdir') or '?'}")
+        console.print(f"  [dim]Services:[/dim]         {', '.join(sorted(running))}")
+    else:
+        console.print("[yellow]Stale lock found (recorded deployment is not running).[/yellow]")
+        console.print(f"  Tenant / project: {lock.get('tenant') or '?'} / {lock.get('project') or '?'}")
+        console.print(f"  Workdir: {lock.get('workdir') or '?'}")
+        _clear_cli_lock()
+        console.print("[dim]Stale lock cleared.[/dim]")
 
 
 def _load_bundle_ids_from_descriptor(path: Path) -> set[str]:
@@ -1207,85 +1293,142 @@ def _save_cli_defaults(data: dict) -> None:
     DEFAULT_DEFAULTS_FILE.write_text(json.dumps(data, indent=2))
 
 
-def _check_targeted_command_has_workdir(
+def _parse_workdir_namespace(workdir: Path) -> tuple[str, str]:
+    name = workdir.name
+    if "__" in name:
+        tenant, _, project = name.partition("__")
+        return tenant, project
+    return "", name
+
+
+def _read_cli_lock() -> dict | None:
+    try:
+        return json.loads(CLI_LOCK_FILE.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+
+
+def _write_cli_lock(
     *,
-    is_targeted_command: bool,
-    workdir_arg: bool,
-    cli_defaults: dict,
+    tenant: str,
+    project: str,
+    workdir: Path,
+    docker_dir: Path,
+    env_file: Path,
 ) -> None:
-    """Raise SystemExit when a targeted command has no resolvable workdir.
-
-    Targeted commands (--stop, --info, --bundle-reload, --export-live-bundles)
-    require an explicit --workdir or a configured default_workdir.  Without
-    either, the CLI would silently fall back to DEFAULT_WORKDIR and either
-    pick the wrong deployment or emit a confusing "multiple candidates" error.
-    """
-    if is_targeted_command and not workdir_arg and "default_workdir" not in cli_defaults:
-        raise SystemExit(
-            "No target workdir specified.\n"
-            "Pass --workdir explicitly or configure a default:\n"
-            "  kdcube --set-defaults --default-workdir <path>"
+    CLI_LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CLI_LOCK_FILE.write_text(
+        json.dumps(
+            {
+                "tenant": tenant,
+                "project": project,
+                "workdir": str(workdir),
+                "docker_dir": str(docker_dir),
+                "env_file": str(env_file),
+            },
+            indent=2,
         )
+    )
 
 
-def _check_no_other_local_stack_running(
+def _clear_cli_lock() -> None:
+    try:
+        CLI_LOCK_FILE.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _lock_running_services(lock: dict) -> set[str]:
+    """Return the set of running Docker services for a lock entry, or empty set if stale/inaccessible."""
+    docker_dir = Path(lock["docker_dir"]) if lock.get("docker_dir") else None
+    env_file = Path(lock["env_file"]) if lock.get("env_file") else None
+    if not (docker_dir and env_file and docker_dir.exists() and env_file.exists()):
+        return set()
+    try:
+        return _compose_running_services(docker_dir, env_file)
+    except Exception:
+        return set()
+
+
+def _check_before_start(
     console: Console,
     *,
-    target_workdir: Path,
-    repo_root: Path,
+    tenant: str,
+    project: str,
 ) -> None:
-    """Refuse if any sibling local KDCube compose stack is already running.
+    """Raise SystemExit if a different deployment is already running. Clear stale locks silently."""
+    lock = _read_cli_lock()
+    if lock is None:
+        return
+    lock_tenant = str(lock.get("tenant", "")).strip()
+    lock_project = str(lock.get("project", "")).strip()
+    if lock_tenant == tenant and lock_project == project:
+        return
+    running = _lock_running_services(lock)
+    if running:
+        raise SystemExit(
+            f"Another local KDCube deployment is already running.\n"
+            f"  Tenant  : {lock_tenant}\n"
+            f"  Project : {lock_project}\n"
+            f"  Workdir : {lock.get('workdir', '?')}\n"
+            f"  Services: {', '.join(sorted(running))}\n\n"
+            f"Stop it first, then retry:\n"
+            f"  kdcube stop --workdir {lock.get('workdir', '<workdir>')}"
+        )
+    _clear_cli_lock()
 
-    Scans runtime directories under target_workdir.parent (the base workdir)
-    AND under all sibling base directories at target_workdir.parent.parent
-    (the kdcube home dir, typically ~/.kdcube/).  The broader scan is required
-    because two commands may use different --workdir bases (e.g. kdcube-runtime
-    vs kdcube-runtime2), which would be invisible to a single-level scan.
 
-    Errors from individual candidate checks are silently skipped so a missing
-    or broken sibling does not block the operator.
-    """
-    base_workdir = target_workdir.parent
-    kdcube_home = base_workdir.parent
-
-    all_candidates: list[Path] = list(_runtime_candidates(base_workdir))
-    if kdcube_home.exists() and kdcube_home.is_dir():
-        for sibling_base in sorted(kdcube_home.iterdir()):
-            if sibling_base.is_dir() and sibling_base.resolve() != base_workdir.resolve():
-                all_candidates.extend(_runtime_candidates(sibling_base))
-
-    target_docker_dir: Path | None = None
+def _check_before_stop(workdir: Path, env_file: Path, docker_dir: Path) -> None:
+    """Raise SystemExit if the target deployment is not running or a different one is."""
+    running = set()
     try:
-        target_docker_dir = _build_paths_for_repo(repo_root, target_workdir).docker_dir.resolve()
+        running = _compose_running_services(docker_dir, env_file)
     except Exception:
         pass
 
-    for candidate in all_candidates:
-        if candidate.resolve() == target_workdir.resolve():
-            continue
-        env_file = candidate / "config" / ".env"
-        if not env_file.exists():
-            continue
-        try:
-            ctx = _build_paths_for_repo(repo_root, candidate)
-            # Two workdirs that share the same docker_dir use the same Docker
-            # Compose project name.  docker compose ps would report the
-            # target's own running containers as belonging to this sibling —
-            # a false positive.  They are not independent deployments and
-            # cannot run concurrently regardless of ports, so skip them.
-            if target_docker_dir is not None and ctx.docker_dir.resolve() == target_docker_dir:
-                continue
-            running = _compose_running_services(ctx.docker_dir, env_file)
-        except (SystemExit, Exception):
-            continue
-        if running:
+    if not running:
+        raise SystemExit(
+            f"Deployment is not running.\n"
+            f"  Workdir: {workdir}"
+        )
+
+    target_tenant, target_project = _parse_workdir_namespace(workdir)
+    lock = _read_cli_lock()
+    if lock is not None:
+        lock_tenant = str(lock.get("tenant", "")).strip()
+        lock_project = str(lock.get("project", "")).strip()
+        if lock_tenant != target_tenant or lock_project != target_project:
             raise SystemExit(
-                f"Another local KDCube deployment is already running.\n"
-                f"  Workdir : {candidate}\n"
-                f"  Services: {', '.join(sorted(running))}\n\n"
-                f"Stop it first, then retry:\n"
-                f"  kdcube --workdir {candidate} --stop"
+                f"Cannot stop: a different deployment is currently running.\n"
+                f"  Running  : {lock_tenant} / {lock_project}  ({lock.get('workdir', '?')})\n"
+                f"  Requested: {target_tenant} / {target_project}  ({workdir})\n\n"
+                f"Stop the running deployment first:\n"
+                f"  kdcube stop --workdir {lock.get('workdir', '<workdir>')}"
             )
+
+
+def _resolve_subcommand_workdir(workdir_arg: str | None, cli_defaults: dict) -> Path:
+    if workdir_arg is not None:
+        return Path(os.path.expanduser(workdir_arg)).resolve()
+    if "default_workdir" in cli_defaults:
+        return Path(cli_defaults["default_workdir"]).resolve()
+    raise SystemExit(
+        "No target workdir specified.\n"
+        "Pass --workdir explicitly or configure a default:\n"
+        "  kdcube defaults --default-workdir <path>"
+    )
+
+
+def _resolve_subcommand_repo(path_arg: str, *, workdir: Path) -> Path:
+    meta_repo = _repo_path_from_install_meta(_resolve_cli_workdir(workdir))
+    if meta_repo is not None:
+        return meta_repo
+    return Path(os.path.expanduser(path_arg)).resolve()
+
+
+
+
+
 
 
 def _bootstrap_repo_for_defaults(
@@ -1358,6 +1501,15 @@ def main() -> None:
         help="With --descriptors-location, checkout the selected platform release source and build images locally instead of pulling release images",
     )
     parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help=(
+            "When using the default-descriptor bootstrap (no --descriptors-location), "
+            "prompt for required fields that are missing in the assembly instead of failing"
+        ),
+    )
+    parser.add_argument(
         "--reset-config",
         action="store_true",
         help="Re-run config prompts and allow editing existing values",
@@ -1371,11 +1523,6 @@ def main() -> None:
         "--clean",
         action="store_true",
         help="Clean dangling images, build cache, and old KDCube image tags",
-    )
-    parser.add_argument(
-        "--stop",
-        action="store_true",
-        help="Stop the local Docker Compose stack for the selected workdir",
     )
     parser.add_argument(
         "--remove-volumes",
@@ -1414,21 +1561,6 @@ def main() -> None:
         help="With --dry-run, print full env file contents",
     )
     parser.add_argument(
-        "--bundle-reload",
-        default="",
-        help="Reapply runtime workspace bundles.yaml and clear proc bundle caches for local development. Validates that the given bundle id exists in the current descriptor.",
-    )
-    parser.add_argument(
-        "--info",
-        action="store_true",
-        help="Print resolved runtime info for the selected workdir, including descriptor files, install metadata, and host/container bundle mount mappings.",
-    )
-    parser.add_argument(
-        "--export-live-bundles",
-        action="store_true",
-        help="Export the current effective live bundles.yaml and bundles.secrets.yaml from the active bundle authority.",
-    )
-    parser.add_argument(
         "--tenant",
         default="",
         help="Tenant for --export-live-bundles when exporting from AWS SM. Ignored when exporting workspace descriptors directly.",
@@ -1459,11 +1591,6 @@ def main() -> None:
         help="Explicit AWS Secrets Manager prefix for --export-live-bundles when exporting from AWS SM. Default is kdcube/<tenant>/<project>.",
     )
     parser.add_argument(
-        "--set-defaults",
-        action="store_true",
-        help="Save --default-tenant, --default-project, and --default-workdir as persistent operator defaults",
-    )
-    parser.add_argument(
         "--default-tenant",
         default="",
         help="Default tenant to persist with --set-defaults",
@@ -1478,6 +1605,61 @@ def main() -> None:
         default="",
         help="Default workdir to persist with --set-defaults",
     )
+    parser.add_argument(
+        "--info",
+        action="store_true",
+        help="Print global CLI info (defaults, running deployment) or, when --workdir is given, deployment-level runtime info",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    _sp = subparsers.add_parser("stop", help="Stop the local Docker Compose stack")
+    _sp.add_argument("--workdir", default=None, help="Namespaced runtime workdir to stop")
+    _sp.add_argument("--path", default=str(DEFAULT_DIR), help="Platform repo path")
+    _sp.add_argument("--remove-volumes", action="store_true", help="Also pass -v to docker compose down")
+
+    _sp = subparsers.add_parser("reload", help="Reload a bundle from its descriptor")
+    _sp.add_argument("bundle_id", help="Bundle ID to reload")
+    _sp.add_argument("--workdir", default=None, help="Namespaced runtime workdir")
+    _sp.add_argument("--path", default=str(DEFAULT_DIR), help="Platform repo path")
+
+    _sp = subparsers.add_parser("export", help="Export live bundle descriptors")
+    _sp.add_argument("--workdir", default=None, help="Namespaced runtime workdir")
+    _sp.add_argument("--path", default=str(DEFAULT_DIR), help="Platform repo path")
+    _sp.add_argument("--tenant", default="", help="Tenant for AWS SM export")
+    _sp.add_argument("--project", default="", help="Project for AWS SM export")
+    _sp.add_argument("--out-dir", default="", help="Output directory for exported files")
+    _sp.add_argument("--aws-region", default="", help="AWS region for AWS SM export")
+    _sp.add_argument("--aws-profile", default="", help="AWS profile for AWS SM export")
+    _sp.add_argument("--aws-sm-prefix", default="", help="AWS SM prefix override")
+
+    _sp = subparsers.add_parser("defaults", help="Save persistent operator defaults")
+    _sp.add_argument("--default-tenant", default="", help="Default tenant to persist")
+    _sp.add_argument("--default-project", default="", help="Default project to persist")
+    _sp.add_argument("--default-workdir", default="", help="Default workdir to persist")
+
+    _sp = subparsers.add_parser("start", help="Start the Docker Compose stack for an initialized workdir")
+    _sp.add_argument("--workdir", default=None, help="Namespaced runtime workdir to start")
+    _sp.add_argument("--path", default=str(DEFAULT_DIR), help="Platform repo path")
+    _sp.add_argument("--build", action="store_true", help="Build images before starting")
+
+    _sp = subparsers.add_parser("init", help="Initialize a workdir (stage descriptors and env files) without starting Docker")
+    _sp.add_argument("--workdir", default=str(DEFAULT_WORKDIR), help="Base or namespaced runtime workdir")
+    _sp.add_argument("--path", default=str(DEFAULT_DIR), help="Platform repo path")
+    _sp.add_argument("--descriptors-location", default="", help="Directory containing the descriptor set")
+    _sp.add_argument("--latest", action="store_true", help="Use the latest platform release")
+    _sp.add_argument("--upstream", action="store_true", help="Use upstream repo state (requires --build)")
+    _sp.add_argument("--release", default="", help="Use a specific platform release ref")
+    _sp.add_argument("--build", action="store_true", help="Checkout source and build images locally")
+    _sp.add_argument("--tenant", default="", help="Tenant for the deployment namespace")
+    _sp.add_argument("--project", default="", help="Project for the deployment namespace")
+    _sp.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Prompt for required fields missing in the assembly instead of failing",
+    )
+
     args = parser.parse_args()
 
     def _arg_provided(name: str) -> bool:
@@ -1491,7 +1673,7 @@ def main() -> None:
     repo_path = Path(os.path.expanduser(args.path)).resolve()
     path_provided = _arg_provided("--path")
     workdir_arg = _arg_provided("--workdir")
-    workdir = Path(os.path.expanduser(args.workdir)).expanduser().resolve()
+    workdir = Path(os.path.expanduser(args.workdir or str(DEFAULT_WORKDIR))).expanduser().resolve()
     cli_defaults = _load_cli_defaults()
     if not workdir_arg and "default_workdir" in cli_defaults:
         workdir = Path(cli_defaults["default_workdir"]).resolve()
@@ -1509,7 +1691,7 @@ def main() -> None:
         else implicit_descriptors_location
     )
     try:
-        if args.set_defaults:
+        if args.command == "defaults":
             updates: dict[str, str] = {}
             if args.default_tenant.strip():
                 updates["default_tenant"] = args.default_tenant.strip()
@@ -1522,7 +1704,7 @@ def main() -> None:
             if not updates:
                 raise SystemExit(
                     "Provide at least one of --default-tenant, --default-project, "
-                    "or --default-workdir with --set-defaults."
+                    "or --default-workdir."
                 )
             cli_defaults.update(updates)
             _save_cli_defaults(cli_defaults)
@@ -1530,34 +1712,58 @@ def main() -> None:
             for k, v in cli_defaults.items():
                 console.print(f"  {k}: {v}")
             return
-        if args.clean:
-            clean_docker_images(console)
+        if args.command == "stop":
+            _workdir = _resolve_subcommand_workdir(args.workdir, cli_defaults)
+            _repo = _resolve_subcommand_repo(args.path, workdir=_workdir)
+            stop_compose_stack(
+                console,
+                repo_root=_repo,
+                workdir=_resolve_cli_workdir(_workdir),
+                remove_volumes=args.remove_volumes,
+            )
             return
-        _check_targeted_command_has_workdir(
-            is_targeted_command=bool(
-                args.stop
-                or args.info
-                or str(args.bundle_reload or "").strip()
-                or args.export_live_bundles
-            ),
-            workdir_arg=workdir_arg,
-            cli_defaults=cli_defaults,
-        )
-        if args.export_live_bundles:
-            workdir = _resolve_cli_workdir(workdir)
-            out_dir = Path(os.path.expanduser(args.out_dir or os.getcwd())).expanduser().resolve()
-            bundles_path = None
-            bundles_secrets_path = None
+        if args.info:
+            if _arg_provided("--workdir"):
+                _workdir = Path(os.path.expanduser(args.workdir)).resolve()
+                _repo = _resolve_subcommand_repo(
+                    getattr(args, "path", str(DEFAULT_DIR)), workdir=_workdir
+                )
+                print_runtime_info(
+                    console,
+                    repo_root=_repo,
+                    workdir=_resolve_cli_workdir(_workdir),
+                )
+            else:
+                print_global_info(console, cli_defaults)
+            return
+        if args.command == "reload":
+            _workdir = _resolve_subcommand_workdir(args.workdir, cli_defaults)
+            _repo = _resolve_subcommand_repo(args.path, workdir=_workdir)
+            reload_bundle_from_descriptor(
+                console,
+                repo_root=_repo,
+                workdir=_resolve_cli_workdir(_workdir),
+                bundle_id=str(args.bundle_id).strip(),
+            )
+            return
+        if args.command == "export":
+            _workdir = _resolve_subcommand_workdir(args.workdir, cli_defaults)
+            _repo = _resolve_subcommand_repo(args.path, workdir=_workdir)
+            _resolved = _resolve_cli_workdir(_workdir)
+            _out_dir = Path(os.path.expanduser(args.out_dir or os.getcwd())).resolve()
+            _bundles_path: Path | None = None
+            _bundles_secrets_path: Path | None = None
             try:
-                ctx = _build_paths_for_repo(repo_path, workdir)
-                env_main_path = ctx.config_dir / ".env"
-                env_proc_path = ctx.config_dir / ".env.proc"
-                if env_main_path.exists() and env_proc_path.exists():
-                    env_main = installer_mod.load_env_file(env_main_path)
-                    env_proc = installer_mod.load_env_file(env_proc_path)
-                    sources = _resolve_live_bundle_export_sources(env_main, env_proc)
-                    if sources is not None:
-                        bundles_path, bundles_secrets_path = sources
+                _ctx = _build_paths_for_repo(_repo, _resolved)
+                _env_main = _ctx.config_dir / ".env"
+                _env_proc = _ctx.config_dir / ".env.proc"
+                if _env_main.exists() and _env_proc.exists():
+                    _sources = _resolve_live_bundle_export_sources(
+                        installer_mod.load_env_file(_env_main),
+                        installer_mod.load_env_file(_env_proc),
+                    )
+                    if _sources is not None:
+                        _bundles_path, _bundles_secrets_path = _sources
             except SystemExit:
                 raise
             except Exception:
@@ -1566,16 +1772,141 @@ def main() -> None:
                 console,
                 tenant=str(args.tenant or cli_defaults.get("default_tenant", "") or "").strip(),
                 project=str(args.project or cli_defaults.get("default_project", "") or "").strip(),
-                out_dir=out_dir,
+                out_dir=_out_dir,
                 aws_region=str(args.aws_region or "").strip() or None,
                 aws_profile=str(args.aws_profile or "").strip() or None,
                 aws_sm_prefix=str(args.aws_sm_prefix or "").strip() or None,
-                bundles_path=bundles_path,
-                bundles_secrets_path=bundles_secrets_path,
+                bundles_path=_bundles_path,
+                bundles_secrets_path=_bundles_secrets_path,
             )
             return
-        if args.remove_volumes and not args.stop:
-            raise SystemExit("--remove-volumes can only be used together with --stop.")
+        if args.command == "start":
+            _workdir = _resolve_subcommand_workdir(args.workdir, cli_defaults)
+            _repo = _resolve_subcommand_repo(args.path, workdir=_workdir)
+            _resolved = _resolve_cli_workdir(_workdir)
+            _t, _p = _parse_workdir_namespace(_resolved)
+            _check_before_start(console, tenant=_t, project=_p)
+            start_compose_stack(console, repo_root=_repo, workdir=_resolved, build=args.build)
+            return
+        if args.command == "init":
+            _init_workdir = Path(os.path.expanduser(args.workdir)).resolve()
+            _init_repo = _resolve_subcommand_repo(args.path, workdir=_init_workdir)
+            _init_descriptors_location: Path | None = None
+            if str(args.descriptors_location or "").strip():
+                _init_descriptors_location = Path(
+                    os.path.expanduser(args.descriptors_location)
+                ).resolve()
+            elif args.latest or args.upstream or str(args.release or "").strip() or args.build:
+                _init_repo, _init_descriptors_location = _bootstrap_repo_for_defaults(
+                    console,
+                    repo=args.path,
+                    repo_path=_init_repo,
+                    path_provided=bool(_arg_provided("--path")),
+                )
+                console.print(
+                    f"[dim]No --descriptors-location provided. "
+                    f"Using repo defaults from:[/dim] {_init_descriptors_location}"
+                )
+            else:
+                raise SystemExit(
+                    "kdcube init requires a descriptor source.\n"
+                    "Pass --descriptors-location <dir>, or use --latest/--upstream/--release/--build "
+                    "to bootstrap from the platform repo."
+                )
+
+            # For --interactive: prompt tenant/project BEFORE resolving/creating the workdir
+            # so the directory is created with the correct namespace from the start.
+            _init_preset_tenant: str | None = None
+            _init_preset_project: str | None = None
+            if args.interactive:
+                _src_assembly = installer_mod.load_release_descriptor_soft(
+                    _init_descriptors_location / "assembly.yaml"
+                ) or {}
+                _t_default, _p_default = installer_mod.descriptor_context_from_assembly(_src_assembly)
+                _init_preset_tenant = installer_mod.ask(
+                    console, "Tenant ID", default=_t_default or "demo-tenant"
+                )
+                _init_preset_project = installer_mod.ask(
+                    console, "Project name", default=_p_default or "demo-project"
+                )
+
+            if _init_preset_tenant and _init_preset_project:
+                _init_resolved = installer_mod.workspace_runtime_dir(
+                    _init_workdir, _init_preset_tenant, _init_preset_project
+                ).resolve()
+            else:
+                _init_resolved = _resolve_cli_workdir(
+                    _init_workdir, descriptors_location=_init_descriptors_location
+                )
+
+            _descriptor_bootstrap = _stage_descriptor_set(
+                repo_root=_init_repo,
+                workdir=_init_resolved,
+                descriptors_location=_init_descriptors_location,
+            )
+
+            if _init_preset_tenant and _init_preset_project:
+                os.environ["KDCUBE_PRESET_TENANT"] = _init_preset_tenant
+                os.environ["KDCUBE_PRESET_PROJECT"] = _init_preset_project
+
+            os.environ["KDCUBE_DESCRIPTORS_LOCATION"] = str(_init_descriptors_location)
+            os.environ["KDCUBE_ASSEMBLY_DESCRIPTOR_PATH"] = str(_descriptor_bootstrap["assembly_path"])
+            os.environ["KDCUBE_ASSEMBLY_USER_SUPPLIED"] = (
+                "0"
+                if _init_descriptors_location.resolve() == (_init_resolved / "config").resolve()
+                else "1"
+            )
+            if _descriptor_bootstrap["secrets_path"]:
+                os.environ["KDCUBE_SECRETS_DESCRIPTOR_PATH"] = str(_descriptor_bootstrap["secrets_path"])
+            if _descriptor_bootstrap["gateway_path"]:
+                os.environ["KDCUBE_GATEWAY_DESCRIPTOR_PATH"] = str(_descriptor_bootstrap["gateway_path"])
+            if _descriptor_bootstrap["bundles_path"]:
+                os.environ["KDCUBE_BUNDLES_DESCRIPTOR_PATH"] = str(_descriptor_bootstrap["bundles_path"])
+            if _descriptor_bootstrap["bundles_secrets_path"]:
+                os.environ["KDCUBE_BUNDLES_SECRETS_PATH"] = str(_descriptor_bootstrap["bundles_secrets_path"])
+            _init_assembly = _descriptor_bootstrap["assembly"]
+            os.environ["KDCUBE_ASSEMBLY_USE_BUNDLES"] = "1" if bool(_get_nested(_init_assembly, "bundles")) else "0"
+            os.environ["KDCUBE_ASSEMBLY_USE_FRONTEND"] = "1" if bool(_get_nested(_init_assembly, "frontend")) else "0"
+            os.environ["KDCUBE_ASSEMBLY_USE_PLATFORM"] = "0"
+            os.environ["KDCUBE_USE_BUNDLES_DESCRIPTOR"] = "1" if _descriptor_bootstrap["bundles_path"] else "0"
+            os.environ["KDCUBE_USE_BUNDLES_SECRETS"] = "1" if _descriptor_bootstrap["bundles_secrets_path"] else "0"
+
+            _init_release_ref: str | None = None
+            _init_mode = "release"
+            if args.upstream:
+                _init_release_ref = _checkout_repo_upstream(console, _init_repo)
+                _init_mode = "upstream"
+            elif args.latest:
+                _init_release_ref = _read_remote_ref(_init_repo) or _read_local_ref(_init_repo)
+                if not _init_release_ref:
+                    raise SystemExit(
+                        "Could not resolve the latest platform release. "
+                        "Check platform.repo or pass a repo that contains release.yaml."
+                    )
+            elif str(args.release or "").strip():
+                _init_release_ref = str(args.release).strip()
+            else:
+                _init_release_ref = (
+                    str(_get_nested(_init_assembly, "platform", "ref") or "").strip() or None
+                )
+                if not _init_release_ref:
+                    raise SystemExit(
+                        "assembly platform.ref is required unless --latest, --upstream, or --release is used."
+                    )
+
+            if args.build:
+                if not args.upstream:
+                    _checkout_repo_ref(console, _init_repo, _init_release_ref)
+                if _init_mode != "upstream":
+                    _init_mode = "skip"
+
+            if not args.interactive:
+                os.environ["KDCUBE_CLI_NONINTERACTIVE"] = "1"
+            run_installer(console, _init_repo, _init_resolved, _init_mode, _init_release_ref, None, True)
+            return
+        if args.clean:
+            clean_docker_images(console)
+            return
         selected_version_flags = int(bool(args.latest)) + int(bool(args.upstream)) + int(bool(str(args.release or "").strip()))
         if selected_version_flags > 1:
             raise SystemExit("Choose only one of --latest, --upstream, or --release.")
@@ -1589,42 +1920,6 @@ def main() -> None:
             os.environ["KDCUBE_PROXY_SSL"] = "0"
         if args.dry_run_print_env:
             os.environ["KDCUBE_DRY_RUN_PRINT_ENV"] = "1"
-        if args.stop:
-            stop_compose_stack(
-                console,
-                repo_root=_resolve_cli_repo_path(
-                    repo_path,
-                    workdir=workdir,
-                    path_provided=path_provided,
-                ),
-                workdir=_resolve_cli_workdir(workdir),
-                remove_volumes=args.remove_volumes,
-            )
-            return
-        if args.bundle_reload:
-            reload_bundle_from_descriptor(
-                console,
-                repo_root=_resolve_cli_repo_path(
-                    repo_path,
-                    workdir=workdir,
-                    path_provided=path_provided,
-                ),
-                workdir=_resolve_cli_workdir(workdir),
-                bundle_id=str(args.bundle_reload).strip(),
-            )
-            return
-        if args.info:
-            resolved_workdir = _resolve_cli_workdir(workdir)
-            print_runtime_info(
-                console,
-                repo_root=_resolve_cli_repo_path(
-                    repo_path,
-                    workdir=resolved_workdir,
-                    path_provided=path_provided,
-                ),
-                workdir=resolved_workdir,
-            )
-            return
         # No-descriptors fast path: when a source selector is given without
         # --descriptors-location (and no initialized workdir was found), bootstrap
         # the platform repo and use its deployment/ directory as the descriptor
@@ -1708,11 +2003,12 @@ def main() -> None:
                 upstream=bool(args.upstream),
                 release=str(args.release or "").strip() or None,
             )
-            if reasons:
+            if reasons and not args.interactive:
                 rendered = "\n".join(f"  - {reason}" for reason in reasons)
                 raise SystemExit(
                     "Descriptor directory is not valid for non-interactive install.\n"
-                    f"{rendered}"
+                    f"{rendered}\n\n"
+                    "Use -i to configure missing fields interactively."
                 )
 
             platform_repo = str(_get_nested(assembly, "platform", "repo") or args.repo).strip()
@@ -1750,12 +2046,21 @@ def main() -> None:
                 console.print("[green]Descriptor set is complete. Running non-interactive source build install.[/green]")
             else:
                 console.print("[green]Descriptor set is complete. Running non-interactive release-image install.[/green]")
-            os.environ["KDCUBE_CLI_NONINTERACTIVE"] = "1"
+            if not args.interactive:
+                os.environ["KDCUBE_CLI_NONINTERACTIVE"] = "1"
             if not args.dry_run:
-                _check_no_other_local_stack_running(
-                    console, target_workdir=workdir, repo_root=repo_path
-                )
+                _t, _p = _parse_workdir_namespace(workdir)
+                _check_before_start(console, tenant=_t, project=_p)
             run_installer(console, repo_path, workdir, install_mode, release_ref, None, args.dry_run)
+            if not args.dry_run:
+                try:
+                    _lctx = _build_paths_for_repo(repo_path, workdir)
+                    _write_cli_lock(
+                        tenant=_t, project=_p, workdir=workdir,
+                        docker_dir=_lctx.docker_dir, env_file=_lctx.config_dir / ".env",
+                    )
+                except Exception:
+                    pass
             return
 
         assembly_descriptor_path: Path | None = None
@@ -2051,10 +2356,20 @@ def main() -> None:
         if args.reset_config or args.reset:
             os.environ["KDCUBE_RESET_CONFIG"] = "1"
         if not args.dry_run:
-            _check_no_other_local_stack_running(
-                console, target_workdir=_resolve_cli_workdir(workdir), repo_root=repo_path
-            )
+            _resolved_wdir = _resolve_cli_workdir(workdir)
+            _t, _p = _parse_workdir_namespace(_resolved_wdir)
+            _check_before_start(console, tenant=_t, project=_p)
         run_installer(console, repo_path, workdir, mode, release_ref, docker_namespace, args.dry_run)
+        if not args.dry_run:
+            try:
+                _resolved_wdir = _resolve_cli_workdir(workdir)
+                _lctx = _build_paths_for_repo(repo_path, _resolved_wdir)
+                _write_cli_lock(
+                    tenant=_t, project=_p, workdir=_resolved_wdir,
+                    docker_dir=_lctx.docker_dir, env_file=_lctx.config_dir / ".env",
+                )
+            except Exception:
+                pass
     except FileNotFoundError as exc:
         detail = str(exc).strip()
         if detail:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -1254,6 +1254,12 @@ def _check_no_other_local_stack_running(
             if sibling_base.is_dir() and sibling_base.resolve() != base_workdir.resolve():
                 all_candidates.extend(_runtime_candidates(sibling_base))
 
+    target_docker_dir: Path | None = None
+    try:
+        target_docker_dir = _build_paths_for_repo(repo_root, target_workdir).docker_dir.resolve()
+    except Exception:
+        pass
+
     for candidate in all_candidates:
         if candidate.resolve() == target_workdir.resolve():
             continue
@@ -1262,6 +1268,13 @@ def _check_no_other_local_stack_running(
             continue
         try:
             ctx = _build_paths_for_repo(repo_root, candidate)
+            # Two workdirs that share the same docker_dir use the same Docker
+            # Compose project name.  docker compose ps would report the
+            # target's own running containers as belonging to this sibling —
+            # a false positive.  They are not independent deployments and
+            # cannot run concurrently regardless of ports, so skip them.
+            if target_docker_dir is not None and ctx.docker_dir.resolve() == target_docker_dir:
+                continue
             running = _compose_running_services(ctx.docker_dir, env_file)
         except (SystemExit, Exception):
             continue

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -33,6 +33,7 @@ from kdcube_cli.tty_keys import (
 DEFAULT_REPO = "https://github.com/kdcube/kdcube-ai-app.git"
 DEFAULT_DIR = Path.home() / ".kdcube" / "kdcube-ai-app"
 DEFAULT_WORKDIR = Path.home() / ".kdcube" / "kdcube-runtime"
+DEFAULT_DEFAULTS_FILE = Path.home() / ".kdcube" / "cli-defaults.json"
 DEFAULT_REPO_DIRNAME = "repo"
 KDCUBE_REPOS = {
     "kdcube-chat-ingress",
@@ -1194,6 +1195,65 @@ def run_installer(
     )
 
 
+def _load_cli_defaults() -> dict:
+    try:
+        return json.loads(DEFAULT_DEFAULTS_FILE.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _save_cli_defaults(data: dict) -> None:
+    DEFAULT_DEFAULTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    DEFAULT_DEFAULTS_FILE.write_text(json.dumps(data, indent=2))
+
+
+def _check_no_other_local_stack_running(
+    console: Console,
+    *,
+    target_workdir: Path,
+    repo_root: Path,
+) -> None:
+    """Refuse if any sibling local KDCube compose stack is already running.
+
+    Scans runtime directories under target_workdir.parent (the base workdir)
+    AND under all sibling base directories at target_workdir.parent.parent
+    (the kdcube home dir, typically ~/.kdcube/).  The broader scan is required
+    because two commands may use different --workdir bases (e.g. kdcube-runtime
+    vs kdcube-runtime2), which would be invisible to a single-level scan.
+
+    Errors from individual candidate checks are silently skipped so a missing
+    or broken sibling does not block the operator.
+    """
+    base_workdir = target_workdir.parent
+    kdcube_home = base_workdir.parent
+
+    all_candidates: list[Path] = list(_runtime_candidates(base_workdir))
+    if kdcube_home.exists() and kdcube_home.is_dir():
+        for sibling_base in sorted(kdcube_home.iterdir()):
+            if sibling_base.is_dir() and sibling_base.resolve() != base_workdir.resolve():
+                all_candidates.extend(_runtime_candidates(sibling_base))
+
+    for candidate in all_candidates:
+        if candidate.resolve() == target_workdir.resolve():
+            continue
+        env_file = candidate / "config" / ".env"
+        if not env_file.exists():
+            continue
+        try:
+            ctx = _build_paths_for_repo(repo_root, candidate)
+            running = _compose_running_services(ctx.docker_dir, env_file)
+        except (SystemExit, Exception):
+            continue
+        if running:
+            raise SystemExit(
+                f"Another local KDCube deployment is already running.\n"
+                f"  Workdir : {candidate}\n"
+                f"  Services: {', '.join(sorted(running))}\n\n"
+                f"Stop it first, then retry:\n"
+                f"  kdcube --workdir {candidate} --stop"
+            )
+
+
 def _bootstrap_repo_for_defaults(
     console: Console,
     *,
@@ -1364,6 +1424,26 @@ def main() -> None:
         default="",
         help="Explicit AWS Secrets Manager prefix for --export-live-bundles when exporting from AWS SM. Default is kdcube/<tenant>/<project>.",
     )
+    parser.add_argument(
+        "--set-defaults",
+        action="store_true",
+        help="Save --default-tenant, --default-project, and --default-workdir as persistent operator defaults",
+    )
+    parser.add_argument(
+        "--default-tenant",
+        default="",
+        help="Default tenant to persist with --set-defaults",
+    )
+    parser.add_argument(
+        "--default-project",
+        default="",
+        help="Default project to persist with --set-defaults",
+    )
+    parser.add_argument(
+        "--default-workdir",
+        default="",
+        help="Default workdir to persist with --set-defaults",
+    )
     args = parser.parse_args()
 
     def _arg_provided(name: str) -> bool:
@@ -1378,6 +1458,9 @@ def main() -> None:
     path_provided = _arg_provided("--path")
     workdir_arg = _arg_provided("--workdir")
     workdir = Path(os.path.expanduser(args.workdir)).expanduser().resolve()
+    cli_defaults = _load_cli_defaults()
+    if not workdir_arg and "default_workdir" in cli_defaults:
+        workdir = Path(cli_defaults["default_workdir"]).resolve()
     implicit_descriptors_location: Path | None = None
     if (
         workdir_arg
@@ -1392,11 +1475,32 @@ def main() -> None:
         else implicit_descriptors_location
     )
     try:
+        if args.set_defaults:
+            updates: dict[str, str] = {}
+            if args.default_tenant.strip():
+                updates["default_tenant"] = args.default_tenant.strip()
+            if args.default_project.strip():
+                updates["default_project"] = args.default_project.strip()
+            if args.default_workdir.strip():
+                updates["default_workdir"] = str(
+                    Path(os.path.expanduser(args.default_workdir)).resolve()
+                )
+            if not updates:
+                raise SystemExit(
+                    "Provide at least one of --default-tenant, --default-project, "
+                    "or --default-workdir with --set-defaults."
+                )
+            cli_defaults.update(updates)
+            _save_cli_defaults(cli_defaults)
+            console.print(f"[green]Defaults saved to {DEFAULT_DEFAULTS_FILE}:[/green]")
+            for k, v in cli_defaults.items():
+                console.print(f"  {k}: {v}")
+            return
         if args.clean:
             clean_docker_images(console)
             return
         if args.export_live_bundles:
-            workdir = _resolve_cli_workdir(Path(os.path.expanduser(args.workdir)))
+            workdir = _resolve_cli_workdir(workdir)
             out_dir = Path(os.path.expanduser(args.out_dir or os.getcwd())).expanduser().resolve()
             bundles_path = None
             bundles_secrets_path = None
@@ -1416,8 +1520,8 @@ def main() -> None:
                 pass
             export_live_bundle_descriptors(
                 console,
-                tenant=str(args.tenant or "").strip(),
-                project=str(args.project or "").strip(),
+                tenant=str(args.tenant or cli_defaults.get("default_tenant", "") or "").strip(),
+                project=str(args.project or cli_defaults.get("default_project", "") or "").strip(),
                 out_dir=out_dir,
                 aws_region=str(args.aws_region or "").strip() or None,
                 aws_profile=str(args.aws_profile or "").strip() or None,
@@ -1603,6 +1707,10 @@ def main() -> None:
             else:
                 console.print("[green]Descriptor set is complete. Running non-interactive release-image install.[/green]")
             os.environ["KDCUBE_CLI_NONINTERACTIVE"] = "1"
+            if not args.dry_run:
+                _check_no_other_local_stack_running(
+                    console, target_workdir=workdir, repo_root=repo_path
+                )
             run_installer(console, repo_path, workdir, install_mode, release_ref, None, args.dry_run)
             return
 
@@ -1898,6 +2006,10 @@ def main() -> None:
 
         if args.reset_config or args.reset:
             os.environ["KDCUBE_RESET_CONFIG"] = "1"
+        if not args.dry_run:
+            _check_no_other_local_stack_running(
+                console, target_workdir=_resolve_cli_workdir(workdir), repo_root=repo_path
+            )
         run_installer(console, repo_path, workdir, mode, release_ref, docker_namespace, args.dry_run)
     except FileNotFoundError as exc:
         detail = str(exc).strip()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -2116,7 +2116,12 @@ def gather_configuration(
     descriptor_project = _get_nested(assembly_data, "context", "project")
     tenant_default = str(descriptor_tenant) if descriptor_tenant else existing_tenant or "demo-tenant"
     project_default = str(descriptor_project) if descriptor_project else existing_project or "demo-project"
-    if default_local_bootstrap_mode and not force_prompt:
+    preset_tenant = os.getenv("KDCUBE_PRESET_TENANT", "").strip()
+    preset_project = os.getenv("KDCUBE_PRESET_PROJECT", "").strip()
+    if preset_tenant and preset_project and not force_prompt:
+        tenant = preset_tenant
+        project = preset_project
+    elif default_local_bootstrap_mode and not force_prompt:
         tenant = tenant_default
         project = project_default
     else:
@@ -4017,6 +4022,11 @@ def run_setup(
             console.print("\n[bold]Runtime secrets to inject:[/bold]")
             for key in sorted(runtime_secrets.keys()):
                 console.print(f"  - {key}")
+            apply_runtime_secrets_to_file_descriptors(
+                config_dir=config_dir,
+                runtime_secrets=runtime_secrets,
+            )
+            console.print("[dim]Secrets persisted to staged descriptors.[/dim]")
         return
 
     if install_mode == "release":

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
@@ -2211,11 +2211,14 @@ def _make_minimal_runtime(base: Path, namespace: str, compose_mode: str = "all-i
 
 
 def _make_minimal_repo(base: Path) -> Path:
-    """Create a minimal fake repo with the all-in-one docker-compose stub."""
+    """Create a minimal fake repo with stubs for all supported compose modes."""
     repo = base / "repo"
-    compose_dir = repo / "app" / "ai-app" / "deployment" / "docker" / "all_in_one_kdcube"
-    compose_dir.mkdir(parents=True)
-    (compose_dir / "docker-compose.yaml").write_text("services:\n  chat-proc:\n    image: stub\n")
+    for mode in ("all_in_one_kdcube", "custom-ui-managed-infra"):
+        compose_dir = repo / "app" / "ai-app" / "deployment" / "docker" / mode
+        compose_dir.mkdir(parents=True)
+        (compose_dir / "docker-compose.yaml").write_text(
+            "services:\n  chat-proc:\n    image: stub\n"
+        )
     lib_root = repo / "app" / "ai-app" / "src" / "kdcube-ai-app"
     (lib_root / "kdcube_ai_app").mkdir(parents=True)
     return repo
@@ -2247,11 +2250,12 @@ def test_check_no_other_local_stack_running_passes_for_target_itself(monkeypatch
 def test_check_no_other_local_stack_running_refuses_when_sibling_is_active(monkeypatch, tmp_path: Path):
     repo = _make_minimal_repo(tmp_path)
     workspace = tmp_path / "workspace"
-    target = _make_minimal_runtime(workspace, "tenant-a__proj-a")
-    _make_minimal_runtime(workspace, "tenant-b__proj-b")
+    # target uses default all-in-one; sibling uses a different compose mode so
+    # they have different docker_dirs and are truly independent deployments.
+    target = _make_minimal_runtime(workspace, "tenant-a__proj-a", compose_mode="all-in-one")
+    _make_minimal_runtime(workspace, "tenant-b__proj-b", compose_mode="custom-ui-managed-infra")
 
     def fake_running_services(docker_dir, env_file):
-        # Only the sibling is "running"
         if "tenant-b__proj-b" in str(env_file):
             return {"chat-proc", "chat-ingress"}
         return set()
@@ -2288,14 +2292,16 @@ def test_check_no_other_local_stack_running_skips_broken_sibling(monkeypatch, tm
 def test_check_no_other_local_stack_running_refuses_when_sibling_base_is_active(
     monkeypatch, tmp_path: Path
 ):
-    # Reproduces the real scenario: two different --workdir bases under the
-    # same kdcube home (e.g. kdcube-runtime vs kdcube-runtime2).  The running
-    # stack lives in base1; the new command targets base2 — guard must still fire.
+    # Two different --workdir bases under the same kdcube home
+    # (e.g. kdcube-runtime vs kdcube-runtime2).  The guard must fire when the
+    # sibling uses a DIFFERENT docker_dir (different compose project name) —
+    # those are truly independent deployments that could conflict on ports.
     repo = _make_minimal_repo(tmp_path)
     base1 = tmp_path / "kdcube-runtime"
     base2 = tmp_path / "kdcube-runtime2"
-    running_workdir = _make_minimal_runtime(base1, "tenant-a__proj-a")
-    target = _make_minimal_runtime(base2, "tenant-b__proj-b")
+    # sibling uses a different compose mode → different docker_dir → independent
+    _make_minimal_runtime(base1, "tenant-a__proj-a", compose_mode="custom-ui-managed-infra")
+    target = _make_minimal_runtime(base2, "tenant-b__proj-b", compose_mode="all-in-one")
 
     def fake_running_services(docker_dir, env_file):
         if "tenant-a__proj-a" in str(env_file):
@@ -2312,6 +2318,29 @@ def test_check_no_other_local_stack_running_refuses_when_sibling_base_is_active(
         msg = str(exc)
         assert "tenant-a__proj-a" in msg
         assert "--stop" in msg
+
+
+def test_check_no_other_local_stack_running_skips_sibling_with_same_docker_dir(
+    monkeypatch, tmp_path: Path
+):
+    # Both workdirs use the same docker_dir (same compose project name).
+    # docker compose ps from the sibling would report the target's own
+    # containers — a false positive.  Guard must not fire in this case.
+    repo = _make_minimal_repo(tmp_path)
+    base1 = tmp_path / "kdcube-runtime"
+    base2 = tmp_path / "kdcube-runtime2"
+    _make_minimal_runtime(base1, "tenant-a__proj-a")
+    target = _make_minimal_runtime(base2, "tenant-b__proj-b")
+
+    # Sibling reports running services — but same docker_dir as target
+    monkeypatch.setattr(
+        "kdcube_cli.cli._compose_running_services",
+        lambda docker_dir, env_file: {"chat-proc"},
+    )
+
+    console = Console(quiet=True)
+    # Should not raise — sibling shares docker_dir with target (false positive)
+    _check_no_other_local_stack_running(console, target_workdir=target, repo_root=repo)
 
 
 # ---------------------------------------------------------------------------

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
@@ -9,6 +9,7 @@ from kdcube_cli.cli import (
     _build_paths_for_repo,
     _canonical_descriptor_dir_from_initialized_workdir,
     _check_no_other_local_stack_running,
+    _check_targeted_command_has_workdir,
     _collect_runtime_info,
     _compose_running_services,
     _descriptor_fast_path_reasons,
@@ -2385,3 +2386,48 @@ def test_save_and_load_cli_defaults_roundtrip(monkeypatch, tmp_path: Path):
     loaded = _load_cli_defaults()
 
     assert loaded == original
+
+
+# ---------------------------------------------------------------------------
+# Block 4: Ambiguity refusal — _check_targeted_command_has_workdir
+# ---------------------------------------------------------------------------
+
+
+def test_targeted_command_raises_when_no_workdir_and_no_defaults():
+    import pytest
+    with pytest.raises(SystemExit) as exc_info:
+        _check_targeted_command_has_workdir(
+            is_targeted_command=True,
+            workdir_arg=False,
+            cli_defaults={},
+        )
+    msg = str(exc_info.value)
+    assert "--set-defaults" in msg
+    assert "--default-workdir" in msg
+
+
+def test_targeted_command_passes_when_workdir_arg_provided():
+    # Explicit --workdir resolves ambiguity — should not raise
+    _check_targeted_command_has_workdir(
+        is_targeted_command=True,
+        workdir_arg=True,
+        cli_defaults={},
+    )
+
+
+def test_targeted_command_passes_when_default_workdir_configured():
+    # default_workdir in defaults resolves ambiguity — should not raise
+    _check_targeted_command_has_workdir(
+        is_targeted_command=True,
+        workdir_arg=False,
+        cli_defaults={"default_workdir": "/home/user/.kdcube/kdcube-runtime/tenant__project"},
+    )
+
+
+def test_targeted_command_passes_for_non_targeted_command():
+    # Install commands do not require a pre-existing workdir
+    _check_targeted_command_has_workdir(
+        is_targeted_command=False,
+        workdir_arg=False,
+        cli_defaults={},
+    )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
@@ -8,12 +8,15 @@ from kdcube_cli.cli import (
     _bootstrap_repo_for_defaults,
     _build_paths_for_repo,
     _canonical_descriptor_dir_from_initialized_workdir,
+    _check_no_other_local_stack_running,
     _collect_runtime_info,
     _compose_running_services,
     _descriptor_fast_path_reasons,
     _load_bundle_ids_from_descriptor,
+    _load_cli_defaults,
     _resolve_cli_repo_path,
     _resolve_cli_workdir,
+    _save_cli_defaults,
 )
 from kdcube_cli import export_live_bundles as export_mod
 from kdcube_cli.installer import (
@@ -2190,3 +2193,195 @@ def test_bootstrap_repo_for_defaults_raises_when_deployment_missing(tmp_path: Pa
         raise AssertionError("Expected SystemExit for missing deployment dir")
     except SystemExit as exc:
         assert "deployment descriptors" in str(exc).lower()
+
+
+# ---------------------------------------------------------------------------
+# _check_no_other_local_stack_running
+# ---------------------------------------------------------------------------
+
+def _make_minimal_runtime(base: Path, namespace: str, compose_mode: str = "all-in-one") -> Path:
+    """Create a minimal initialized runtime directory with a .env file."""
+    runtime = base / namespace
+    config = runtime / "config"
+    config.mkdir(parents=True)
+    env_content = f'KDCUBE_COMPOSE_MODE="{compose_mode}"\n'
+    (config / ".env").write_text(env_content)
+    return runtime
+
+
+def _make_minimal_repo(base: Path) -> Path:
+    """Create a minimal fake repo with the all-in-one docker-compose stub."""
+    repo = base / "repo"
+    compose_dir = repo / "app" / "ai-app" / "deployment" / "docker" / "all_in_one_kdcube"
+    compose_dir.mkdir(parents=True)
+    (compose_dir / "docker-compose.yaml").write_text("services:\n  chat-proc:\n    image: stub\n")
+    lib_root = repo / "app" / "ai-app" / "src" / "kdcube-ai-app"
+    (lib_root / "kdcube_ai_app").mkdir(parents=True)
+    return repo
+
+
+def test_check_no_other_local_stack_running_passes_when_no_siblings(monkeypatch, tmp_path: Path):
+    repo = _make_minimal_repo(tmp_path)
+    target = _make_minimal_runtime(tmp_path / "workspace", "tenant-a__proj-a")
+
+    monkeypatch.setattr("kdcube_cli.cli._compose_running_services", lambda *a, **kw: set())
+
+    console = Console(quiet=True)
+    # Should not raise
+    _check_no_other_local_stack_running(console, target_workdir=target, repo_root=repo)
+
+
+def test_check_no_other_local_stack_running_passes_for_target_itself(monkeypatch, tmp_path: Path):
+    repo = _make_minimal_repo(tmp_path)
+    workspace = tmp_path / "workspace"
+    target = _make_minimal_runtime(workspace, "tenant-a__proj-a")
+
+    # Target itself reports running services — still allowed
+    monkeypatch.setattr("kdcube_cli.cli._compose_running_services", lambda *a, **kw: {"chat-proc"})
+
+    console = Console(quiet=True)
+    _check_no_other_local_stack_running(console, target_workdir=target, repo_root=repo)
+
+
+def test_check_no_other_local_stack_running_refuses_when_sibling_is_active(monkeypatch, tmp_path: Path):
+    repo = _make_minimal_repo(tmp_path)
+    workspace = tmp_path / "workspace"
+    target = _make_minimal_runtime(workspace, "tenant-a__proj-a")
+    _make_minimal_runtime(workspace, "tenant-b__proj-b")
+
+    def fake_running_services(docker_dir, env_file):
+        # Only the sibling is "running"
+        if "tenant-b__proj-b" in str(env_file):
+            return {"chat-proc", "chat-ingress"}
+        return set()
+
+    monkeypatch.setattr("kdcube_cli.cli._compose_running_services", fake_running_services)
+
+    console = Console(quiet=True)
+    try:
+        _check_no_other_local_stack_running(console, target_workdir=target, repo_root=repo)
+        raise AssertionError("Expected SystemExit when a sibling stack is running")
+    except SystemExit as exc:
+        msg = str(exc)
+        assert "tenant-b__proj-b" in msg
+        assert "chat-ingress" in msg or "chat-proc" in msg
+        assert "--stop" in msg
+
+
+def test_check_no_other_local_stack_running_skips_broken_sibling(monkeypatch, tmp_path: Path):
+    repo = _make_minimal_repo(tmp_path)
+    workspace = tmp_path / "workspace"
+    target = _make_minimal_runtime(workspace, "tenant-a__proj-a")
+    _make_minimal_runtime(workspace, "tenant-b__proj-b")
+
+    def fake_running_services(docker_dir, env_file):
+        raise RuntimeError("docker not available")
+
+    monkeypatch.setattr("kdcube_cli.cli._compose_running_services", fake_running_services)
+
+    console = Console(quiet=True)
+    # Should not raise — broken sibling is silently skipped
+    _check_no_other_local_stack_running(console, target_workdir=target, repo_root=repo)
+
+
+def test_check_no_other_local_stack_running_refuses_when_sibling_base_is_active(
+    monkeypatch, tmp_path: Path
+):
+    # Reproduces the real scenario: two different --workdir bases under the
+    # same kdcube home (e.g. kdcube-runtime vs kdcube-runtime2).  The running
+    # stack lives in base1; the new command targets base2 — guard must still fire.
+    repo = _make_minimal_repo(tmp_path)
+    base1 = tmp_path / "kdcube-runtime"
+    base2 = tmp_path / "kdcube-runtime2"
+    running_workdir = _make_minimal_runtime(base1, "tenant-a__proj-a")
+    target = _make_minimal_runtime(base2, "tenant-b__proj-b")
+
+    def fake_running_services(docker_dir, env_file):
+        if "tenant-a__proj-a" in str(env_file):
+            return {"chat-proc", "chat-ingress"}
+        return set()
+
+    monkeypatch.setattr("kdcube_cli.cli._compose_running_services", fake_running_services)
+
+    console = Console(quiet=True)
+    try:
+        _check_no_other_local_stack_running(console, target_workdir=target, repo_root=repo)
+        raise AssertionError("Expected SystemExit when a sibling base stack is running")
+    except SystemExit as exc:
+        msg = str(exc)
+        assert "tenant-a__proj-a" in msg
+        assert "--stop" in msg
+
+
+# ---------------------------------------------------------------------------
+# Block 3: Defaults system — _load_cli_defaults / _save_cli_defaults
+# ---------------------------------------------------------------------------
+
+
+def test_load_cli_defaults_returns_empty_when_file_missing(monkeypatch, tmp_path: Path):
+    import kdcube_cli.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "DEFAULT_DEFAULTS_FILE", tmp_path / "nonexistent.json")
+    assert _load_cli_defaults() == {}
+
+
+def test_load_cli_defaults_returns_data_when_file_exists(monkeypatch, tmp_path: Path):
+    import kdcube_cli.cli as cli_mod
+
+    defaults_file = tmp_path / "cli-defaults.json"
+    defaults_file.write_text(json.dumps({"default_tenant": "acme", "default_project": "app"}))
+    monkeypatch.setattr(cli_mod, "DEFAULT_DEFAULTS_FILE", defaults_file)
+
+    result = _load_cli_defaults()
+
+    assert result == {"default_tenant": "acme", "default_project": "app"}
+
+
+def test_load_cli_defaults_returns_empty_on_corrupt_json(monkeypatch, tmp_path: Path):
+    import kdcube_cli.cli as cli_mod
+
+    defaults_file = tmp_path / "cli-defaults.json"
+    defaults_file.write_text("{ not valid json }")
+    monkeypatch.setattr(cli_mod, "DEFAULT_DEFAULTS_FILE", defaults_file)
+
+    assert _load_cli_defaults() == {}
+
+
+def test_save_cli_defaults_creates_file_and_parent(monkeypatch, tmp_path: Path):
+    import kdcube_cli.cli as cli_mod
+
+    defaults_file = tmp_path / "nested" / "dir" / "cli-defaults.json"
+    monkeypatch.setattr(cli_mod, "DEFAULT_DEFAULTS_FILE", defaults_file)
+
+    _save_cli_defaults({"default_tenant": "demo", "default_workdir": "/tmp/runtime"})
+
+    assert defaults_file.exists()
+    saved = json.loads(defaults_file.read_text())
+    assert saved["default_tenant"] == "demo"
+    assert saved["default_workdir"] == "/tmp/runtime"
+
+
+def test_save_cli_defaults_overwrites_existing(monkeypatch, tmp_path: Path):
+    import kdcube_cli.cli as cli_mod
+
+    defaults_file = tmp_path / "cli-defaults.json"
+    defaults_file.write_text(json.dumps({"default_tenant": "old"}))
+    monkeypatch.setattr(cli_mod, "DEFAULT_DEFAULTS_FILE", defaults_file)
+
+    _save_cli_defaults({"default_tenant": "new", "default_project": "app"})
+
+    saved = json.loads(defaults_file.read_text())
+    assert saved == {"default_tenant": "new", "default_project": "app"}
+
+
+def test_save_and_load_cli_defaults_roundtrip(monkeypatch, tmp_path: Path):
+    import kdcube_cli.cli as cli_mod
+
+    defaults_file = tmp_path / "cli-defaults.json"
+    monkeypatch.setattr(cli_mod, "DEFAULT_DEFAULTS_FILE", defaults_file)
+
+    original = {"default_tenant": "corp", "default_project": "chat", "default_workdir": "/opt/rt"}
+    _save_cli_defaults(original)
+    loaded = _load_cli_defaults()
+
+    assert loaded == original

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
@@ -5,6 +5,7 @@ import yaml
 from rich.console import Console
 
 from kdcube_cli.cli import (
+    _bootstrap_repo_for_defaults,
     _build_paths_for_repo,
     _canonical_descriptor_dir_from_initialized_workdir,
     _collect_runtime_info,
@@ -2102,3 +2103,90 @@ def test_gather_configuration_default_bootstrap_prompts_only_minimal_inputs(monk
 
     env_main = (config_dir / ".env").read_text()
     assert f"HOST_BUNDLES_PATH={(tmp_path / 'src').resolve()}" in env_main
+
+
+# ---------------------------------------------------------------------------
+# _bootstrap_repo_for_defaults
+# ---------------------------------------------------------------------------
+
+def _make_fake_repo_with_deployment(base: Path) -> Path:
+    """Create a minimal fake git repo that contains app/ai-app/deployment/assembly.yaml."""
+    repo = base / "repo"
+    (repo / ".git").mkdir(parents=True)
+    deployment = repo / "app" / "ai-app" / "deployment"
+    deployment.mkdir(parents=True)
+    (deployment / "assembly.yaml").write_text("context:\n  tenant: demo-tenant\n  project: demo-project\n")
+    return repo
+
+
+def test_bootstrap_repo_for_defaults_uses_path_provided_repo(tmp_path: Path):
+    repo = _make_fake_repo_with_deployment(tmp_path)
+    console = Console(quiet=True)
+
+    resolved_repo, descriptors_loc = _bootstrap_repo_for_defaults(
+        console,
+        repo="https://example.com/repo.git",
+        repo_path=repo,
+        path_provided=True,
+    )
+
+    assert resolved_repo == repo
+    assert descriptors_loc == repo / "app" / "ai-app" / "deployment"
+    assert (descriptors_loc / "assembly.yaml").exists()
+
+
+def test_bootstrap_repo_for_defaults_path_provided_requires_git_repo(tmp_path: Path):
+    not_a_repo = tmp_path / "not-a-repo"
+    not_a_repo.mkdir()
+    console = Console(quiet=True)
+
+    try:
+        _bootstrap_repo_for_defaults(
+            console,
+            repo="https://example.com/repo.git",
+            repo_path=not_a_repo,
+            path_provided=True,
+        )
+        raise AssertionError("Expected SystemExit for non-git path")
+    except SystemExit as exc:
+        assert "not a git repo" in str(exc).lower()
+
+
+def test_bootstrap_repo_for_defaults_clones_when_path_not_provided(monkeypatch, tmp_path: Path):
+    repo = _make_fake_repo_with_deployment(tmp_path)
+    cloned: list[str] = []
+
+    def fake_ensure_repo(console, repo_url, target):
+        cloned.append(repo_url)
+
+    monkeypatch.setattr("kdcube_cli.cli.ensure_repo", fake_ensure_repo)
+    console = Console(quiet=True)
+
+    resolved_repo, descriptors_loc = _bootstrap_repo_for_defaults(
+        console,
+        repo="https://example.com/repo.git",
+        repo_path=repo,
+        path_provided=False,
+    )
+
+    assert cloned == ["https://example.com/repo.git"]
+    assert resolved_repo == repo
+    assert descriptors_loc == repo / "app" / "ai-app" / "deployment"
+
+
+def test_bootstrap_repo_for_defaults_raises_when_deployment_missing(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    # No app/ai-app/deployment directory created
+    console = Console(quiet=True)
+
+    try:
+        _bootstrap_repo_for_defaults(
+            console,
+            repo="https://example.com/repo.git",
+            repo_path=repo,
+            path_provided=True,
+        )
+        raise AssertionError("Expected SystemExit for missing deployment dir")
+    except SystemExit as exc:
+        assert "deployment descriptors" in str(exc).lower()


### PR DESCRIPTION
  ## Summary                                                                                                                   
  
  Replaces legacy top-level flags with dedicated subcommands, adds a                                                           
  per-machine deployment guard via `cli-lock.json`, introduces persistent
  operator defaults, and aligns all documentation to the new CLI surface.                                                      
                  
  ### New subcommands                                                                                                          
                  
  - `kdcube init` — stage descriptors and env files without starting Docker;                                                   
    `-i/--interactive` prompts for tenant/project **before** workdir resolution
    so the directory namespace is correct from the start                                                                       
  - `kdcube start` — launch Docker Compose for an already-initialized workdir
  - `kdcube stop` — pre-validates via `docker compose ps` and `cli-lock.json`                                                  
    before stopping; replaces `--stop`                                                                                         
  - `kdcube reload <bundle_id>` — replaces `--bundle-reload`                                                                   
  - `kdcube export` — replaces `--export-live-bundles`                                                                         
  - `kdcube defaults` — persists operator defaults to
    `~/.kdcube/cli-defaults.json`; replaces `--set-defaults`                                                                   
                                                                                                                               
  ### `--info` flag (two levels)                                                                                               
                                                                                                                               
  - `kdcube --info` — global: shows configured defaults + currently running                                                    
    deployment (verified via `docker compose ps`); stale locks cleared
    automatically                                                                                                              
  - `kdcube --info --workdir <path>` — deployment: descriptor paths, install
    metadata, host/container bundle mount mappings                                                                             
                                                                                                                               
  ### Workdir resolution for subcommands                                                                                       
                                                                                                                               
  1. `--workdir` explicit → use it                                                                                             
  2. omitted + `default_workdir` in `cli-defaults.json` → use that
  3. neither → error with hint to run `kdcube defaults`                                                                        
                                                                                                                               
  ### Single-deployment guard (`cli-lock.json`)                                                                                
                                                                                                                               
  `~/.kdcube/cli-lock.json` tracks the active local deployment.                                                                
                  
  - **start**: aborts if a different live deployment is running; clears stale                                                  
    locks automatically
  - **stop**: verifies target is running and matches the lock record before                                                    
    proceeding                                                                                                                 
  - Lock helpers centralized: `_check_before_start`, `_check_before_stop`,
    `_lock_running_services`                                                                                                   
                                                                                                                               
  ### `kdcube init --interactive`                                                                                              
                                                                                                                               
  Tenant/project are prompted **before** workdir resolution. The CLI sets                                                      
  `KDCUBE_PRESET_TENANT` / `KDCUBE_PRESET_PROJECT` env vars so
  `gather_configuration()` in the installer skips its own prompt without                                                       
  triggering the full default-descriptor bootstrap path (which would cause                                                     
  unwanted extra prompts for host paths).                                                                                      
                                                                                                                               
  ### Removed legacy flags                                                                                                     
                                                                                                                               
  `--stop`, `--bundle-reload`, `--export-live-bundles`, `--set-defaults`.                                                      
  Companion args (`--remove-volumes`, `--tenant`, `--project`, `--out-dir`,
  `--aws-*`, `--default-*`) kept and wired to the new subcommands.  