### PR TITLE
Fix chat timeline event ordering

### DIFF
--- a/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/ChatLog.tsx
+++ b/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/ChatLog.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from "react";
+import {Fragment, ReactNode, useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {connectChat, sendChatMessage} from "../../../features/chat/chatServiceMiddleware.ts";
 import {ChevronsDown, Loader} from "lucide-react";
 import {UserMessageComponent} from "./UserMessageComponent.tsx";
@@ -16,6 +16,63 @@ import {
 } from "../../../features/logExtensions/conversationStatus/types.ts";
 import {motion} from "motion/react";
 import IconContainer from "../../IconContainer.tsx";
+import {AssistantMessage, UserMessage, UnknownArtifact} from "../../../features/chat/chatTypes.ts";
+import {getChatLogComponent} from "../../../features/extensions/logExtesnions.ts";
+
+type OrderedTurnItem =
+    | { kind: "user"; item: UserMessage; timestamp: number; index: number }
+    | { kind: "assistant"; item: AssistantMessage; artifacts: UnknownArtifact[]; timestamp: number; index: number }
+    | { kind: "activity"; timestamp: number; index: number }
+    | { kind: "artifact"; item: UnknownArtifact; timestamp: number; index: number };
+
+const isRenderableArtifact = (artifact: UnknownArtifact) => {
+    if (artifact.artifactType === ConversationStatusArtifactType) return false;
+    return !!getChatLogComponent(artifact.artifactType);
+}
+
+const activityArtifacts = (artifacts: UnknownArtifact[]) => {
+    return artifacts.filter((artifact) => {
+        switch (artifact.artifactType) {
+            case "thinking":
+                return true;
+            default:
+                return false;
+        }
+    });
+}
+
+const assistantArtifacts = (artifacts: UnknownArtifact[]) => {
+    return artifacts.filter((artifact) => {
+        switch (artifact.artifactType) {
+            case "citation":
+            case "file":
+                return true;
+            default:
+                return false;
+        }
+    });
+}
+
+const getActivityTimestamp = (
+    artifacts: UnknownArtifact[],
+    steps: { timestamp: number }[],
+    fallback: number,
+) => {
+    const artifactTimestamps = artifacts
+        .map((artifact) => artifact.timestamp)
+        .filter(Number.isFinite);
+
+    const stepTimestamps = steps
+        .map((step) => step.timestamp)
+        .filter(Number.isFinite);
+
+    const timestamps = [...artifactTimestamps, ...stepTimestamps];
+    if (timestamps.length > 0) {
+        return Math.min(...timestamps);
+    }
+
+    return fallback;
+}
 
 const ChatLog = () => {
     const dispatch = useAppDispatch();
@@ -141,19 +198,148 @@ const ChatLog = () => {
         return (<>
             {turnOrder.map(turnId => {
                 const turn = turns[turnId];
+                const orderedItems: OrderedTurnItem[] = [];
+                let index = 0;
+                const sharedActivityArtifacts = activityArtifacts(turn.artifacts);
+                const assistantScopedArtifacts = assistantArtifacts(turn.artifacts);
+                const renderableArtifacts = turn.artifacts.filter(isRenderableArtifact);
+                const turnSteps = Object.values(turn.steps);
+
+                if (turn.userMessage.text || turn.userMessage.attachments?.length) {
+                    orderedItems.push({
+                        kind: "user",
+                        item: turn.userMessage,
+                        timestamp: turn.userMessage.timestamp,
+                        index: index++,
+                    });
+                }
+
+                (turn.additionalUserMessages ?? []).forEach((message) => {
+                    orderedItems.push({
+                        kind: "user",
+                        item: message,
+                        timestamp: message.timestamp,
+                        index: index++,
+                    });
+                });
+
+                if (sharedActivityArtifacts.length > 0 || turnSteps.length > 0 || turn.state === "inProgress") {
+                    orderedItems.push({
+                        kind: "activity",
+                        timestamp: getActivityTimestamp(
+                            sharedActivityArtifacts,
+                            turnSteps,
+                            turn.userMessage.timestamp + 1,
+                        ),
+                        index: index++,
+                    });
+                }
+
+                const assistantMessages = (turn.assistantMessages && turn.assistantMessages.length > 0)
+                    ? turn.assistantMessages
+                    : (turn.answer ? [{text: turn.answer, timestamp: turn.events.find((event) => event.eventType === "answer")?.timestamp ?? turn.userMessage.timestamp + 1}] : []);
+
+                assistantMessages.forEach((message, assistantIndex) => {
+                    orderedItems.push({
+                        kind: "assistant",
+                        item: message,
+                        artifacts: assistantIndex === assistantMessages.length - 1 ? assistantScopedArtifacts : [],
+                        timestamp: message.timestamp,
+                        index: index++,
+                    });
+                });
+
+                renderableArtifacts.forEach((artifact) => {
+                    orderedItems.push({
+                        kind: "artifact",
+                        item: artifact,
+                        timestamp: artifact.timestamp,
+                        index: index++,
+                    });
+                });
+
+                orderedItems.sort((a, b) => a.timestamp - b.timestamp || a.index - b.index);
+
+                const rendered: ReactNode[] = [];
+                let renderedActivity = false;
+                let renderedAssistant = false;
+
+                const renderActivityCarrier = (key: string) => {
+                    const showActivity = !renderedActivity;
+                    renderedActivity = true;
+                    renderedAssistant = true;
+                    return (
+                        <AssistantMessageComponent
+                            key={key}
+                            message={null}
+                            isGreeting={false}
+                            artifacts={showActivity ? sharedActivityArtifacts : []}
+                            steps={showActivity ? turnSteps : []}
+                            isError={turn.state === 'error'}
+                            isHistorical={turn.historical}
+                            turnId={turnId}
+                            showActivity={showActivity}
+                            showTimelineArtifacts={showActivity}
+                        />
+                    );
+                };
+
+                const renderAssistantMessage = (key: string, message: AssistantMessage, artifacts: UnknownArtifact[]) => {
+                    renderedAssistant = true;
+                    return (
+                        <AssistantMessageComponent
+                            key={key}
+                            message={message.text}
+                            isGreeting={false}
+                            artifacts={artifacts}
+                            steps={[]}
+                            isError={turn.state === 'error'}
+                            isHistorical={turn.historical}
+                            turnId={turnId}
+                            showActivity={false}
+                            showTimelineArtifacts={false}
+                        />
+                    );
+                };
+
+                orderedItems.forEach((entry) => {
+                    if (entry.kind === "user") {
+                        rendered.push(
+                            <UserMessageComponent
+                                key={`user_${turnId}_${entry.item.timestamp}_${entry.index}`}
+                                message={entry.item}
+                                turnId={turnId}
+                            />
+                        );
+                        return;
+                    }
+
+                    if (entry.kind === "assistant") {
+                        rendered.push(renderAssistantMessage(`assistant_${turnId}_${entry.item.timestamp}_${entry.index}`, entry.item, entry.artifacts));
+                        return;
+                    }
+
+                    if (entry.kind === "activity") {
+                        rendered.push(renderActivityCarrier(`activity_${turnId}_${entry.timestamp}_${entry.index}`));
+                        return;
+                    }
+
+                    const Component = getChatLogComponent(entry.item.artifactType);
+                    if (Component) {
+                        rendered.push(
+                            <Component
+                                key={`artifact_${turnId}_${entry.item.artifactType}_${entry.item.timestamp}_${entry.index}`}
+                                item={entry.item}
+                                historical={turn.historical}
+                            />
+                        );
+                    }
+                });
 
                 return (<Fragment key={turnId}>
-                    {turn.userMessage.text && <UserMessageComponent message={turn.userMessage} turnId={turnId}/>}
-                    <AssistantMessageComponent
-                        message={turn.answer}
-                        isGreeting={false}
-                        artifacts={turn.artifacts}
-                        steps={Object.values(turn.steps)}
-                        isError={turn.state === 'error'}
-                        isHistorical={turn.historical}
-                        followupMessages={turn.additionalUserMessages}
-                        turnId={turnId}
-                    />
+                    {rendered}
+                    {!renderedAssistant && (sharedActivityArtifacts.length > 0 || turnSteps.length > 0 || turn.state === "inProgress") &&
+                        renderActivityCarrier(`assistant_activity_${turnId}`)}
                 </Fragment>)
             })}
         </>)

--- a/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/UserMessageComponent.tsx
+++ b/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/UserMessageComponent.tsx
@@ -27,11 +27,12 @@ export const UserMessageComponent = ({turnId, message}: UserMessageProps) => {
                             {message.attachments && message.attachments.length > 0 && (
                                 <div className="flex flex-row gap-1 flex-wrap">
                                     {message.attachments?.map(attachment => {
+                                        const key = attachment.artifactPath ?? attachment.sourceMessageId ?? `${attachment.name}_${attachment.size}`;
                                         return (
                                             <div
-                                                key={attachment.name}
+                                                key={key}
                                                 className="flex items-center border-2 px-2 py-1 rounded-xl border-gray-300 bg-gray-100"
-                                            >{getFileIcon(attachment.name, 18, undefined, "mr-1")}{attachment.name}</div>
+                                            >{getFileIcon(attachment.name, 18, attachment.mime ?? undefined, "mr-1")}{attachment.name}</div>
                                         )
                                     })}
                                 </div>)}

--- a/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/assistantMessage/AssistantMessageComponent.tsx
+++ b/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/assistantMessage/AssistantMessageComponent.tsx
@@ -2,7 +2,6 @@ import {RNFile, TurnStep} from "../../../../features/chatController/chatBase.ts"
 import {useAppSelector} from "../../../../app/store.ts";
 import {selectCurrentTurn} from "../../../../features/chat/chatStateSlice.ts";
 import React, {ReactNode, useCallback, useMemo, useRef, useState} from "react";
-import {UserMessageComponent} from "../UserMessageComponent.tsx";
 import {closeUpMarkdown, useWordStreamEffect} from "../../../WordStreamingEffects.tsx";
 import ReactMarkdown from "react-markdown";
 import {markdownComponents, markdownComponentsTight, rehypePlugins, remarkPlugins} from "../markdownRenderUtils.tsx";
@@ -31,8 +30,7 @@ import {
     CitationArtifact,
     FileArtifact,
     ThinkingArtifact,
-    UnknownArtifact,
-    UserMessage
+    UnknownArtifact
 } from "../../../../features/chat/chatTypes.ts";
 import {downloadResourceByRN} from "../../../../app/api/utils.ts";
 import {getFileIcon} from "../../../FileIcons.tsx";
@@ -135,8 +133,9 @@ interface AssistantMessageProps {
     isGreeting: boolean;
     isError: boolean;
     isHistorical: boolean | undefined | null;
-    followupMessages?: UserMessage[];
     turnId?: string;
+    showActivity?: boolean;
+    showTimelineArtifacts?: boolean;
 }
 
 export const AssistantMessageComponent = ({
@@ -145,8 +144,8 @@ export const AssistantMessageComponent = ({
                                               artifacts,
                                               isHistorical,
                                               isGreeting = false,
-                                              followupMessages,
-                                              turnId,
+                                              showActivity = true,
+                                              showTimelineArtifacts = true,
                                           }: AssistantMessageProps) => {
     const currentTurn = useAppSelector(selectCurrentTurn)
     const inProgress = useMemo(() => !!currentTurn, [currentTurn])
@@ -307,58 +306,25 @@ export const AssistantMessageComponent = ({
         </div>)
     }, [citations])
 
-    const thinkingStartMs = useMemo(() => {
-        if (thinkingItems.length === 0) return null;
-        return Math.min(...thinkingItems.map(t => t.timestamp));
-    }, [thinkingItems]);
-
-    const {beforeThinkingFollowups, afterThinkingFollowups} = useMemo(() => {
-        const msgs = followupMessages ?? [];
-        if (msgs.length === 0) return {beforeThinkingFollowups: [], afterThinkingFollowups: []};
-        if (thinkingStartMs === null) return {beforeThinkingFollowups: msgs, afterThinkingFollowups: []};
-        return {
-            beforeThinkingFollowups: msgs.filter(m => m.timestamp < thinkingStartMs),
-            afterThinkingFollowups: msgs.filter(m => m.timestamp >= thinkingStartMs),
-        };
-    }, [followupMessages, thinkingStartMs]);
-
     const thinkingItemsMemo = useMemo(() => {
-        const thinkingBlock = thinkingItems.length > 0 ? (
-            <>
-                {thinkingItems.map((item, i) => <Thinking item={item} key={i}/>)}
-            </>
-        ) : null;
-
-        if (beforeThinkingFollowups.length === 0) return thinkingBlock;
-
-        return (
-            <>
-                {beforeThinkingFollowups.map(msg => (
-                    <UserMessageComponent key={`followup_${msg.timestamp}`} turnId={turnId ?? ""} message={msg}/>
-                ))}
-                {thinkingBlock}
-            </>
-        );
-    }, [thinkingItems, beforeThinkingFollowups, turnId])
+        if (!showActivity || thinkingItems.length === 0) return null;
+        return <>{thinkingItems.map((item, i) => <Thinking item={item} key={i}/>)}</>;
+    }, [thinkingItems, showActivity])
 
     const timelineMemo = useMemo(() => {
-        type MixedItem = UnknownArtifact | UserMessage;
-        const items: MixedItem[] = [...other, ...afterThinkingFollowups];
+        if (!showTimelineArtifacts) return null;
+        const items: UnknownArtifact[] = [...other];
         items.sort((a, b) => a.timestamp - b.timestamp);
 
         return <div className={"w-full min-w-0 flex flex-col"}>
             {items.map((item) => {
-                if ('text' in item && 'attachments' in item) {
-                    const msg = item as UserMessage;
-                    return <UserMessageComponent key={`followup_${msg.timestamp}`} turnId={turnId ?? ""} message={msg}/>
-                }
                 const artifact = item as UnknownArtifact;
                 const Component = getChatLogComponent(artifact.artifactType)
                 if (!Component) return null
                 return <Component key={`${artifact.artifactType}_${artifact.timestamp}`} item={artifact} historical={isHistorical}/>
             })}
         </div>
-    }, [isHistorical, other, afterThinkingFollowups, turnId])
+    }, [isHistorical, other, showTimelineArtifacts])
 
     return useMemo(() => {
         return (

--- a/app/ai-app/ui/chat-web-app/src/features/chat/chatServiceMiddleware.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/chat/chatServiceMiddleware.ts
@@ -5,6 +5,7 @@ import SocketIOChat from "../chatController/socketIOChat.ts";
 import {
     chatCompleted,
     chatConnected,
+    appendTurnUserMessage,
     chatDelta,
     chatDisconnected,
     chatStarted,
@@ -389,6 +390,7 @@ export const chatServiceMiddleware = (transportType: TransportType): Middleware 
                     const isContinuation = continuationKind === "followup" || continuationKind === "steer"
                     const targetTurnId = request.targetTurnId ?? activeTurn?.id ?? undefined
                     const turnId = `turn_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+                    const sentAt = new Date().getTime();
 
                     const message = request.message ?? selectUserMessage(state)
 
@@ -470,6 +472,15 @@ export const chatServiceMiddleware = (transportType: TransportType): Middleware 
                             const ackStatus = typeof ack?.status === "string" ? ack.status : null
                             const continuationAccepted = ackStatus === "followup_accepted" || ackStatus === "steer_accepted"
                             const continuationStartedNewTurn = !!ackStatus && !continuationAccepted
+                            if (!continuationStartedNewTurn && continuationKind === "followup" && targetTurnId) {
+                                dispatch(appendTurnUserMessage({
+                                    turnId: targetTurnId,
+                                    text: message,
+                                    attachments,
+                                    timestamp: sentAt,
+                                    continuationKind: "followup",
+                                }))
+                            }
                             dispatch(pushNotification({
                                 type: "info",
                                 text: continuationStartedNewTurn

--- a/app/ai-app/ui/chat-web-app/src/features/chat/chatStateSlice.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/chat/chatStateSlice.ts
@@ -12,6 +12,7 @@ import {
 import {v4 as uuidv4} from "uuid";
 import {
     AgentTiming,
+    AssistantMessage,
     AnswerEvent,
     CanvasEvent,
     ChatTurn,
@@ -25,7 +26,9 @@ import {
     ThinkingArtifact,
     ThinkingEvent,
     TimelineTextEvent,
-    TurnError
+    TurnError,
+    UserMessage,
+    UserAttachmentDescription
 } from "./chatTypes.ts";
 import {
     CodeExecArtifact,
@@ -335,6 +338,84 @@ const createSyntheticTurn = (
     }
 }
 
+const splitAssistantAnswerAttempts = (events: AnswerEvent[]): AssistantMessage[] => {
+    const attempts: AnswerEvent[][] = [];
+    let current: AnswerEvent[] = [];
+
+    events
+        .slice()
+        .sort((a, b) => a.timestamp - b.timestamp || a.index - b.index)
+        .forEach((event) => {
+            const prev = current[current.length - 1];
+            const startsNewAttempt =
+                current.length > 0 &&
+                (
+                    !!prev?.completed ||
+                    event.index <= (prev?.index ?? -1)
+                );
+
+            if (startsNewAttempt) {
+                attempts.push(current);
+                current = [];
+            }
+
+            current.push(event);
+
+            if (event.completed) {
+                attempts.push(current);
+                current = [];
+            }
+        });
+
+    if (current.length > 0) {
+        attempts.push(current);
+    }
+
+    return attempts
+        .filter((attempt) => attempt.length > 0)
+        .map((attempt) => ({
+            text: attempt.map((event) => event.data.text).join(""),
+            timestamp: attempt[0].timestamp,
+        }));
+}
+
+const isUserOriginAttachmentItem = (item: unknown) => {
+    if (!item || typeof item !== "object") return false;
+    const data = item as Record<string, unknown>;
+    const meta = data.meta && typeof data.meta === "object" ? data.meta as Record<string, unknown> : {};
+    const role = String(data.role ?? meta.role ?? "").toLowerCase();
+    const origin = String(data.origin ?? meta.origin ?? "").toLowerCase();
+    return role === "user" || origin === "user";
+}
+
+const isUserOriginAttachmentStep = (stepId: string, data: Record<string, unknown> | undefined) => {
+    if (stepId !== "attachments") return false;
+    const items = Array.isArray(data?.items) ? data.items : [];
+    return items.length > 0 && items.every((item) => isUserOriginAttachmentItem(item));
+}
+
+const appendUserMessageToTurn = (
+    turn: WritableDraft<ChatTurn>,
+    message: UserMessage,
+) => {
+    const continuationKind = String(message.continuationKind ?? "").toLowerCase();
+    const isFollowupLike = continuationKind === "followup" || continuationKind === "steer";
+
+    if (!isFollowupLike && !turn.userMessage.text) {
+        turn.userMessage = message;
+        return;
+    }
+
+    turn.additionalUserMessages = turn.additionalUserMessages ?? [];
+    const alreadyExists = turn.additionalUserMessages.some((existing) => {
+        if (message.sourceMessageId && existing.sourceMessageId === message.sourceMessageId) return true;
+        return existing.timestamp === message.timestamp && existing.text === message.text;
+    });
+    if (!alreadyExists) {
+        turn.additionalUserMessages.push(message);
+    }
+}
+
 const chatStateSlice = createSlice({
     name: 'chatState',
     initialState: (): ChatState => {
@@ -470,6 +551,31 @@ const chatStateSlice = createSlice({
             };
             state.turnOrder.push(turnId);
         },
+        appendTurnUserMessage: (state, action: PayloadAction<{
+            turnId: string;
+            text: string;
+            attachments: UserAttachmentDescription[];
+            timestamp: number;
+            continuationKind?: string;
+            sourceMessageId?: string;
+            artifactPath?: string;
+            historyMeta?: Record<string, unknown>;
+        }>) => {
+            const turn = state.turns[action.payload.turnId];
+            if (!turn) {
+                console.warn("Received user message for an unknown turn", action.payload.turnId);
+                return;
+            }
+            appendUserMessageToTurn(turn, {
+                text: action.payload.text,
+                attachments: action.payload.attachments,
+                timestamp: action.payload.timestamp,
+                continuationKind: action.payload.continuationKind,
+                sourceMessageId: action.payload.sourceMessageId,
+                artifactPath: action.payload.artifactPath,
+                historyMeta: action.payload.historyMeta,
+            });
+        },
         turnError: (state, action: PayloadAction<TurnError>) => {
             const turn = state.turns[action.payload.turnId];
             turn.state = "error";
@@ -509,6 +615,15 @@ const chatStateSlice = createSlice({
             const turn = state.turns[turnId]
             const stepId = env.event.step
             const stepStatus = env.event.status
+
+            if (!turn) {
+                console.warn("Received step for an unknown turn", env);
+                return;
+            }
+
+            if (isUserOriginAttachmentStep(stepId, env.data)) {
+                return;
+            }
 
             const existing = Object.hasOwn(state.turns[turnId].steps, stepId) ? state.turns[turnId].steps[stepId] : null;
 
@@ -585,6 +700,10 @@ const chatStateSlice = createSlice({
             const completed = !!env.delta.completed;
 
             const turn = state.turns[turnId]
+            if (!turn) {
+                console.warn("Received delta for an unknown turn", env);
+                return;
+            }
 
             switch (marker) {
                 case "thinking": {
@@ -625,7 +744,9 @@ const chatStateSlice = createSlice({
                     }
                     turn.events.push(event);
                     const turnEvents = turn.events.filter(ev => ev.eventType === "answer") as AnswerEvent[]
-                    turn.answer = turnEvents.map(event => event.data.text).join("")
+                    const attempts = splitAssistantAnswerAttempts(turnEvents);
+                    turn.assistantMessages = attempts;
+                    turn.answer = attempts.at(-1)?.text ?? "";
                     break;
                 }
                 case "canvas": {
@@ -886,6 +1007,7 @@ export const {
     addUserAttachments,
     removeUserAttachment,
     clearUserInput,
+    appendTurnUserMessage,
     newConversation,
     loadConversation,
     loadExampleConversation,

--- a/app/ai-app/ui/chat-web-app/src/features/chat/chatTypes.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/chat/chatTypes.ts
@@ -42,6 +42,13 @@ export interface ChatSettingsState {
 export interface UserAttachmentDescription {
     name: string;
     size: number;
+    timestamp?: number;
+    mime?: string | null;
+    rn?: string | null;
+    artifactPath?: string;
+    sourceMessageId?: string;
+    continuationKind?: string;
+    historyMeta?: Record<string, unknown>;
 }
 
 export interface UserAttachment extends UserAttachmentDescription {
@@ -69,6 +76,16 @@ export interface ChatState extends ConversationState {
 export interface UserMessage extends Timestamped {
     text: string,
     attachments: UserAttachmentDescription[],
+    continuationKind?: string;
+    sourceMessageId?: string;
+    artifactPath?: string;
+    historyMeta?: Record<string, unknown>;
+}
+
+export interface AssistantMessage extends Timestamped {
+    text: string;
+    artifactPath?: string;
+    historyMeta?: Record<string, unknown>;
 }
 
 export interface AgentTiming {
@@ -173,6 +190,7 @@ export interface ChatTurn {
     state: TurnState;
     userMessage: UserMessage;
     additionalUserMessages?: UserMessage[];
+    assistantMessages?: AssistantMessage[];
     answer?: string | null;
     events: TurnEvent<unknown>[];
     steps: Record<string, TurnStep>;

--- a/app/ai-app/ui/chat-web-app/src/features/conversations/conversationsMiddleware.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/conversations/conversationsMiddleware.ts
@@ -31,11 +31,13 @@ import {
 } from "./conversationsTypes.ts";
 import {
     AgentTiming,
+    AssistantMessage,
     ChatTurn,
     CitationArtifact,
     FileArtifact,
     ThinkingArtifact,
     UnknownArtifact,
+    UserAttachmentDescription,
     UserMessage
 } from "../chat/chatTypes.ts";
 import {RichLink, RNFile} from "../chatController/chatBase.ts";
@@ -96,6 +98,86 @@ export const addArtifactStreamParsers = (...parsers: ArtifactStreamParser[]) => 
     artifactStreamParsers.push(...parsers);
 }
 
+const parseExternalAttachmentPath = (artifactPath?: string | null) => {
+    if (!artifactPath || typeof artifactPath !== "string") return {};
+
+    const externalMatch = artifactPath.match(/^fi:([^.]*)\.external\.([^.]+)\.attachments\/([^/]+)\/(.+)$/);
+    if (externalMatch) {
+        return {
+            continuationKind: externalMatch[2],
+            sourceMessageId: externalMatch[3],
+        };
+    }
+
+    const legacyExternalMatch = artifactPath.match(/^fi:([^.]*)\.external\.([^.]+)\.([^.]+)\.attachments\/(.+)$/);
+    if (legacyExternalMatch) {
+        return {
+            continuationKind: legacyExternalMatch[2],
+            sourceMessageId: legacyExternalMatch[3],
+        };
+    }
+
+    return {};
+}
+
+const parseExternalMessageIdFromPath = (path?: string | null) => {
+    if (!path || typeof path !== "string") return undefined;
+    const match = path.match(/^ar:([^.]*)\.external\.([^.]+)\.([^.]+)$/);
+    return match?.[3];
+}
+
+const isExternalAttachmentArtifact = (artifactPath?: string | null) => {
+    return !!artifactPath && (
+        /^fi:([^.]*)\.external\.([^.]+)\.attachments\//.test(artifactPath) ||
+        /^fi:([^.]*)\.external\.([^.]+)\.([^.]+)\.attachments\//.test(artifactPath)
+    );
+}
+
+const getArtifactMeta = (data: unknown): Record<string, unknown> => {
+    if (!data || typeof data !== "object") return {};
+    const meta = (data as { meta?: unknown }).meta;
+    return meta && typeof meta === "object" ? meta as Record<string, unknown> : {};
+}
+
+const getUserMessageIdentity = (message: UserMessage) => {
+    if (message.sourceMessageId) return message.sourceMessageId;
+    const meta = message.historyMeta;
+    if (meta && typeof meta.message_id === "string") return meta.message_id;
+    if (meta && typeof meta.path === "string") return parseExternalMessageIdFromPath(meta.path);
+    if (message.artifactPath) return parseExternalMessageIdFromPath(message.artifactPath);
+    return undefined;
+}
+
+const bindAttachmentsToUserMessages = (messages: UserMessage[], attachments: UserAttachmentDescription[]) => {
+    if (!messages.length || !attachments.length) return;
+
+    attachments.forEach((attachment) => {
+        let target = messages.find((message) => {
+            const sourceMessageId = attachment.sourceMessageId;
+            return !!sourceMessageId && sourceMessageId === getUserMessageIdentity(message);
+        });
+
+        if (!target && attachment.continuationKind) {
+            const attachmentTs = attachment.timestamp ?? Number.MAX_SAFE_INTEGER;
+            const candidates = messages.filter((message) => message.continuationKind === attachment.continuationKind);
+            target = candidates
+                .filter((message) => message.timestamp <= attachmentTs)
+                .sort((a, b) => b.timestamp - a.timestamp)[0] ?? candidates.at(-1);
+        }
+
+        if (!target) {
+            const attachmentTs = attachment.timestamp ?? Number.MAX_SAFE_INTEGER;
+            target = messages
+                .filter((message) => message.timestamp <= attachmentTs)
+                .sort((a, b) => b.timestamp - a.timestamp)[0] ?? messages.at(-1);
+        }
+
+        if (target) {
+            target.attachments.push(attachment);
+        }
+    });
+}
+
 const conversationsMiddleware = (): Middleware => {
     const loadConversationList = (store: AppStore) => {
         const dispatch = store.dispatch
@@ -128,6 +210,9 @@ const conversationsMiddleware = (): Middleware => {
                 turns: conversation.turns.reduce((previousValue, currentValue, i, arr) => {
                     let userMessage: UserMessage | null = null;
                     const additionalUserMessages: UserMessage[] = [];
+                    const userMessages: UserMessage[] = [];
+                    const userAttachments: UserAttachmentDescription[] = [];
+                    const assistantMessages: AssistantMessage[] = [];
                     let answer: string | null = null;
                     const followUpQuestions: string[] = []
                     const turnArtifacts: UnknownArtifact[] = []
@@ -135,39 +220,75 @@ const conversationsMiddleware = (): Middleware => {
                     currentValue.artifacts.forEach(it => {
                         switch (it.type) {
                             case "chat:user": {
-                                const isFollowup = it.data.continuation_kind === "followup";
-                                if (isFollowup && userMessage) {
-                                    // Followup message within the active turn — append after original
-                                    additionalUserMessages.push({
-                                        text: it.data.text,
-                                        timestamp: Date.parse(it.ts),
-                                        attachments: [],
-                                    });
-                                } else if (!isFollowup) {
-                                    userMessage = {
-                                        text: it.data.text,
-                                        timestamp: Date.parse(it.ts),
-                                        attachments: userMessage ? userMessage.attachments : []
-                                    };
-                                }
-                                // isFollowup && !userMessage → Turn B, skip
+                                const meta = getArtifactMeta(it.data);
+                                const artifactPath = typeof meta.path === "string" ? meta.path : undefined;
+                                const continuationKind = it.data.continuation_kind ?? (typeof meta.continuation_kind === "string" ? meta.continuation_kind : undefined);
+                                const sourceMessageId =
+                                    (typeof meta.message_id === "string" ? meta.message_id : undefined) ??
+                                    parseExternalMessageIdFromPath(artifactPath);
+                                userMessages.push({
+                                    text: it.data.text,
+                                    timestamp: Date.parse(it.ts),
+                                    attachments: [],
+                                    continuationKind,
+                                    sourceMessageId,
+                                    artifactPath,
+                                    historyMeta: meta,
+                                });
                                 break;
                             }
-                            case "artifact:user.attachment":
-                                userMessage = {
-                                    text: userMessage ? userMessage.text : "",
-                                    timestamp: userMessage ? userMessage.timestamp : Date.parse(it.ts),
-                                    attachments: []
-                                }
+                            case "artifact:user.attachment": {
+                                const dto = it.data as {
+                                    payload?: {
+                                        filename?: string;
+                                        name?: string;
+                                        size?: number;
+                                        mime?: string | null;
+                                        rn?: string | null;
+                                        artifact_path?: string;
+                                        message_id?: string;
+                                        continuation_kind?: string;
+                                        meta?: Record<string, unknown>;
+                                    };
+                                    meta?: Record<string, unknown>;
+                                };
+                                const payload = dto.payload ?? {};
+                                const meta = getArtifactMeta(it.data);
+                                const artifactPath = payload.artifact_path;
+                                const parsedPath = parseExternalAttachmentPath(artifactPath);
+                                userAttachments.push({
+                                    name: payload.filename ?? payload.name ?? "file",
+                                    size: payload.size ?? 0,
+                                    timestamp: Date.parse(it.ts),
+                                    mime: payload.mime,
+                                    rn: payload.rn,
+                                    artifactPath,
+                                    sourceMessageId: payload.message_id ?? (typeof meta.message_id === "string" ? meta.message_id : undefined) ?? parsedPath.sourceMessageId,
+                                    continuationKind: payload.continuation_kind ?? (typeof meta.continuation_kind === "string" ? meta.continuation_kind : undefined) ?? parsedPath.continuationKind,
+                                    historyMeta: meta,
+                                });
                                 break
+                            }
                             case "chat:assistant":
-                                answer = it.data.text
+                                {
+                                    const meta = getArtifactMeta(it.data);
+                                    assistantMessages.push({
+                                        text: it.data.text,
+                                        timestamp: Date.parse(it.ts),
+                                        artifactPath: typeof meta.path === "string" ? meta.path : undefined,
+                                        historyMeta: meta,
+                                    });
+                                    answer = it.data.text
+                                }
                                 break
                             case "artifact:assistant.file": {
                                 const dto = it.data as AssistantFileData;
+                                if (isExternalAttachmentArtifact(dto.payload.artifact_path)) {
+                                    break;
+                                }
                                 const tf: FileArtifact = {
                                     artifactType: "file",
-                                    timestamp: Date.now(), //todo: use actual date
+                                    timestamp: Date.parse(it.ts),
                                     content: {
                                         filename: dto.payload.filename,
                                         rn: dto.payload.rn,
@@ -197,7 +318,7 @@ const conversationsMiddleware = (): Middleware => {
                                 })
                                 const r: ThinkingArtifact = {
                                     artifactType: "thinking",
-                                    timestamp: Date.now(), //todo: use actual date
+                                    timestamp: startTime,
                                     content: {
                                         agentTimes,
                                         agents,
@@ -220,7 +341,7 @@ const conversationsMiddleware = (): Middleware => {
                                         const r: CitationArtifact = {
                                             artifactType: "citation",
                                             content: t,
-                                            timestamp: Date.now(), //todo: use actual date
+                                            timestamp: Date.parse(it.ts),
                                         }
                                         turnArtifacts.push(r)
                                     }
@@ -272,6 +393,30 @@ const conversationsMiddleware = (): Middleware => {
                         turnArtifacts.push(...r.flush())
                     })
 
+                    userMessages.sort((a, b) => a.timestamp - b.timestamp);
+                    userAttachments.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+                    bindAttachmentsToUserMessages(userMessages, userAttachments);
+
+                    const skipRestoredUserMessages =
+                        userMessages.length > 0 &&
+                        assistantMessages.length === 0 &&
+                        userMessages.every((message) => message.continuationKind === "followup");
+
+                    if (!skipRestoredUserMessages) {
+                        for (const message of userMessages) {
+                            const isFollowup = message.continuationKind === "followup";
+                            if (isFollowup) {
+                                additionalUserMessages.push(message);
+                            } else if (!userMessage) {
+                                userMessage = message;
+                            } else {
+                                additionalUserMessages.push(message);
+                            }
+                        }
+                    }
+
+                    assistantMessages.sort((a, b) => a.timestamp - b.timestamp);
+
                     turnArtifacts.forEach(a => a.historical = true)
 
                     previousValue[currentValue.turn_id] = {
@@ -279,6 +424,7 @@ const conversationsMiddleware = (): Middleware => {
                         state: i < arr.length - 2 ? "finished" : "inProgress",
                         userMessage: userMessage ?? {text: "", attachments: [], timestamp: 0},
                         ...(additionalUserMessages.length > 0 ? {additionalUserMessages} : {}),
+                        ...(assistantMessages.length > 0 ? {assistantMessages} : {}),
                         events: [],
                         artifacts: turnArtifacts,
                         steps: {},

--- a/app/ai-app/ui/chat-web-app/src/features/conversations/conversationsTypes.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/conversations/conversationsTypes.ts
@@ -18,6 +18,7 @@ export interface ArtifactDataDTO {
     payload: unknown,
     text: string,
     continuation_kind?: string,
+    meta?: Record<string, unknown>,
 }
 
 export interface AssistantFileData {
@@ -26,7 +27,12 @@ export interface AssistantFileData {
         rn: string,
         mime: string | null | undefined,
         description: string | null | undefined,
+        artifact_path?: string,
+        message_id?: string,
+        continuation_kind?: string,
+        meta?: Record<string, unknown>,
     },
+    meta?: Record<string, unknown>,
 }
 
 interface CitationsItem {

--- a/app/ai-app/ui/chat-web-app/src/features/logExtensions/webSearch/WebSearchArtifactStreamReducer.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/logExtensions/webSearch/WebSearchArtifactStreamReducer.ts
@@ -26,6 +26,7 @@ export class WebSearchArtifactStreamReducer implements ArtifactStreamParser {
     private addWebSearchArtifact(codeExec: WebSearchArtifact) {
         const idx = this.artifacts.findIndex(c => c.content.searchId === codeExec.content.searchId)
         if (idx >= 0) {
+            codeExec.timestamp = Math.min(codeExec.timestamp, this.artifacts[idx].timestamp)
             this.artifacts.splice(idx, 1, codeExec)
         } else {
             this.artifacts.push(codeExec)


### PR DESCRIPTION
Render turn items from a normalized timestamp order so followups, timeline notes, assistant attempts, and subsystem widgets appear in their natural event sequence.

Restore historical user messages, attachments, citations, thinking, and assistant attempts with persisted timestamps instead of render-time fallback timestamps.

Keep subsystem widgets as individual timeline entries and preserve earliest web-search stream timestamps when search result fragments are merged.