### PR TITLE
[CLI]: init, bundle command, docs 

### DIFF
--- a/app/ai-app/deployment/assembly.yaml
+++ b/app/ai-app/deployment/assembly.yaml
@@ -2,8 +2,8 @@ domain: "" # required when proxy.ssl=true; used for proxylogin URLs and nginx SS
 company: "KDCube"
 
 context:
-  tenant: "demo-tenant"    # TENANT_ID
-  project: "demo-project"  # PROJECT_ID
+  tenant: "default"    # TENANT_ID
+  project: "default"   # PROJECT_ID
 
 # ---------------------------------------------------------------------------
 # Authentication

--- a/app/ai-app/docs/quick-start-README.md
+++ b/app/ai-app/docs/quick-start-README.md
@@ -101,8 +101,8 @@ Open the URL printed by the CLI.
 
 Default local context from the shipped descriptor set:
 
-- tenant: `demo-tenant`
-- project: `demo-project`
+- tenant: `default`
+- project: `default`
 
 From the admin UI you can:
 

--- a/app/ai-app/docs/sdk/bundle/build/how-to-configure-and-run-bundle-README.md
+++ b/app/ai-app/docs/sdk/bundle/build/how-to-configure-and-run-bundle-README.md
@@ -3,7 +3,7 @@ id: ks:docs/sdk/bundle/build/how-to-configure-and-run-bundle-README.md
 title: "How To Configure And Run A Bundle"
 summary: "Current bundle-development runtime workflow: tenant/project environment setup, descriptor staging, local-path and git bundles, configuration translation, start/stop/reload loop, configuration/secret scopes, and the rule that one machine may hold many local deployment snapshots but should not be treated as running many local compose-backed KDCubes at once."
 tags: ["sdk", "bundle", "configuration", "runtime", "cli", "bundles.yaml"]
-keywords: ["local bundle development workflow", "tenant project environment boundary", "descriptor driven runtime setup", "local path bundle loop", "git bundle loop", "bundle reload workflow", "runtime sandbox selection", "bundle config and secret scopes", "bundle configurator workflow", "bundle deployer workflow", "current kdcube cli workflow", "multiple local runtime snapshots", "single active local compose deployment", "run multiple kdcubes on one machine"]
+keywords: ["local bundle development workflow", "tenant project environment boundary", "descriptor driven runtime setup", "local path bundle loop", "git bundle loop", "bundle reload workflow", "runtime sandbox selection", "bundle config and secret scopes", "bundle configurator workflow", "bundle deployer workflow", "current kdcube cli workflow", "multiple local runtime snapshots", "single active local compose deployment", "run multiple kdcubes on one machine", "kdcube bundle command", "patch bundle config cli", "patch bundle secret cli"]
 see_also:
   - ks:docs/sdk/bundle/build/how-to-navigate-kdcube-docs-README.md
   - ks:docs/configuration/bundles-descriptor-README.md
@@ -848,17 +848,26 @@ This is required because `kdcube reload` does not read arbitrary external descri
 
 ### If you changed `bundles.yaml` or `bundles.secrets.yaml` inside the active runtime
 
-After editing:
-
-```text
-<runtime>/config/bundles.yaml
-<runtime>/config/bundles.secrets.yaml
-```
-
-apply the change with:
+Use `kdcube bundle` to patch specific keys:
 
 ```bash
-kdcube reload my.bundle@1-0 --workdir ~/.kdcube/kdcube-runtime/mytenant__myproject
+kdcube bundle <bundle_id> \
+  --set-config key.path value \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+
+kdcube bundle <bundle_id> \
+  --set-secret key.path value \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+
+kdcube bundle <bundle_id> \
+  --del-config key.path \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+Apply the change with:
+
+```bash
+kdcube reload <bundle_id> --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
 ```
 
 `reload`:
@@ -981,6 +990,28 @@ bundles:
         api:
           shared_token: "replace-me"
 ```
+
+To patch a config or secret key without editing the files by hand, use `kdcube bundle`:
+
+```bash
+# Set a config value
+kdcube bundle <bundle_id> \
+  --set-config key.path value \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+
+# Set a secret
+kdcube bundle <bundle_id> \
+  --set-secret key.path value \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+
+# Delete a config or secret key (raises an error if the key does not exist)
+kdcube bundle <bundle_id> --del-config key.path \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+kdcube bundle <bundle_id> --del-secret key.path \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+`kdcube bundle` only patches the staged files. Run `kdcube reload` afterward to apply the change.
 
 `enabled_config` values belong in bundle props, not in secrets.
 
@@ -1144,6 +1175,7 @@ If you only remember the essentials, remember these:
 - file-producing tools use the React/tool runtime file contract, not a
   `bundles.yaml` switch
 - rerun install when you changed the canonical source descriptor set or runtime topology
+- use `kdcube bundle <bundle_id> --set-config / --set-secret / --del-config / --del-secret` to patch staged config or secrets without editing YAML by hand
 - use `kdcube reload <bundle_id>` when you changed active runtime bundle descriptors or need proc cache eviction
 - use `kdcube --info --workdir <path>` to inspect the runtime you are actually using
 - use `kdcube export` before overwriting runtime bundle state with older descriptor copies

--- a/app/ai-app/docs/sdk/bundle/build/how-to-configure-and-run-bundle-README.md
+++ b/app/ai-app/docs/sdk/bundle/build/how-to-configure-and-run-bundle-README.md
@@ -42,14 +42,13 @@ Use it when you need to answer questions like:
 - how do I avoid overwriting live bundle props/secrets with stale descriptor copies
 
 This page is not the primary source for bundle design or test strategy.
-It also documents the CLI/runtime model that exists now, not the planned
-deployment-first CLI redesign.
+It documents the supported local CLI/runtime workflow for descriptor-backed
+bundle development.
 
 Important:
 
 - `tenant/project` isolation already exists in the current model
-- the planned CLI redesign does not introduce that isolation
-- the redesign changes how the operator targets and manages deployments
+- the CLI uses that namespace to target one concrete runtime workdir
 - one machine may hold many local deployment snapshots on disk
 - one machine should not be treated as supporting many concurrently running
   local compose-backed KDCube stacks by default
@@ -152,9 +151,9 @@ The local runtime is not only a CLI command. It is a concrete workspace that con
 
 Those files under `workdir/config/` are the active runtime inputs.
 
-### 2. `--descriptors-location` stages the descriptor set into the runtime
+### 2. `kdcube init --descriptors-location` stages the descriptor set into the runtime
 
-When you run `kdcube` with `--descriptors-location`, the CLI copies the canonical descriptor set into:
+When you run `kdcube init --descriptors-location`, the CLI copies the canonical descriptor set into:
 
 ```text
 <runtime>/config/
@@ -277,7 +276,7 @@ isolated from each other.
 This is intentional today because it lets bundle developers keep one known-good
 runtime snapshot while testing another one with a newer platform version.
 
-For the planned deployment-first CLI model, use:
+For broader deployment-first CLI design context, use:
 
 - [how-to-configure-and-run-bundle-new-cli-README.md](how-to-configure-and-run-bundle-new-cli-README.md)
 - [cli--as-control-plane-README.md](../../../service/cicd/design/cli--as-control-plane-README.md)
@@ -355,9 +354,9 @@ The desired local behavior is:
    - per-deployment published port ranges
    - explicit runtime discovery and stop semantics
 
-### 5. Local vs remote meaning in the future CLI
+### 5. Local vs remote deployment targeting
 
-The planned CLI should still let one machine manage many deployments.
+The CLI should still let one machine manage many deployments.
 
 That means:
 
@@ -534,7 +533,7 @@ For non-interactive local install, the descriptor set should be complete and int
 
 ## Recommended Local Workflow
 
-Use a canonical descriptor directory and let `kdcube` stage it into the runtime.
+Use a canonical descriptor directory and let `kdcube init` stage it into the runtime.
 
 Before running bundle tests or interpreting failures, use the working
 environment checklist in
@@ -848,7 +847,15 @@ This is required because `kdcube reload` does not read arbitrary external descri
 
 ### If you changed `bundles.yaml` or `bundles.secrets.yaml` inside the active runtime
 
-Use `kdcube bundle` to patch specific keys:
+You can edit the staged files directly:
+
+```text
+<runtime>/config/bundles.yaml
+<runtime>/config/bundles.secrets.yaml
+```
+
+For targeted config or secret changes, use `kdcube bundle` instead of editing
+YAML by hand:
 
 ```bash
 kdcube bundle <bundle_id> \
@@ -864,7 +871,7 @@ kdcube bundle <bundle_id> \
   --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
 ```
 
-Apply the change with:
+Apply either kind of change with:
 
 ```bash
 kdcube reload <bundle_id> --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
@@ -991,7 +998,7 @@ bundles:
           shared_token: "replace-me"
 ```
 
-To patch a config or secret key without editing the files by hand, use `kdcube bundle`:
+To patch a config or secret key without editing the files by hand, use `kdcube bundle` against the staged runtime descriptors:
 
 ```bash
 # Set a config value
@@ -1011,7 +1018,8 @@ kdcube bundle <bundle_id> --del-secret key.path \
   --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
 ```
 
-`kdcube bundle` only patches the staged files. Run `kdcube reload` afterward to apply the change.
+`kdcube bundle` only patches the staged files. It does not edit the original
+source descriptor directory. Run `kdcube reload` afterward to apply the change.
 
 `enabled_config` values belong in bundle props, not in secrets.
 
@@ -1175,7 +1183,7 @@ If you only remember the essentials, remember these:
 - file-producing tools use the React/tool runtime file contract, not a
   `bundles.yaml` switch
 - rerun install when you changed the canonical source descriptor set or runtime topology
-- use `kdcube bundle <bundle_id> --set-config / --set-secret / --del-config / --del-secret` to patch staged config or secrets without editing YAML by hand
+- use `kdcube bundle <bundle_id> --set-config / --set-secret / --del-config / --del-secret` for targeted staged config or secret patches
 - use `kdcube reload <bundle_id>` when you changed active runtime bundle descriptors or need proc cache eviction
 - use `kdcube --info --workdir <path>` to inspect the runtime you are actually using
 - use `kdcube export` before overwriting runtime bundle state with older descriptor copies

--- a/app/ai-app/docs/service/cicd/cli-README.md
+++ b/app/ai-app/docs/service/cicd/cli-README.md
@@ -80,10 +80,11 @@ Important local-runtime rule:
    - Create data folders
 
 2b) **Compose with custom UI (advanced)**
-   - Use an `assembly.yaml` that includes a `frontend` section
+   - Use an `assembly.yaml` that includes `frontend.build` or `frontend.image`
    - If `frontend.image` is set, the UI build is skipped
    - If `frontend.build` is set, the UI repo is cloned and built
    - Switches compose mode to `custom‑ui‑managed‑infra`
+   - `frontend.config` alone does **not** trigger this mode
 
 3) **Validate assembly descriptor**
    - Validate schema + refs
@@ -165,11 +166,14 @@ kdcube env init \
 
 ### 2.3 Custom UI via assembly descriptor (compose)
 
-When `assembly.yaml` contains a `frontend` section, the CLI uses
+When `assembly.yaml` contains `frontend.build` or `frontend.image`, the CLI uses
 **custom‑ui‑managed‑infra** compose mode:
 
 - `frontend.image` → use a prebuilt UI image (skip build)
 - `frontend.build` → clone repo and build UI
+
+`frontend.config` (auth type, routes prefix, debug flags) is runtime metadata consumed in
+both modes and does **not** trigger `custom‑ui‑managed‑infra` on its own.
 
 The CLI also generates runtime `config.json` from `frontend_config`.
 If `frontend_config` is omitted, it falls back to a built-in template based on auth mode:

--- a/app/ai-app/docs/service/cicd/cli-README.md
+++ b/app/ai-app/docs/service/cicd/cli-README.md
@@ -224,9 +224,58 @@ Repo field contract:
   backward compatibility, but new descriptors should use one of the cloneable
   forms above
 
-### 2.3a Descriptor folder fast path
+### 2.3a Plain init (no descriptor source required)
 
-The CLI now supports a descriptor-folder driven install path:
+`kdcube init` can be run with no additional flags. The CLI clones the platform
+repo directly into the scoped runtime directory and uses its bundled
+`app/ai-app/deployment/` as the descriptor source:
+
+```bash
+kdcube init
+```
+
+This is equivalent to `kdcube init --latest`. The runtime is created under:
+
+```text
+~/.kdcube/kdcube-runtime/default__default/repo
+```
+
+Pass `--tenant` / `--project` (or `-i` for interactive prompts) to use a
+non-default namespace. Interactive prompts happen **before** cloning so the
+directory is created with the correct namespace from the start:
+
+```bash
+kdcube init -i
+kdcube init --tenant acme --project prod
+```
+
+`--workdir` sets the base directory. If the value already contains `__`
+(i.e. it is itself a namespaced runtime path), it is used directly without
+appending a tenant/project subdirectory:
+
+```bash
+# base dir → creates ~/.kdcube/kdcube-runtime/default__default/
+kdcube init --workdir ~/.kdcube/kdcube-runtime
+
+# namespaced dir → used as-is
+kdcube init --workdir ~/.kdcube/kdcube-runtime/acme__prod
+```
+
+All version selectors work the same way without `--descriptors-location`:
+
+```bash
+kdcube init --latest
+kdcube init --upstream
+kdcube init --release 2026.4.30.317
+kdcube init --build
+```
+
+`--latest`, `--upstream`, and `--release` are mutually exclusive — combining
+any two raises an error.
+
+### 2.3b Descriptor folder fast path
+
+The CLI also supports a descriptor-folder driven install path:
 
 ```bash
 kdcube init \
@@ -306,10 +355,12 @@ kdcube init \
   --release 2026.4.11.012
 ```
 
-Choose exactly one source selector:
+Choose at most one source selector (`--latest`, `--upstream`, `--release` are
+mutually exclusive — combining any two raises an error):
 
 - `--upstream` for the latest upstream repo state
-- `--latest` for the latest released platform ref
+- `--latest` for the latest released platform ref (also the default when no
+  `--descriptors-location` is provided and no selector is specified)
 - `--release <ref>` for a specific released ref
 - explicit `--path <repo>` without the selectors above for dirty local source
   staging
@@ -602,7 +653,15 @@ Inspect a specific workdir deployment:
 kdcube --info --workdir ~/.kdcube/kdcube-runtime/acme__prod
 ```
 
-Initialize a workdir without starting Docker:
+Initialize a workdir without starting Docker (clones platform repo automatically):
+
+```bash
+kdcube init
+kdcube init --latest
+kdcube init --tenant acme --project prod --latest
+```
+
+Initialize from a prepared descriptor folder:
 
 ```bash
 kdcube init \

--- a/app/ai-app/docs/service/cicd/cli-README.md
+++ b/app/ai-app/docs/service/cicd/cli-README.md
@@ -1,9 +1,9 @@
 ---
 id: ks:docs/service/cicd/cli-README.md
 title: "Current KDCube CLI"
-summary: "Current implemented CLI surface for local environment bootstrapping, workdir preparation, Docker Compose startup, descriptor validation, and the practical rule that multiple namespaced runtime snapshots may exist on one machine while local compose-backed execution remains one active deployment at a time."
-tags: ["service", "cicd", "cli", "env", "deployment"]
-keywords: ["kdcube cli", "local environment bootstrap", "workdir setup", "docker compose control", "descriptor validation", "current cli contract", "local deployment tooling", "multiple local runtime snapshots", "single active local deployment", "tenant project workdir namespace"]
+summary: "Current implemented CLI surface for local environment bootstrapping, workdir preparation, Docker Compose startup, descriptor validation, bundle config and secret patching, and the practical rule that multiple namespaced runtime snapshots may exist on one machine while local compose-backed execution remains one active deployment at a time."
+tags: ["service", "cicd", "cli", "env", "deployment", "bundle"]
+keywords: ["kdcube cli", "local environment bootstrap", "workdir setup", "docker compose control", "descriptor validation", "current cli contract", "local deployment tooling", "multiple local runtime snapshots", "single active local deployment", "tenant project workdir namespace", "bundle config patch", "bundle secret patch", "kdcube bundle command"]
 see_also:
   - ks:docs/service/cicd/release-README.md
   - ks:docs/service/cicd/descriptors-README.md
@@ -435,6 +435,73 @@ Operational rule for `aws-sm` deployments:
 If you skip that step, a later provision can replay stale `BUNDLES_YAML` or
 `BUNDLES_SECRETS_YAML` and overwrite runtime bundle changes.
 
+### 2.3c Patch staged bundle config and secrets
+
+`kdcube bundle` patches the staged descriptor files in the active runtime workdir
+without a full reinstall or manual YAML edit.
+
+**Set a config value by dotted key path:**
+
+```bash
+kdcube bundle <bundle_id> \
+  --set-config key.path value \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+**Delete a config key:**
+
+```bash
+kdcube bundle <bundle_id> \
+  --del-config key.path \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+**Set a secret:**
+
+```bash
+kdcube bundle <bundle_id> \
+  --set-secret key.path value \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+**Delete a secret key:**
+
+```bash
+kdcube bundle <bundle_id> \
+  --del-secret key.path \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+Multiple operations can be chained in a single invocation:
+
+```bash
+kdcube bundle <bundle_id> \
+  --set-config model.name claude-3-5-sonnet \
+  --set-config features.debug false \
+  --del-config features.legacy_mode \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+Value coercion rules:
+
+| CLI value | Stored as |
+|---|---|
+| `true` / `false` | bool |
+| `42`, `3.14` | int / float |
+| `hello world` | string (no quotes needed) |
+| `'{"a": 1}'` (shell-quoted JSON) | string (the JSON literal) |
+
+`--del-config` and `--del-secret` raise an error if the key does not exist.
+
+After patching, apply the change with:
+
+```bash
+kdcube reload <bundle_id> --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+`kdcube bundle` only patches the staged files under `workdir/config/`.
+It does not push the change live on its own — `kdcube reload` is still required.
+
 ### 2.4 Bundles descriptor (optional)
 
 You can provide a **bundles descriptor** (`bundles.yaml`) and an optional
@@ -650,7 +717,7 @@ kdcube --info
 Inspect a specific workdir deployment:
 
 ```bash
-kdcube --info --workdir ~/.kdcube/kdcube-runtime/acme__prod
+kdcube --info --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
 ```
 
 Initialize a workdir without starting Docker (clones platform repo automatically):
@@ -696,19 +763,38 @@ Use this for uncommitted platform changes. Do not combine this flow with
 Start the stack for an already-initialized workdir:
 
 ```bash
-kdcube start --workdir ~/.kdcube/kdcube-runtime/acme__prod
+kdcube start --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
 ```
+
+Patch staged bundle config or secrets without editing YAML by hand:
+
+```bash
+kdcube bundle <bundle_id> \
+  --set-config key.path value \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+
+kdcube bundle <bundle_id> \
+  --set-secret key.path value \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+
+kdcube bundle <bundle_id> \
+  --del-config key.path \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+Multiple `--set-config`, `--set-secret`, `--del-config`, `--del-secret` flags can be combined in one call.
+After patching, reload the bundle to apply the change.
 
 Reload a bundle after descriptor changes:
 
 ```bash
-kdcube reload <bundle_id> --workdir ~/.kdcube/kdcube-runtime/acme__prod
+kdcube reload <bundle_id> --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
 ```
 
 Export live bundle descriptors:
 
 ```bash
-kdcube export --workdir ~/.kdcube/kdcube-runtime/acme__prod --out-dir /tmp/export
+kdcube export --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id> --out-dir /tmp/export
 ```
 
 Stop the local workdir stack:

--- a/app/ai-app/docs/service/cicd/cli-README.md
+++ b/app/ai-app/docs/service/cicd/cli-README.md
@@ -703,7 +703,6 @@ This is intended for **local development** only.
 ## 8) Future commands (next phase)
 
 - `kdcube doctor` (validate env + filesystem + runtime dependencies)
-- `kdcube compose up` (wrapper around docker compose)
 - `kdcube release tag` (tag + VERSION validation)
 
 ## 9) Operational commands

--- a/app/ai-app/docs/service/cicd/cli-README.md
+++ b/app/ai-app/docs/service/cicd/cli-README.md
@@ -439,10 +439,80 @@ Operational rule for `aws-sm` deployments:
 If you skip that step, a later provision can replay stale `BUNDLES_YAML` or
 `BUNDLES_SECRETS_YAML` and overwrite runtime bundle changes.
 
-### 2.3c Patch staged bundle config and secrets
+### 2.3c Manage staged bundle entries
 
-`kdcube bundle` patches the staged descriptor files in the active runtime workdir
-without a full reinstall or manual YAML edit.
+`kdcube bundle` creates, updates, or deletes entries in the staged descriptor
+files in the active runtime workdir without a full reinstall or manual YAML edit.
+All non-delete flag groups can be combined in one invocation — the command does a
+single atomic read-modify-write of `bundles.yaml` / `bundles.secrets.yaml`.
+
+When `--local-path` or `--git-repo` is provided and `<bundle_id>` does not yet
+exist in `bundles.yaml`, the command **creates** a new entry (upsert).
+For all other operations (identity, config, secrets) the bundle must already exist.
+
+#### Source mode
+
+Switch where proc loads the bundle from.
+
+**Local path** — proc reads from a host-mounted directory.
+The path must be the **container-visible** path (under `/bundles/`, not the host path):
+
+```bash
+kdcube bundle <bundle_id> \
+  --local-path /bundles/my.bundle \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+Setting `--local-path` clears any `repo`/`ref`/`subdir` fields.
+
+**Git repo** — proc clones the repo into `/managed-bundles/` on first `kdcube reload`:
+
+```bash
+kdcube bundle <bundle_id> \
+  --git-repo git@github.com:org/my-bundle.git \
+  --git-ref 2026.4.30 \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+`--git-ref` is required with `--git-repo`.
+
+If the bundle root is a subdirectory of the repo:
+
+```bash
+kdcube bundle <bundle_id> \
+  --git-repo git@github.com:org/monorepo.git \
+  --git-ref main \
+  --git-subdir src/my.bundle \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+`--git-subdir` requires `--git-repo`.
+
+After proc resolves a git bundle it writes the concrete resolved path back into
+the descriptor (e.g. `/managed-bundles/org__my-bundle__2026.4.30`).
+This is expected — the source-of-truth for the next reload is the
+`repo`/`ref`/`subdir` fields.
+
+Setting `--git-repo` clears any `path` field.
+
+#### Identity fields
+
+```bash
+kdcube bundle <bundle_id> \
+  --name "My Bundle" \
+  --module entrypoint \
+  --singleton \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--name NAME` | bundle_id | Human-readable display name |
+| `--module MODULE` | `entrypoint` | Python module used as the bundle entry point |
+| `--singleton` | `false` | Only one instance may run at a time |
+| `--no-singleton` | — | Explicitly set `singleton: false` |
+
+#### Config and secrets patch
 
 **Set a config value by dotted key path:**
 
@@ -476,11 +546,11 @@ kdcube bundle <bundle_id> \
   --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
 ```
 
-Multiple operations can be chained in a single invocation:
+Multiple patch operations can be chained:
 
 ```bash
 kdcube bundle <bundle_id> \
-  --set-config model.name claude-3-5-sonnet \
+  --set-config model.name claude-opus-4-7 \
   --set-config features.debug false \
   --del-config features.legacy_mode \
   --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
@@ -496,6 +566,22 @@ Value coercion rules:
 | `'{"a": 1}'` (shell-quoted JSON) | string (the JSON literal) |
 
 `--del-config` and `--del-secret` raise an error if the key does not exist.
+
+#### Delete a bundle entry
+
+Remove a bundle from `bundles.yaml` (and its secrets entry from
+`bundles.secrets.yaml`, if present):
+
+```bash
+kdcube bundle <bundle_id> \
+  --delete \
+  --workdir ~/.kdcube/kdcube-runtime/<tenant_id>__<project_id>
+```
+
+`--delete` cannot be combined with any other flag. Exits with an error if the
+bundle is not found.
+
+#### Apply changes
 
 After patching, apply the change with:
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/README.md
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/README.md
@@ -117,7 +117,7 @@ showing what is running and how to stop it first.
 | Command | What it does |
 |---|---|
 | `kdcube reload <bundle_id>` | Reapply bundle config and clear proc caches — no full restart needed |
-| `kdcube bundle <bundle_id>` | Patch bundle config or secrets by dotted key path |
+| `kdcube bundle <bundle_id>` | Patch bundle source, identity, config, or secrets |
 | `kdcube export` | Export live `bundles.yaml` / `bundles.secrets.yaml` |
 
 ### Configuration
@@ -130,30 +130,55 @@ showing what is running and how to stop it first.
 
 ---
 
-## `kdcube bundle` — patch config at runtime
+## `kdcube bundle` — manage bundles at runtime
 
-Patch a staged bundle without touching YAML files by hand:
+Patch a staged bundle — source, identity, config, or secrets — without touching
+YAML files by hand. Changes are staged and take effect after `kdcube reload`.
+
+**Source mode** — switch where proc loads the bundle from:
 
 ```bash
-# Change a cron schedule
+# Local path (container-visible path under /bundles/)
+kdcube bundle <bundle_id> --local-path /bundles/my.bundle
+
+# Git repo (proc clones to /managed-bundles/ on reload)
 kdcube bundle <bundle_id> \
-  --set-config routines.heartbeat.cron "*/5 * * * *"
+  --git-repo git@github.com:org/my-bundle.git \
+  --git-ref 2026.4.30
 
-# Disable a feature flag
+# Git monorepo with a bundle subdirectory
 kdcube bundle <bundle_id> \
-  --set-config features.some_feature.enabled false
+  --git-repo git@github.com:org/monorepo.git \
+  --git-ref main \
+  --git-subdir src/my.bundle
+```
 
-# Set a secret
+**Identity and config/secrets patch:**
+
+```bash
+# Set display name, module, singleton flag
 kdcube bundle <bundle_id> \
-  --set-secret api.token "sk-..."
+  --name "My Bundle" --module entrypoint --singleton
 
-# Remove a key
-kdcube bundle <bundle_id>  \
-  --del-config routines.heartbeat.cron
+# Patch config and secrets by dotted key path
+kdcube bundle <bundle_id> \
+  --set-config routines.heartbeat.cron "*/5 * * * *" \
+  --set-secret api.token "sk-..." \
+  --del-config features.legacy_mode
 
-# Apply changes
+# Apply all staged changes
 kdcube reload <bundle_id>
 ```
+
+```bash
+# Delete a bundle entry (also removes its secrets entry)
+kdcube bundle <bundle_id> --delete
+```
+
+When `--local-path` or `--git-repo` is given and the bundle doesn't exist yet,
+the command creates a new entry (upsert). All other flags require an existing entry.
+All non-delete flags can be combined in one invocation (single atomic write).
+`--git-ref` is required with `--git-repo`. `--git-subdir` requires `--git-repo`.
 
 ---
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/README.md
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/README.md
@@ -2,1013 +2,162 @@
 
 ![KDCube CLI](https://raw.githubusercontent.com/kdcube/kdcube-ai-app/main/app/ai-app/src/kdcube-ai-app/kdcube_cli/pixel-cubes.png)
 
-Bootstrap installer for the KDCube platform stack. This package clones the
-repository (if needed) and launches the guided setup wizard.
+Bootstrap and operate a KDCube platform stack from the command line.
 
-This README describes the current implemented CLI behavior.
-
-Short version of the current model:
-
-- the CLI bootstraps or reuses a concrete runtime snapshot under a namespaced
-  workdir
-- the namespace is usually derived from `assembly.yaml -> context.tenant` and
-  `context.project`
-- each local runtime snapshot keeps its own staged descriptors, platform
-  snapshot, and runtime data
-
-So current local CLI usage is still deployment-isolated, but workdir-first.
-
-Operationally, that means:
-
-- one `tenant/project` = one isolated environment
-- use separate `tenant/project` values for different customers or different
-  stages such as `dev`, `staging`, and `prod`
-- keep multiple bundles inside one `tenant/project` when they belong to the
-  same environment
-
-So the current CLI does not create one runtime per bundle.
-It creates one runtime per environment, and that environment may host many
-bundles.
-
-One more practical rule is easy to miss:
-
-- one machine can hold many local runtime snapshots under different
-  `tenant/project` namespaces
-- that does not mean the current compose-backed local workflow supports many
-  concurrently running local KDCube stacks as a normal mode
-- treat the current local runtime as one active deployment at a time unless a
-  future explicit multi-instance local mode is introduced
-
-----
-
-## Prerequisites
-
-### macOS
-- Python 3.9+ (Homebrew recommended)
-- Git (Xcode Command Line Tools or Homebrew)
-- Docker Desktop (includes Docker Compose)
-
-### Windows
-- Python 3.9+
-- Git for Windows
-- Docker Desktop (enable WSL2 backend)
-
-### Linux
-- Python 3.9+
-- Git
-- Docker Engine + Docker Compose plugin
+---
 
 ## Install
+
+```bash
+pip install kdcube-cli
+```
+
+Or with pipx (recommended):
 
 ```bash
 pipx install kdcube-cli
 ```
 
-Alternative (pip):
+---
 
-```bash
-python -m pip install --user kdcube-cli
-```
+## Get started
 
-On Debian/Ubuntu hosts that enforce PEP 668 (`externally-managed-environment`),
-install the CLI into a dedicated virtual environment instead of the system
-Python:
-
-```bash
-sudo apt-get update
-sudo apt-get install -y python3-pip python3-venv
-python3 -m venv ~/.venvs/kdcube-cli
-~/.venvs/kdcube-cli/bin/pip install -e /path/to/kdcube_cli
-~/.venvs/kdcube-cli/bin/kdcube --help
-```
-
-## Run
+### Interactive wizard (first run)
 
 ```bash
 kdcube
 ```
 
-## Quick start (new users)
+The wizard creates a runtime workdir, generates config files, and optionally
+builds images and starts the stack.
 
-1) Run `kdcube`  
-2) Choose **release-latest** (pull prebuilt images)  
-3) Answer **yes** to “Run docker compose now?”  
+### Descriptor-driven init (automated)
 
-That brings up the stack with no local build required.
+```bash
+kdcube init --descriptors-location /path/to/descriptors
+kdcube start
+```
 
-We aim for a setup that is simple to try, and easy to explore further using the
-installed admin assistant and bundled tools.
-
-## Quick start (prepared descriptors)
-
-If you already have a descriptor folder, you can skip the wizard:
+With a local platform source tree and image build:
 
 ```bash
 kdcube init \
   --descriptors-location /path/to/descriptors \
-  --workdir /path/to/workspace
-```
-
-With descriptor-driven installs, `--workdir` is the base workspace root. The
-effective runtime is created under:
-
-```text
-<workspace>/<safe_tenant>__<safe_project>/
-```
-
-using `assembly.yaml -> context.tenant` and `context.project`.
-
-If `--path` is omitted, the CLI clones or reuses the platform checkout under:
-
-```text
-<workspace>/<safe_tenant>__<safe_project>/repo
-```
-
-You can still pass `--path` explicitly if you want to force a specific local
-checkout. In descriptor-driven `init`, explicit `--path` means “stage this local
-source tree into the runtime workdir and use that staged copy”. The CLI copies
-tracked files plus untracked files that are not ignored by git, so dirty local
-source changes can be tested without copying `.git`, local runtime data, or
-other gitignored paths.
-
-```bash
-kdcube init \
-  --descriptors-location /path/to/descriptors \
-  --workdir /path/to/workspace \
   --path /path/to/kdcube-ai-app \
   --build
+kdcube start
 ```
 
-`--workdir` answers “where should this runtime live?”. `--path` answers “which
-local platform source tree should this runtime use?”. If `--upstream`,
-`--latest`, or `--release` is also provided, that version selector wins and
-`--path` is only the local repo/cache location for the selected source.
-
-Or pull the latest platform release from the platform repo instead of
-`assembly.yaml -> platform.ref`:
+### Typical day-to-day flow
 
 ```bash
-kdcube init \
-  --descriptors-location /path/to/descriptors \
-  --workdir /path/to/workspace \
-  --latest
+# Start the stack
+kdcube start --workdir ~/.kdcube/kdcube-runtime/<tenant>__<project>
+
+# After editing a bundle's config or code — reload without a full restart
+kdcube reload <bundle_id> --workdir ~/.kdcube/kdcube-runtime/<tenant>__<project>
+
+# Stop the stack
+kdcube stop --workdir ~/.kdcube/kdcube-runtime/<tenant>__<project>
 ```
 
-Or initialize from the latest upstream repo state instead of a released ref:
+---
+
+## Workdir scopes
+
+Every runtime lives under a **namespaced workdir**:
+
+```
+~/.kdcube/kdcube-runtime/<tenant>__<project>/
+```
+
+The namespace comes from `assembly.yaml → context.tenant` and
+`context.project`. With default values this becomes `default__default`.
+
+```
+~/.kdcube/kdcube-runtime/
+├── default__default/       # default scope
+├── acme__staging/          # acme tenant, staging project
+└── acme__prod/             # acme tenant, prod project
+```
+
+Each scope is fully isolated — its own config, data, logs, and running stack.
+
+### Persistent defaults
+
+Save your most-used workdir so you can omit `--workdir` from every command:
 
 ```bash
-kdcube init \
-  --descriptors-location /path/to/descriptors \
-  --workdir /path/to/workspace \
-  --upstream
+kdcube defaults \
+  --default-workdir ~/.kdcube/kdcube-runtime/<tenant>__<project> \
+  --default-tenant <tenant> \
+  --default-project <project>
 ```
 
-If you also want the runtime ready with freshly built local images, build during
-init:
+### Single-deployment guard
 
-```bash
-kdcube init \
-  --descriptors-location /path/to/descriptors \
-  --workdir /path/to/workspace \
-  --upstream \
-  --build
-```
+The CLI writes `~/.kdcube/cli-lock.json` on `start` and clears it on `stop`.
+Starting a **different** scope while another is live aborts with a message
+showing what is running and how to stop it first.
 
-Use `--upstream` when you want the deployment assets from the latest GitHub
-`origin/main`, including:
+---
 
-- compose files
-- nginx templates
-- installer-side deployment templates
+## Command groups
 
-If the runtime was already initialized earlier, you can omit
-`--descriptors-location` and reuse the staged descriptors from `workdir/config`
-instead:
+### Lifecycle
 
-```bash
-kdcube init \
-  --workdir /path/to/workspace/<safe_tenant>__<safe_project> \
-  --upstream
-```
-
-This reuse path requires:
-
-- `workdir/config/install-meta.json`
-- the canonical descriptor set already present under `workdir/config`
-  - `assembly.yaml`
-  - `secrets.yaml`
-  - `bundles.yaml`
-  - `bundles.secrets.yaml`
-  - `gateway.yaml`
-
-When those files exist, the CLI treats `workdir/config` as the descriptor
-authority and reuses the repo recorded in `install-meta.json` when possible.
-
-Important reused-runtime rule:
-
-- the CLI reuses `workdir/config/assembly.yaml`, `bundles.yaml`, and `bundles.secrets.yaml` as they already exist
-- it does not reseed default descriptors
-- if `bundles.yaml` already contains local path entries under `/bundles/...`, those are treated as container paths and preserved
-- the matching host root is taken from `assembly.yaml -> paths.host_bundles_path`
-- the CLI does not reinterpret `/bundles/...` as a host filesystem path
-
-So for an initialized runtime, change bundle topology by editing:
-
-- `workdir/config/assembly.yaml`
-- `workdir/config/bundles.yaml`
-
-Do not change local path bundles by putting host paths directly into `bundles.yaml`.
-
-Correct split:
-
-```yaml
-# workdir/config/assembly.yaml
-paths:
-  host_bundles_path: "/Users/you/src"
-```
-
-```yaml
-# workdir/config/bundles.yaml
-bundles:
-  items:
-    - id: "my.bundle@1-0"
-      path: "/bundles/my-repo/src/my_bundle"
-      module: "entrypoint"
-```
-
-`host_bundles_path` is the host parent root.
-`path` in `bundles.yaml` is the container-visible bundle root.
-
-`--latest` is different: it resolves the latest release ref for release-image
-installs. It does not mean “latest source templates from GitHub main”.
-
-Or pin a specific release explicitly:
-
-```bash
-kdcube init \
-  --descriptors-location /path/to/descriptors \
-  --release 2026.4.11.012
-```
-
-Choose exactly one source selector:
-- `--upstream` for the latest upstream repo state
-- `--latest` for the latest released platform ref
-- `--release <ref>` for a specific released ref
-- explicit `--path <repo>` without the selectors above for dirty local source
-  staging
-- otherwise `assembly.yaml -> platform.ref`
-
-For `aws-sm` deployments, you can also export the current effective live
-deployment-scoped bundle descriptors directly from AWS Secrets Manager:
-
-```bash
-kdcube export \
-  --tenant <tenant> \
-  --project <project> \
-  --aws-region <region> \
-  --out-dir /tmp/kdcube-export
-```
-
-Optional:
-- `--aws-profile <profile>`
-- `--aws-sm-prefix <prefix>`
-
-This reconstructs:
-- `bundles.yaml`
-- `bundles.secrets.yaml`
-
-from the authoritative grouped AWS SM bundle documents, not from Redis or the
-currently mounted `/config/bundles.yaml`.
-
-Expected descriptor folder:
-
-```text
-descriptors/
-  assembly.yaml
-  secrets.yaml
-  gateway.yaml
-  bundles.yaml            # optional
-  bundles.secrets.yaml    # optional
-```
-
-When the descriptor set is complete, the CLI:
-- resolves the effective runtime as `<workspace>/<safe_tenant>__<safe_project>`
-- stages the descriptors into `<runtime>/config`
-- clones or reuses the platform repo under `<runtime>/repo` when `--path` is omitted
-- copies the explicit local `--path` repo into `<runtime>/repo` when no version selector is used
-- skips interactive prompts
-- runs a release install directly
-
-The same non-interactive path is also used when:
-
-- `--descriptors-location` is omitted
-- `--workdir` points to an existing runtime
-- `config/install-meta.json` exists
-- the canonical descriptor set already exists under `config/`
-
-In that case the CLI reuses the staged runtime descriptors and the repo path
-recorded in `install-meta.json`.
-
-If required fields are missing, it falls back to the guided setup and prints
-what is incomplete.
-
-## What it installs (default)
-- Base workspace: `~/.kdcube/kdcube-runtime`
-- Runtime namespace: `~/.kdcube/kdcube-runtime/<safe_tenant>__<safe_project>`
-- Repo clone default: `~/.kdcube/kdcube-runtime/<safe_tenant>__<safe_project>/repo`
-- Docker images: prepared by `init --build` or rebuilt as a convenience by `start --build`
-
-### CLI options (common)
-| Option | Purpose |
+| Command | What it does |
 |---|---|
-| `--repo <url>` | Git repo URL (default: official kdcube repo). |
-| `--path <repo>` | For `kdcube init` without `--upstream`, `--latest`, or `--release`, copy this local platform checkout into the runtime and use the staged copy. With a version selector, use this path as the local repo/cache location. If omitted in descriptor mode, the checkout defaults to `<workspace>/<tenant>__<project>/repo`. |
-| `--workdir <path>` | Base workspace root. In descriptor mode the effective runtime becomes `<workdir>/<tenant>__<project>`. If it already points to an initialized runtime with `config/install-meta.json` and the canonical descriptor set under `config/`, the CLI can reuse that runtime non-interactively. |
-| `--descriptors-location <dir>` | Use a folder containing `assembly.yaml`, `secrets.yaml`, `gateway.yaml`, and optional bundle descriptors. |
-| `--latest` | With `--descriptors-location`, resolve the latest platform release instead of using `assembly.yaml -> platform.ref`. |
-| `--upstream` | Use the latest upstream repo state (`origin/main`) instead of a released platform ref. Requires either `--descriptors-location` or an initialized runtime with the canonical descriptor set under `config/`. |
-| `--release <ref>` | With `--descriptors-location`, use the given platform release instead of `assembly.yaml -> platform.ref`. |
-| `--build` | With `kdcube init`, build images after staging the runtime without starting containers. With `kdcube start`, rebuild images before starting. |
-| `--info` | Print global CLI state (defaults, running deployment). With `--workdir`, print resolved runtime info for that workdir: descriptor paths, install metadata, and host/container bundle mount mappings. |
-| `--remove-volumes` | With `kdcube stop`, also remove local volumes. |
-| `--reset-config` | Re‑prompt for config values without deleting files. |
-| `--reset` | Alias for `--reset-config`. |
-| `--clean` | Clean local Docker cache and unused KDCube images. |
-| `--secrets-prompt` | Prompt for OpenAI, Anthropic, and Git HTTPS token values and inject them at runtime (sidecar). |
-| `--secrets-set KEY=VALUE` | Inject a secret value without prompting (repeatable). |
-| `--proxy-ssl` | Force SSL proxy config (overrides assembly descriptor). |
-| `--no-proxy-ssl` | Force non‑SSL proxy config (overrides assembly descriptor). |
-| `--dry-run` | Generate env files and print their paths without running Docker. |
-| `--dry-run-print-env` | With `--dry-run`, also print the full env file contents. |
+| `kdcube init` | Stage descriptors, generate env files, optionally build images |
+| `kdcube start` | Start the platform stack for an initialized workdir |
+| `kdcube stop` | Stop the stack; `--remove-volumes` also wipes local volumes |
 
-### Subcommands
+### Runtime operations
 
-| Subcommand | Purpose |
+| Command | What it does |
 |---|---|
-| `kdcube init [--workdir <path>] [--path <repo>] [--descriptors-location <dir>] [--latest\|--upstream\|--release <ref>] [--build] [-i]` | Initialize a workdir (stage descriptors, generate env files). Explicit `--path` stages that local source tree unless a version selector is used. With `--build`, also build images **without** starting containers. |
-| `kdcube start [--workdir <path>] [--build]` | Start the Docker Compose stack for an already-initialized workdir. `--build` is a convenience rebuild before start, not required if `init --build` was already run. |
-| `kdcube stop [--workdir <path>] [--remove-volumes]` | Stop the local Docker Compose stack. |
-| `kdcube reload <bundle_id> [--workdir <path>]` | Reapply `bundles.yaml` from the active runtime and clear proc bundle caches. |
-| `kdcube export [--workdir <path>] [--tenant <id>] [--project <id>] [--out-dir <dir>] [--aws-region <region>]` | Export effective live `bundles.yaml` and `bundles.secrets.yaml`. |
-| `kdcube defaults [--default-workdir <path>] [--default-tenant <t>] [--default-project <p>]` | Save persistent operator defaults to `~/.kdcube/cli-defaults.json`. |
+| `kdcube reload <bundle_id>` | Reapply bundle config and clear proc caches — no full restart needed |
+| `kdcube bundle <bundle_id>` | Patch bundle config or secrets by dotted key path |
+| `kdcube export` | Export live `bundles.yaml` / `bundles.secrets.yaml` |
 
-### Operator defaults (`kdcube defaults`)
+### Configuration
 
-`kdcube defaults` persists values to `~/.kdcube/cli-defaults.json`:
+| Command | What it does |
+|---|---|
+| `kdcube defaults` | Save persistent `--workdir`, `--tenant`, `--project` defaults |
+| `kdcube --info` | Show global CLI state and resolved runtime info |
+| `kdcube --reset` | Re-prompt for config values without deleting files |
 
-| Field | Flag | Purpose |
-|---|---|---|
-| `default_workdir` | `--default-workdir` | Fallback workdir when `--workdir` is omitted from a subcommand |
-| `default_tenant` | `--default-tenant` | Displayed in global `--info`; used by `kdcube export` as fallback tenant |
-| `default_project` | `--default-project` | Displayed in global `--info`; used by `kdcube export` as fallback project |
+---
 
-`kdcube start`, `kdcube stop`, `kdcube reload`, and `kdcube export` resolve the
-target workdir with the following precedence:
+## `kdcube bundle` — patch config at runtime
 
-1. `--workdir` passed explicitly → use it.
-2. `--workdir` omitted, `default_workdir` present in `cli-defaults.json` → use that.
-3. Neither provided → error with a hint to run `kdcube defaults --default-workdir <path>`.
-
-`kdcube --info` (without `--workdir`) reads `cli-defaults.json` and displays the
-configured values, or reports that no defaults are set.
-
-### Single-deployment guard (`cli-lock.json`)
-
-`~/.kdcube/cli-lock.json` is a per-machine deployment lock written on start and
-cleared on stop.
-
-Format:
-
-```json
-{
-  "tenant": "...",
-  "project": "...",
-  "workdir": "...",
-  "docker_dir": "...",
-  "env_file": "..."
-}
-```
-
-**Guard at start (`kdcube start`)** — reads the lock and runs `docker compose ps`:
-
-- No lock → proceed.
-- Lock matches the target `tenant/project` → proceed (same deployment restart).
-- Lock points to a **different** deployment and services are **live** → abort with
-  a message showing what is running and how to stop it first.
-- Lock exists but services are **not live** (stale) → lock cleared automatically,
-  start proceeds.
-
-**Guard at stop (`kdcube stop`)** — before stopping:
-
-1. Runs `docker compose ps` for the target workdir — nothing running →
-   `"Deployment is not running"`.
-2. Something running and lock matches the target `tenant/project` → stop and
-   clear the lock.
-3. Something running but lock points to a **different** deployment → abort.
-
-**`kdcube --info` and stale locks** — global `--info` verifies the lock via
-`docker compose ps`. If the recorded deployment is no longer running, the lock is
-reported as stale and cleared automatically.
-
-### Use a local checkout (dev)
+Patch a staged bundle without touching YAML files by hand:
 
 ```bash
-kdcube --path /Users/you/src/kdcube/kdcube-ai-app
+# Change a cron schedule
+kdcube bundle <bundle_id> \
+  --set-config routines.heartbeat.cron "*/5 * * * *"
+
+# Disable a feature flag
+kdcube bundle <bundle_id> \
+  --set-config features.some_feature.enabled false
+
+# Set a secret
+kdcube bundle <bundle_id> \
+  --set-secret api.token "sk-..."
+
+# Remove a key
+kdcube bundle <bundle_id>  \
+  --del-config routines.heartbeat.cron
+
+# Apply changes
+kdcube reload <bundle_id>
 ```
 
-When `--path` is provided, the wizard **uses that repo for templates and local builds**
-and **does not show the Install source menu**.
+---
 
-For the descriptor `init` path, use `--path` when you need to test uncommitted
-platform changes:
+## Full documentation
 
-```bash
-kdcube init \
-  --descriptors-location /path/to/descriptors \
-  --workdir ~/.kdcube/kdcube-runtime \
-  --path /Users/you/src/kdcube/kdcube-ai-app \
-  --build
-```
-
-This copies the dirty local checkout into the namespaced runtime workdir and
-builds from the staged copy. Do not combine this flow with `--upstream`,
-`--latest`, or `--release`, because those flags explicitly select a managed
-version instead of the dirty local source.
-
-Re-run prompts (edit existing values):
-
-```bash
-kdcube --reset
-```
-
-Clean local Docker images/cache:
-
-```bash
-kdcube --clean
-```
-
-Stop the local stack:
-
-```bash
-kdcube stop --workdir ~/.kdcube/kdcube-runtime
-```
-
-Stop and remove volumes:
-
-```bash
-kdcube stop --workdir ~/.kdcube/kdcube-runtime --remove-volumes
-```
-
-Inspect global CLI state (defaults + running deployment):
-
-```bash
-kdcube --info
-```
-
-Inspect the resolved runtime, including how local non-git bundles are mounted:
-
-```bash
-kdcube --info --workdir ~/.kdcube/kdcube-runtime/acme__prod_demo
-```
-
-When `--workdir` points at the base workspace root, `kdcube stop` resolves the
-single matching runtime namespace automatically. If there are multiple runtime
-namespaces under that base workspace, pass the concrete namespaced runtime path
-explicitly.
-
-Tip: if `kdcube` is not on your PATH, run `python -m pipx ensurepath`
-or re-open your shell after installation.
-
-## What the wizard does (today)
-
-When you run `kdcube`, the **wizard** performs the steps below:
-1) Creates a **workdir** with `config/`, `data/`, and `logs/` folders.
-2) Writes compose env files into `config/` (only if missing; it won’t overwrite existing files).
-3) Copies nginx configs into `config/` for runtime overrides:
-   - `nginx_ui.conf`
-   - runtime proxy config (based on selected auth mode)
-4) Selects **auth mode** (simple, cognito, or delegated) and writes:
-   - `AUTH_PROVIDER` in `.env.ingress` + `.env.proc`
-   - Cognito fields when applicable (see below)
-5) Generates frontend runtime config based on auth mode or descriptor template.
-6) Creates local data folders for Postgres/Redis/exec workspace/bundle storage.
-7) Optionally builds images and starts `docker compose up -d`.
-
-### Authentication modes
-The wizard prompts for an auth mode and updates both backend and frontend config.
-
-**Simple (hardcoded)**
-- `AUTH_PROVIDER=simple`
-- Frontend config: `frontend.config.hardcoded.json`
-- Uses a hardcoded admin token in config (local dev only)
-
-**Cognito**
-- `AUTH_PROVIDER=cognito`
-- Frontend config: `frontend.config.cognito.json`
-- Required fields:
-  - `COGNITO_REGION`
-  - `COGNITO_USER_POOL_ID`
-  - `COGNITO_APP_CLIENT_ID`
-  - `COGNITO_SERVICE_CLIENT_ID`
-- The frontend `authority` is composed as:
-  - `https://cognito-idp.<COGNITO_REGION>.amazonaws.com/<COGNITO_USER_POOL_ID>`
-
-**Delegated**
-- `AUTH_PROVIDER=cognito`
-- Frontend config: `frontend.config.delegated.json`
-- Uses the delegated proxy template (proxylogin) while still validating tokens via Cognito.
-- If `assembly.yaml` provides `company`, the generated delegated config uses it for:
-  - `auth.totpAppName`
-  - `auth.totpIssuer`
-
-### Routes prefix & nginx proxy
-The frontend config includes `routesPrefix` (default: `/chatbot`).
-The wizard patches the **runtime proxy config** in `config/` so nginx uses the
-same prefix. This keeps `/chatbot` (or any custom prefix) consistent between UI and proxy.
-
-If `proxy.ssl: true` and `assembly.domain` is set, the wizard also patches the
-runtime nginx SSL config so `YOUR_DOMAIN_NAME` becomes the configured domain in:
-- `server_name`
-- `/etc/letsencrypt/live/<domain>/fullchain.pem`
-- `/etc/letsencrypt/live/<domain>/privkey.pem`
-
-### Secrets (third services tokens)
-The wizard **does not** write OpenAI/Anthropic/Git token values to `.env` files.
-If you provide them during setup, they are injected at runtime into the
-`kdcube-secrets` sidecar (in‑memory only) when `assembly.yaml` uses
-`secrets.provider: secrets-service`. If you restart the stack, you’ll be
-prompted again to re‑inject them.
-
-Order (automatic):
-1) Start `kdcube-secrets`
-2) Wait for it to be ready
-3) Inject keys
-4) Start/restart ingress + proc (they fetch secrets)
-
-Manual re‑inject:
-
-```bash
-kdcube --secrets-prompt --workdir ~/.kdcube/kdcube-runtime
-```
-
-Or pass explicit values:
-
-```bash
-kdcube --secrets-set OPENAI_API_KEY=... --secrets-set ANTHROPIC_API_KEY=...
-```
-
-You can also override the git HTTPS token this way:
-
-```bash
-kdcube --secrets-set GIT_HTTP_TOKEN=...
-```
-
-Note: re‑inject will **restart** `kdcube-secrets`, `chat-ingress`, and `chat-proc`
-to refresh per‑run tokens (and the web proxy to keep upstreams in sync).
-Per‑run tokens are generated by the CLI and are **not stored** in `config/`.
-
-If you set LLM keys in env files (managed infra / custom setups), those env
-values still work and take precedence. The secrets sidecar is only used when
-env keys are missing.
-
-### First-run defaults
-Plain `kdcube` now seeds the full canonical descriptor set into `workdir/config/`
-from the tracked reference descriptors:
-
-- `assembly.yaml`
-- `secrets.yaml`
-- `bundles.yaml`
-- `bundles.secrets.yaml`
-- `gateway.yaml`
-
-That first local bootstrap is descriptor-first and local-first:
-
-- `storage.workspace.type=local`
-- `storage.claude_code_session.type=local`
-- `storage.kdcube=/kdcube-storage`
-- `storage.bundles=/bundle-storage`
-- `bundles.default_bundle_id=versatile@2026-03-31-13-36`
-
-When a seed descriptor sets `storage.kdcube` or `storage.bundles` to a host
-`file://...` path, `init` treats that as a host-side storage root. The staged
-runtime descriptor is rewritten to the container paths `file:///kdcube-storage`
-and `file:///bundle-storage`, and compose mounts the selected host roots there.
-This keeps descriptors portable while still allowing local host storage during
-CLI testing.
-
-On a fresh default run, the installer asks only for:
-
-- `Host bundles root (local path bundles)`
-- `OpenAI API key` (optional)
-- `Anthropic API key` (optional)
-- `Git HTTPS token` (optional)
-
-It does not ask for OpenRouter. It does not ask for Brave. It auto-seeds local
-defaults for Postgres, Redis, auth mode, UI port, managed bundle cache paths,
-bundle storage, and exec workspace.
-
-### Git HTTPS token (private bundles)
-If you choose or provide a Git HTTPS token for private bundles, the token is
-treated as a secret and is **not stored** in `.env.proc`. It is injected at
-runtime (same flow as LLM keys). You will be prompted again on the next run
-unless you pass it via `--secrets-set GIT_HTTP_TOKEN=...`.
-
-More details:
-https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/ops/local/local-setup-README.md
-
-Current scope: the wizard is **optimized for docker‑compose** (all‑in‑one).
-It creates a workdir (default: `~/.kdcube/kdcube-runtime`) and lets you:
-- generate config/data/log folders
-- choose where **all artifacts** come from (templates + images)
-- start `docker compose` (optional)
-
-Install source menu (shown only when `--path` is **not** provided):
-- **upstream**: clone/pull the repo into the workspace; use `init --build` to prebuild images before start
-- **release-latest**: pull prebuilt images for the latest release
-- **release-tag**: pull prebuilt images for a specific version (platform.ref)
-- **local**: use a local repo path you provide (build locally)
-- **workspace**: use the repo already cloned in the workspace (build locally)
-
-Defaults:
-- If the workspace repo exists → default is **workspace**
-- If it does not exist → default is **upstream**
-
-The **workspace** option only appears when a repo is already cloned there.
-
-Only **release-latest** and **release-tag** pull images. All other choices build locally.
-
-Tip: you can select the install source using the ↑/↓ arrow keys and Enter.
-
-Example workdir layout:
-
-```
-~/.kdcube/kdcube-runtime
-├─ config/
-│  ├─ .env
-│  ├─ .env.ingress
-│  ├─ .env.proc
-│  ├─ .env.metrics
-│  ├─ .env.postgres.setup
-│  ├─ .env.proxylogin
-│  ├─ frontend.config.<mode>.json
-│  ├─ nginx_ui.conf
-│  └─ nginx_proxy*.conf
-├─ data/
-│  ├─ postgres/
-│  ├─ redis/
-│  ├─ kdcube-storage/
-│  │  ├─ cb/
-│  │  │  └─ tenants/<tenant>/projects/<project>/
-│  │  │     ├─ conversation/<user>/<conversation>/<turn>/
-│  │  │     └─ executions/<user>/<conversation>/<turn>/<exec_id>/
-│  │  ├─ accounting/<tenant>/project/<YYYY.MM.DD>/<service>/<bundle_id>/
-│  │  └─ analytics/<tenant>/project/accounting/{daily,weekly,monthly}/
-│  ├─ exec-workspace/
-│  └─ bundle-storage/
-└─ logs/
-   ├─ chat-ingress/
-   └─ chat-proc/
-```
-
-## Advanced usage
-
-### Assembly descriptor (platform / frontend / infra)
-You can point the CLI to an **assembly descriptor YAML** (`assembly.yaml`) that defines
-platform metadata, frontend settings, auth, infra, and proxy defaults.
-
-The wizard prompts for this as **Assembly descriptor path**.
-**Wizard flow (descriptor usage):**
-1) Provide the `assembly.yaml` path (defaults to `workdir/config/assembly.yaml`).
-   If you provide another path, the CLI copies it into `workdir/config/assembly.yaml`
-   and uses the copied file as the source of truth.
-2) Choose whether to apply the **Frontend** section (build or image).
-
-Repo field contract:
-- `platform.repo` and `frontend.build.repo` should use a cloneable repo spec:
-  - `git@github.com:org/repo.git`
-  - `https://github.com/org/repo.git`
-  - `org/repo`
-- older single-name values such as `kdcube-ai-app` are still accepted for
-  backward compatibility, but new descriptors should use one of the cloneable
-  forms above
-
-When an assembly descriptor is provided, the wizard **writes non‑secret values back**
-into `assembly.yaml` (tenant/project, auth, infra, paths) and then renders `.env*`
-from it. This makes `assembly.yaml` the source of truth for install‑time config.
-
-The same assembly descriptor also configures runtime workspace/session bootstrap policy:
-
-- `storage.workspace.type` -> `REACT_WORKSPACE_IMPLEMENTATION`
-- `storage.workspace.repo` -> `REACT_WORKSPACE_GIT_REPO`
-- `storage.claude_code_session.type` -> `CLAUDE_CODE_SESSION_STORE_IMPLEMENTATION`
-- `storage.claude_code_session.repo` -> `CLAUDE_CODE_SESSION_GIT_REPO`
-
-### Descriptor fast path requirements
-
-The descriptor-folder fast path is used only when the descriptor set is complete
-enough for a non-interactive install. At minimum:
-
-- `assembly.yaml`, `secrets.yaml`, and `gateway.yaml` exist
-- `assembly.secrets.provider == "secrets-file"`
-- `assembly.context.tenant` and `assembly.context.project` are set
-- `assembly.paths.host_bundles_path` is set
-- `assembly.platform.ref` is set unless `--latest`, `--upstream`, or `--release` is used
-- `assembly.domain` is set when `proxy.ssl: true`
-- any git-backed workspace/session config includes its repo URL
-- Cognito auth fields are present when `auth.type` requires them
-- frontend build fields are present when `frontend` is used without `frontend.image`
-
-If any of those are missing, the CLI falls back to the normal guided flow.
-
-Reusing an initialized runtime without `--descriptors-location` requires the
-same canonical descriptor set to already exist under `workdir/config`, plus
-`workdir/config/install-meta.json` so the CLI can recover the repo context.
-
-Template:
-- [`app/ai-app/deployment/assembly.yaml`](../../../deployment/assembly.yaml) (copied into the workdir if no path is provided)
-
-References:
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/descriptors-README.md
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/assembly-descriptor-README.md
-
-### Bundles descriptor (optional)
-You can provide a **bundles descriptor** (`bundles.yaml`) and an optional
-**bundles secrets** file (`bundles.secrets.yaml`). This is the preferred way
-to define bundles and their non‑secret config, with secrets kept separate.
-
-If `workdir/config/bundles.yaml` already exists, the wizard pre-fills the prompt
-with that path so it is reused on subsequent runs.
-
-Note: secrets descriptors are **not** prefilled or cached.
-
-The CLI stages `bundles.yaml` into the workdir and, when enabled:
-- mounts the runtime workspace `config/` directory at `/config`
-- sets `BUNDLES_PRELOAD_ON_START=1` in `.env.proc` by default
-- enables bundle git resolution and env sync on startup
-
-Current proc behavior:
-
-- `config/bundles.yaml` is the normal bundle descriptor authority
-- proc can seed/reset from that descriptor directly
-
-Local bundle root contract:
-
-- `assembly.paths.host_bundles_path` is installer-facing config for non-managed local path bundles and becomes `HOST_BUNDLES_PATH`
-- compose mounts `HOST_BUNDLES_PATH` into proc as `BUNDLES_ROOT` (normally `/bundles`)
-- non-managed local bundle entries in `bundles.yaml` must use the container-visible path, for example:
-  - host folder: `/Users/you/dev/bundles/my.bundle`
-  - descriptor path: `/bundles/my.bundle`
-
-- `assembly.paths.host_managed_bundles_path` becomes `HOST_MANAGED_BUNDLES_PATH`
-- compose mounts `HOST_MANAGED_BUNDLES_PATH` into proc as `MANAGED_BUNDLES_ROOT` (normally `/managed-bundles`)
-
-Managed bundle materialization uses the dedicated managed root:
-
-- non-managed local path bundles continue to use `HOST_BUNDLES_PATH` and `/bundles/...`
-- git bundles are cloned under `HOST_MANAGED_BUNDLES_PATH` and resolved inside proc as `/managed-bundles/...`
-- built-in example bundles are also materialized under the managed root
-
-Symlink note:
-
-- if you symlink a bundle into `HOST_BUNDLES_PATH`, proc sees the symlink through the `/bundles` mount
-- this works only if Docker can also access the symlink target on the host
-- safest local pattern: keep the real bundle folder inside `HOST_BUNDLES_PATH`, or symlink only to another host path that is already accessible through the same Docker file-sharing scope
-
-`bundles.secrets.yaml` is staged into the workdir only when it is provided.
-If `assembly.yaml -> secrets.provider == "secrets-file"`, runtime resolves it
-from `/config/bundles.secrets.yaml` via `PLATFORM_DESCRIPTORS_DIR=/config`.
-
-Example (`bundles.yaml`):
-```yaml
-bundles:
-  version: "1"
-  default_bundle_id: "react@2026-02-10-02-44"
-  items:
-    - id: "react@2026-02-10-02-44"
-      name: "ReAct (example)"
-      repo: "git@github.com:kdcube/kdcube-ai-app.git"
-      ref: "v0.3.2"
-      subdir: "app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles"
-      module: "react@2026-02-10-02-44.entrypoint"
-      config:
-        embedding:
-          provider: "openai"
-          model: "text-embedding-3-small"
-        role_models:
-          solver.react.v2.decision.v2.strong:
-            provider: "anthropic"
-            model: "claude-sonnet-4-6"
-```
-
-Example (`bundles.secrets.yaml`):
-```yaml
-bundles:
-  version: "1"
-  items:
-    - id: "react@2026-02-10-02-44"
-      secrets:
-        openai:
-          api_key: null
-```
-
-Templates:
-- [`app/ai-app/deployment/bundles.yaml`](../../../deployment/bundles.yaml)
-- [`app/ai-app/deployment/bundles.secrets.yaml`](../../../deployment/bundles.secrets.yaml)
-
-For local host-edited bundle development:
-
-- define the bundle with `path: /bundles/...`
-- set `assembly.paths.host_bundles_path` to the matching host root
-- run KDCube through the CLI compose path
-- use `kdcube reload <bundle_id>` after code changes
-
-For AWS deployment:
-
-- use git bundle descriptors only
-- do not use local `path:` bundle entries
-- do not carry local `assembly.paths.host_bundles_path` values into the AWS descriptor set
-
-References:
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/bundles-descriptor-README.md
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/bundles-secrets-descriptor-README.md
-
-### Secrets descriptor (optional)
-You can provide a `secrets.yaml` path in the wizard (or via `KDCUBE_SECRETS_DESCRIPTOR_PATH`).
-The CLI stages this file into the runtime workspace `config/` directory.
-
-It is used:
-- to prefill runtime secrets (OpenAI/Anthropic/Git HTTP token and delegated Cognito client secret) during guided setup
-- or as the runtime secrets source when `assembly.yaml -> secrets.provider == "secrets-file"`
-
-In `secrets-file` mode runtime resolves `/config/secrets.yaml` via
-`PLATFORM_DESCRIPTORS_DIR=/config`.
-
-Values injected through the `secrets-service` flow are still **not** written to `.env.proc`.
-
-Secrets are keyed by **dot‑path** (e.g. `services.openai.api_key`).
-
-Template:
-- [`app/ai-app/deployment/secrets.yaml`](../../../deployment/secrets.yaml)
-
-Reference:
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/secrets-descriptor-README.md
-
-### Gateway config descriptor (optional)
-You can provide a `gateway.yaml` path in the wizard (or via `KDCUBE_GATEWAY_DESCRIPTOR_PATH`).
-The CLI stages it into `workdir/config` and points runtime at `/config` via
-`PLATFORM_DESCRIPTORS_DIR`.
-
-In current descriptor mode, gateway policy authority is therefore the staged
-workspace descriptor, not a copied field-by-field block in the service env
-files.
-
-If another platform also injects `GATEWAY_CONFIG_JSON`, that JSON still wins at
-runtime because gateway loader precedence prefers it over `gateway.yaml`.
-
-If `workdir/config/gateway.yaml` already exists, the wizard pre-fills the prompt
-with that path so it is reused on subsequent runs.
-
-Template:
-- [`app/ai-app/deployment/gateway.yaml`](../../../deployment/gateway.yaml)
-
-Reference:
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/gateway-descriptor-README.md
-
-### Custom UI via assembly descriptor (build or image)
-If your `assembly.yaml` includes a `frontend` section, the CLI will switch to
-**custom‑ui‑managed‑infra** compose mode.
-
-Minimal example:
-```yaml
-frontend:
-  build:
-    repo: "git@github.com:org/private-app.git"
-    ref: "ui-v2026.02.22"
-    dockerfile: "ops/docker/Dockerfile_UI"
-    src: "ui/chat-web-app"
-  image: "registry/private-app-ui:2026.02.22"  # optional prebuilt UI image; if set, CLI writes KDCUBE_UI_IMAGE and skips the local web-ui build
-  frontend_config: "ops/docker/config.delegated.json"  # optional
-  nginx_ui_config: "ops/docker/nginx_ui.conf"          # optional
-```
-
-Frontend/runtime config behavior:
-- `frontend.image` is optional. When present, the CLI writes `KDCUBE_UI_IMAGE` and treats the UI as a prebuilt image override.
-- If `frontend.image` is omitted but `frontend.build` is present, the CLI clones/uses the frontend source repo and builds `web-ui` locally from `build.repo`, `build.ref`, `build.dockerfile`, and `build.src`.
-- `frontend.build.repo` accepts SSH URLs, HTTPS URLs, and `owner/repo` shorthand.
-- `frontend.build.image_name` is not used by the CLI installer. That field belongs to the ECS CI/CD flow, not the local docker-compose flow.
-
-- If `frontend.frontend_config` is provided, the CLI uses it as the template for the
-  generated runtime `config.json` and patches tenant/project/auth/routesPrefix values.
-- If it is omitted, the CLI falls back to a built-in template by auth mode:
-  - `simple` -> `config.hardcoded.json`
-  - `cognito` -> `config.cognito.json`
-  - `delegated` -> `config.delegated.json`
-- If `frontend.nginx_ui_config` is omitted, the CLI falls back to the built-in `nginx_ui.conf`.
-
-How to activate:
-1) Run `kdcube`
-2) Choose **Use an assembly descriptor** → provide `assembly.yaml`
-3) Confirm **Frontend** usage when prompted.
-4) The CLI selects `deployment/docker/custom-ui-managed-infra/docker-compose.yaml`.
-
-Full details:
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/descriptors-README.md
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/assembly-descriptor-README.md
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/custom-cicd-README.md
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/cli-README.md
-
-### Manual compose (advanced)
-
-If you want to run compose manually, use the workdir env file:
-
-```bash
-docker compose --env-file ~/.kdcube/kdcube-runtime/config/.env up -d --build
-```
-
-Note: `--env-file` is a **Docker Compose** option (not a CLI flag).
-
-## Where data is stored
-- **Config:** `workdir/config/` (env files, nginx config, UI config)
-- **Data:** `workdir/data/` (postgres/redis storage, bundle storage, exec workspace)
-- **Logs:** `workdir/logs/`
-
-Infra credentials (Postgres/Redis) are stored in `config/.env*` for local compose.
-LLM keys are **not** stored in files; they live only in the secrets sidecar.
-
-## Compose usage (recommended)
-
-1) Run the wizard and choose a workdir (example: `/srv/kdcube-local`).
-2) It will generate:
-   - `/srv/kdcube-local/config/.env`
-   - `/srv/kdcube-local/config/.env.ingress`
-   - `/srv/kdcube-local/config/.env.proc`
-   - `/srv/kdcube-local/config/.env.metrics`
-   - `/srv/kdcube-local/config/.env.postgres.setup`
-   - `/srv/kdcube-local/config/.env.proxylogin`
-   - `/srv/kdcube-local/config/frontend.config.<mode>.json`
-   - `/srv/kdcube-local/config/nginx_ui.conf`
-   - `/srv/kdcube-local/config/nginx_proxy*.conf`
-3) Start compose from `deployment/docker/all_in_one_kdcube`:
-
-```bash
-docker compose --env-file /srv/kdcube-local/config/.env up -d --build
-```
-
-Open the UI:
-- `http://localhost[:port]<routesPrefix>/chat`
-
-`routesPrefix` comes from the generated frontend `config.json`. When it is not
-set explicitly, the default is `/chatbot`.
-  (via proxy; if `KDCUBE_PROXY_HTTP_PORT` is unset, it falls back to `KDCUBE_UI_PORT`)
-
-## Notes
-
-- The wizard **does not overwrite** existing config files in your workdir. It only fills
-  placeholders in newly created files.
-- Use `kdcube --reset` to re-enter values without deleting files.
-- Config upgrades/migrations will be added later when configs are versioned.
-- The wizard auto‑saves after major sections, so if you exit early (Ctrl+C) most
-  values entered so far are preserved in `config/` and will appear as defaults next run.
-
-Tip: you can edit `workdir/config/nginx_ui.conf` and the selected `workdir/config/nginx_proxy*.conf`
-without rebuilding images (they are mounted into the containers at runtime).
-
-## UI config source of truth
-
-The web UI loads its runtime config from `/config.json` inside the `web-ui`
-container. Docker compose mounts the host file defined by
-`PATH_TO_FRONTEND_CONFIG_JSON` to:
-
-`/usr/share/nginx/html/config.json`
-
-## Clean / reset
-Clean local Docker cache and unused KDCube images:
-```bash
-kdcube --clean
-```
-
-Reset prompts without deleting files:
-```bash
-kdcube --reset
-```
-
-Full reset (delete workdir):
-```bash
-rm -rf ~/.kdcube/kdcube-runtime
-```
-
-If the UI is calling the wrong tenant/project, check:
-- `PATH_TO_FRONTEND_CONFIG_JSON` in the generated `.env`
-- `curl http://localhost:<ui_port>/config.json`
-
-See the full local setup flow on GitHub:
-https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/ops/local/local-setup-README.md
-
-More documentation:
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/descriptors-README.md
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/assembly-descriptor-README.md
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/bundles-descriptor-README.md
-- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/service-runtime-configuration-mapping-README.md
-
-## License
-MIT License. See `app/ai-app/src/kdcube-ai-app/LICENSE`.
+See `additional-README.md` in this package or the platform docs:  
+https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/cli-README.md

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/additional_README.md
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/additional_README.md
@@ -1,0 +1,978 @@
+# KDCube CLI
+
+![KDCube CLI](https://raw.githubusercontent.com/kdcube/kdcube-ai-app/main/app/ai-app/src/kdcube-ai-app/kdcube_cli/pixel-cubes.png)
+
+Bootstrap installer for the KDCube platform stack. This package clones the
+repository (if needed) and launches the guided setup wizard.
+
+This README describes the current implemented CLI behavior.
+
+Short version of the current model:
+
+- the CLI bootstraps or reuses a concrete runtime snapshot under a namespaced
+  workdir
+- the namespace is usually derived from `assembly.yaml -> context.tenant` and
+  `context.project`
+- each local runtime snapshot keeps its own staged descriptors, platform
+  snapshot, and runtime data
+
+So current local CLI usage is still deployment-isolated, but workdir-first.
+
+Operationally, that means:
+
+- one `tenant/project` = one isolated environment
+- use separate `tenant/project` values for different customers or different
+  stages such as `dev`, `staging`, and `prod`
+- keep multiple bundles inside one `tenant/project` when they belong to the
+  same environment
+
+So the current CLI does not create one runtime per bundle.
+It creates one runtime per environment, and that environment may host many
+bundles.
+
+One more practical rule is easy to miss:
+
+- one machine can hold many local runtime snapshots under different
+  `tenant/project` namespaces
+- that does not mean the current compose-backed local workflow supports many
+  concurrently running local KDCube stacks as a normal mode
+- treat the current local runtime as one active deployment at a time unless a
+  future explicit multi-instance local mode is introduced
+
+----
+
+## Prerequisites
+
+### macOS
+- Python 3.9+ (Homebrew recommended)
+- Git (Xcode Command Line Tools or Homebrew)
+- Docker Desktop (includes Docker Compose)
+
+### Windows
+- Python 3.9+
+- Git for Windows
+- Docker Desktop (enable WSL2 backend)
+
+### Linux
+- Python 3.9+
+- Git
+- Docker Engine + Docker Compose plugin
+
+## Install
+
+```bash
+pipx install kdcube-cli
+```
+
+Alternative (pip):
+
+```bash
+python -m pip install --user kdcube-cli
+```
+
+On Debian/Ubuntu hosts that enforce PEP 668 (`externally-managed-environment`),
+install the CLI into a dedicated virtual environment instead of the system
+Python:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3-pip python3-venv
+python3 -m venv ~/.venvs/kdcube-cli
+~/.venvs/kdcube-cli/bin/pip install -e /path/to/kdcube_cli
+~/.venvs/kdcube-cli/bin/kdcube --help
+```
+
+## Run
+
+```bash
+kdcube
+```
+
+## Quick start (new users)
+
+1) Run `kdcube`  
+2) Choose **release-latest** (pull prebuilt images)  
+3) Answer **yes** to “Run docker compose now?”  
+
+That brings up the stack with no local build required.
+
+We aim for a setup that is simple to try, and easy to explore further using the
+installed admin assistant and bundled tools.
+
+## Quick start (prepared descriptors)
+
+If you already have a descriptor folder, you can skip the wizard:
+
+```bash
+kdcube init \
+  --descriptors-location /path/to/descriptors \
+  --workdir /path/to/workspace
+```
+
+With descriptor-driven installs, `--workdir` is the base workspace root. The
+effective runtime is created under:
+
+```text
+<workspace>/<safe_tenant>__<safe_project>/
+```
+
+using `assembly.yaml -> context.tenant` and `context.project`.
+
+If `--path` is omitted, the CLI clones or reuses the platform checkout under:
+
+```text
+<workspace>/<safe_tenant>__<safe_project>/repo
+```
+
+You can still pass `--path` explicitly if you want to force a specific local
+checkout. In descriptor-driven `init`, explicit `--path` means “stage this local
+source tree into the runtime workdir and use that staged copy”. The CLI copies
+tracked files plus untracked files that are not ignored by git, so dirty local
+source changes can be tested without copying `.git`, local runtime data, or
+other gitignored paths.
+
+```bash
+kdcube init \
+  --descriptors-location /path/to/descriptors \
+  --workdir /path/to/workspace \
+  --path /path/to/kdcube-ai-app \
+  --build
+```
+
+`--workdir` answers “where should this runtime live?”. `--path` answers “which
+local platform source tree should this runtime use?”. If `--upstream`,
+`--latest`, or `--release` is also provided, that version selector wins and
+`--path` is only the local repo/cache location for the selected source.
+
+Or pull the latest platform release from the platform repo instead of
+`assembly.yaml -> platform.ref`:
+
+```bash
+kdcube init \
+  --descriptors-location /path/to/descriptors \
+  --workdir /path/to/workspace \
+  --latest
+```
+
+Or initialize from the latest upstream repo state instead of a released ref:
+
+```bash
+kdcube init \
+  --descriptors-location /path/to/descriptors \
+  --workdir /path/to/workspace \
+  --upstream
+```
+
+If you also want the runtime ready with freshly built local images, build during
+init:
+
+```bash
+kdcube init \
+  --descriptors-location /path/to/descriptors \
+  --workdir /path/to/workspace \
+  --upstream \
+  --build
+```
+
+Use `--upstream` when you want the deployment assets from the latest GitHub
+`origin/main`, including:
+
+- compose files
+- nginx templates
+- installer-side deployment templates
+
+If the runtime was already initialized earlier, you can omit
+`--descriptors-location` and reuse the staged descriptors from `workdir/config`
+instead:
+
+```bash
+kdcube init \
+  --workdir /path/to/workspace/<safe_tenant>__<safe_project> \
+  --upstream
+```
+
+This reuse path requires:
+
+- `workdir/config/install-meta.json`
+- the canonical descriptor set already present under `workdir/config`
+  - `assembly.yaml`
+  - `secrets.yaml`
+  - `bundles.yaml`
+  - `bundles.secrets.yaml`
+  - `gateway.yaml`
+
+When those files exist, the CLI treats `workdir/config` as the descriptor
+authority and reuses the repo recorded in `install-meta.json` when possible.
+
+Important reused-runtime rule:
+
+- the CLI reuses `workdir/config/assembly.yaml`, `bundles.yaml`, and `bundles.secrets.yaml` as they already exist
+- it does not reseed default descriptors
+- if `bundles.yaml` already contains local path entries under `/bundles/...`, those are treated as container paths and preserved
+- the matching host root is taken from `assembly.yaml -> paths.host_bundles_path`
+- the CLI does not reinterpret `/bundles/...` as a host filesystem path
+
+So for an initialized runtime, change bundle topology by editing:
+
+- `workdir/config/assembly.yaml`
+- `workdir/config/bundles.yaml`
+
+Do not change local path bundles by putting host paths directly into `bundles.yaml`.
+
+Correct split:
+
+```yaml
+# workdir/config/assembly.yaml
+paths:
+  host_bundles_path: "/Users/you/src"
+```
+
+```yaml
+# workdir/config/bundles.yaml
+bundles:
+  items:
+    - id: "my.bundle@1-0"
+      path: "/bundles/my-repo/src/my_bundle"
+      module: "entrypoint"
+```
+
+`host_bundles_path` is the host parent root.
+`path` in `bundles.yaml` is the container-visible bundle root.
+
+`--latest` is different: it resolves the latest release ref for release-image
+installs. It does not mean “latest source templates from GitHub main”.
+
+Or pin a specific release explicitly:
+
+```bash
+kdcube init \
+  --descriptors-location /path/to/descriptors \
+  --release 2026.4.11.012
+```
+
+Choose exactly one source selector:
+- `--upstream` for the latest upstream repo state
+- `--latest` for the latest released platform ref
+- `--release <ref>` for a specific released ref
+- explicit `--path <repo>` without the selectors above for dirty local source
+  staging
+- otherwise `assembly.yaml -> platform.ref`
+
+For `aws-sm` deployments, you can also export the current effective live
+deployment-scoped bundle descriptors directly from AWS Secrets Manager:
+
+```bash
+kdcube export \
+  --tenant <tenant> \
+  --project <project> \
+  --aws-region <region> \
+  --out-dir /tmp/kdcube-export
+```
+
+Optional:
+- `--aws-profile <profile>`
+- `--aws-sm-prefix <prefix>`
+
+This reconstructs:
+- `bundles.yaml`
+- `bundles.secrets.yaml`
+
+from the authoritative grouped AWS SM bundle documents, not from Redis or the
+currently mounted `/config/bundles.yaml`.
+
+Expected descriptor folder:
+
+```text
+descriptors/
+  assembly.yaml
+  secrets.yaml
+  gateway.yaml
+  bundles.yaml            # optional
+  bundles.secrets.yaml    # optional
+```
+
+When the descriptor set is complete, the CLI:
+- resolves the effective runtime as `<workspace>/<safe_tenant>__<safe_project>`
+- stages the descriptors into `<runtime>/config`
+- clones or reuses the platform repo under `<runtime>/repo` when `--path` is omitted
+- copies the explicit local `--path` repo into `<runtime>/repo` when no version selector is used
+- skips interactive prompts
+- runs a release install directly
+
+The same non-interactive path is also used when:
+
+- `--descriptors-location` is omitted
+- `--workdir` points to an existing runtime
+- `config/install-meta.json` exists
+- the canonical descriptor set already exists under `config/`
+
+In that case the CLI reuses the staged runtime descriptors and the repo path
+recorded in `install-meta.json`.
+
+If required fields are missing, it falls back to the guided setup and prints
+what is incomplete.
+
+## What it installs (default)
+- Base workspace: `~/.kdcube/kdcube-runtime`
+- Runtime namespace: `~/.kdcube/kdcube-runtime/<safe_tenant>__<safe_project>`
+- Repo clone default: `~/.kdcube/kdcube-runtime/<safe_tenant>__<safe_project>/repo`
+- Docker images: prepared by `init --build` or rebuilt as a convenience by `start --build`
+
+### CLI options (common)
+| Option | Purpose |
+|---|---|
+| `--repo <url>` | Git repo URL (default: official kdcube repo). |
+| `--path <repo>` | For `kdcube init` without `--upstream`, `--latest`, or `--release`, copy this local platform checkout into the runtime and use the staged copy. With a version selector, use this path as the local repo/cache location. If omitted in descriptor mode, the checkout defaults to `<workspace>/<tenant>__<project>/repo`. |
+| `--workdir <path>` | Base workspace root. In descriptor mode the effective runtime becomes `<workdir>/<tenant>__<project>`. If it already points to an initialized runtime with `config/install-meta.json` and the canonical descriptor set under `config/`, the CLI can reuse that runtime non-interactively. |
+| `--descriptors-location <dir>` | Use a folder containing `assembly.yaml`, `secrets.yaml`, `gateway.yaml`, and optional bundle descriptors. |
+| `--latest` | With `--descriptors-location`, resolve the latest platform release instead of using `assembly.yaml -> platform.ref`. |
+| `--upstream` | Use the latest upstream repo state (`origin/main`) instead of a released platform ref. Requires either `--descriptors-location` or an initialized runtime with the canonical descriptor set under `config/`. |
+| `--release <ref>` | With `--descriptors-location`, use the given platform release instead of `assembly.yaml -> platform.ref`. |
+| `--build` | With `kdcube init`, build images after staging the runtime without starting containers. With `kdcube start`, rebuild images before starting. |
+| `--info` | Print global CLI state (defaults, running deployment). With `--workdir`, print resolved runtime info for that workdir: descriptor paths, install metadata, and host/container bundle mount mappings. |
+| `--remove-volumes` | With `kdcube stop`, also remove local volumes. |
+| `--reset-config` | Re‑prompt for config values without deleting files. |
+| `--reset` | Alias for `--reset-config`. |
+| `--clean` | Clean local Docker cache and unused KDCube images. |
+| `--secrets-prompt` | Prompt for OpenAI, Anthropic, and Git HTTPS token values and inject them at runtime (sidecar). |
+| `--secrets-set KEY=VALUE` | Inject a secret value without prompting (repeatable). |
+| `--proxy-ssl` | Force SSL proxy config (overrides assembly descriptor). |
+| `--no-proxy-ssl` | Force non‑SSL proxy config (overrides assembly descriptor). |
+| `--dry-run` | Generate env files and print their paths without running Docker. |
+| `--dry-run-print-env` | With `--dry-run`, also print the full env file contents. |
+
+### Subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `kdcube init [--workdir <path>] [--path <repo>] [--descriptors-location <dir>] [--latest\|--upstream\|--release <ref>] [--build] [-i]` | Initialize a workdir (stage descriptors, generate env files). Explicit `--path` stages that local source tree unless a version selector is used. With `--build`, also build images **without** starting containers. |
+| `kdcube start [--workdir <path>] [--build]` | Start the Docker Compose stack for an already-initialized workdir. `--build` is a convenience rebuild before start, not required if `init --build` was already run. |
+| `kdcube stop [--workdir <path>] [--remove-volumes]` | Stop the local Docker Compose stack. |
+| `kdcube reload <bundle_id> [--workdir <path>]` | Reapply `bundles.yaml` from the active runtime and clear proc bundle caches. |
+| `kdcube export [--workdir <path>] [--tenant <id>] [--project <id>] [--out-dir <dir>] [--aws-region <region>]` | Export effective live `bundles.yaml` and `bundles.secrets.yaml`. |
+| `kdcube defaults [--default-workdir <path>] [--default-tenant <t>] [--default-project <p>]` | Save persistent operator defaults to `~/.kdcube/cli-defaults.json`. |
+
+### Operator defaults (`kdcube defaults`)
+
+`kdcube defaults` persists values to `~/.kdcube/cli-defaults.json`:
+
+| Field | Flag | Purpose |
+|---|---|---|
+| `default_workdir` | `--default-workdir` | Fallback workdir when `--workdir` is omitted from a subcommand |
+| `default_tenant` | `--default-tenant` | Displayed in global `--info`; used by `kdcube export` as fallback tenant |
+| `default_project` | `--default-project` | Displayed in global `--info`; used by `kdcube export` as fallback project |
+
+`kdcube start`, `kdcube stop`, `kdcube reload`, and `kdcube export` resolve the
+target workdir with the following precedence:
+
+1. `--workdir` passed explicitly → use it.
+2. `--workdir` omitted, `default_workdir` present in `cli-defaults.json` → use that.
+3. Neither provided → error with a hint to run `kdcube defaults --default-workdir <path>`.
+
+`kdcube --info` (without `--workdir`) reads `cli-defaults.json` and displays the
+configured values, or reports that no defaults are set.
+
+### Single-deployment guard (`cli-lock.json`)
+
+`~/.kdcube/cli-lock.json` is a per-machine deployment lock written on start and
+cleared on stop.
+
+Format:
+
+```json
+{
+  "tenant": "...",
+  "project": "...",
+  "workdir": "...",
+  "docker_dir": "...",
+  "env_file": "..."
+}
+```
+
+**Guard at start (`kdcube start`)** — reads the lock and runs `docker compose ps`:
+
+- No lock → proceed.
+- Lock matches the target `tenant/project` → proceed (same deployment restart).
+- Lock points to a **different** deployment and services are **live** → abort with
+  a message showing what is running and how to stop it first.
+- Lock exists but services are **not live** (stale) → lock cleared automatically,
+  start proceeds.
+
+**Guard at stop (`kdcube stop`)** — before stopping:
+
+1. Runs `docker compose ps` for the target workdir — nothing running →
+   `"Deployment is not running"`.
+2. Something running and lock matches the target `tenant/project` → stop and
+   clear the lock.
+3. Something running but lock points to a **different** deployment → abort.
+
+**`kdcube --info` and stale locks** — global `--info` verifies the lock via
+`docker compose ps`. If the recorded deployment is no longer running, the lock is
+reported as stale and cleared automatically.
+
+### Use a local checkout (dev)
+
+```bash
+kdcube --path /Users/you/src/kdcube/kdcube-ai-app
+```
+
+When `--path` is provided, the wizard **uses that repo for templates and local builds**
+and **does not show the Install source menu**.
+
+For the descriptor `init` path, use `--path` when you need to test uncommitted
+platform changes:
+
+```bash
+kdcube init \
+  --descriptors-location /path/to/descriptors \
+  --workdir ~/.kdcube/kdcube-runtime \
+  --path /Users/you/src/kdcube/kdcube-ai-app \
+  --build
+```
+
+This copies the dirty local checkout into the namespaced runtime workdir and
+builds from the staged copy. Do not combine this flow with `--upstream`,
+`--latest`, or `--release`, because those flags explicitly select a managed
+version instead of the dirty local source.
+
+Re-run prompts (edit existing values):
+
+```bash
+kdcube --reset
+```
+
+Clean local Docker images/cache:
+
+```bash
+kdcube --clean
+```
+
+Stop the local stack:
+
+```bash
+kdcube stop --workdir ~/.kdcube/kdcube-runtime
+```
+
+Stop and remove volumes:
+
+```bash
+kdcube stop --workdir ~/.kdcube/kdcube-runtime --remove-volumes
+```
+
+Inspect global CLI state (defaults + running deployment):
+
+```bash
+kdcube --info
+```
+
+Inspect the resolved runtime, including how local non-git bundles are mounted:
+
+```bash
+kdcube --info --workdir ~/.kdcube/kdcube-runtime/acme__prod_demo
+```
+
+When `--workdir` points at the base workspace root, `kdcube stop` resolves the
+single matching runtime namespace automatically. If there are multiple runtime
+namespaces under that base workspace, pass the concrete namespaced runtime path
+explicitly.
+
+Tip: if `kdcube` is not on your PATH, run `python -m pipx ensurepath`
+or re-open your shell after installation.
+
+## What the wizard does (today)
+
+When you run `kdcube`, the **wizard** performs the steps below:
+1) Creates a **workdir** with `config/`, `data/`, and `logs/` folders.
+2) Writes compose env files into `config/` (only if missing; it won’t overwrite existing files).
+3) Copies nginx configs into `config/` for runtime overrides:
+   - `nginx_ui.conf`
+   - runtime proxy config (based on selected auth mode)
+4) Selects **auth mode** (simple, cognito, or delegated) and writes:
+   - `AUTH_PROVIDER` in `.env.ingress` + `.env.proc`
+   - Cognito fields when applicable (see below)
+5) Generates frontend runtime config based on auth mode or descriptor template.
+6) Creates local data folders for Postgres/Redis/exec workspace/bundle storage.
+7) Optionally builds images and starts `docker compose up -d`.
+
+### Authentication modes
+The wizard prompts for an auth mode and updates both backend and frontend config.
+
+**Simple (hardcoded)**
+- `AUTH_PROVIDER=simple`
+- Frontend config: `frontend.config.hardcoded.json`
+- Uses a hardcoded admin token in config (local dev only)
+
+**Cognito**
+- `AUTH_PROVIDER=cognito`
+- Frontend config: `frontend.config.cognito.json`
+- Required fields:
+  - `COGNITO_REGION`
+  - `COGNITO_USER_POOL_ID`
+  - `COGNITO_APP_CLIENT_ID`
+  - `COGNITO_SERVICE_CLIENT_ID`
+- The frontend `authority` is composed as:
+  - `https://cognito-idp.<COGNITO_REGION>.amazonaws.com/<COGNITO_USER_POOL_ID>`
+
+**Delegated**
+- `AUTH_PROVIDER=cognito`
+- Frontend config: `frontend.config.delegated.json`
+- Uses the delegated proxy template (proxylogin) while still validating tokens via Cognito.
+- If `assembly.yaml` provides `company`, the generated delegated config uses it for:
+  - `auth.totpAppName`
+  - `auth.totpIssuer`
+
+### Routes prefix & nginx proxy
+The frontend config includes `routesPrefix` (default: `/chatbot`).
+The wizard patches the **runtime proxy config** in `config/` so nginx uses the
+same prefix. This keeps `/chatbot` (or any custom prefix) consistent between UI and proxy.
+
+If `proxy.ssl: true` and `assembly.domain` is set, the wizard also patches the
+runtime nginx SSL config so `YOUR_DOMAIN_NAME` becomes the configured domain in:
+- `server_name`
+- `/etc/letsencrypt/live/<domain>/fullchain.pem`
+- `/etc/letsencrypt/live/<domain>/privkey.pem`
+
+### Secrets (third services tokens)
+The wizard **does not** write OpenAI/Anthropic/Git token values to `.env` files.
+If you provide them during setup, they are injected at runtime into the
+`kdcube-secrets` sidecar (in‑memory only) when `assembly.yaml` uses
+`secrets.provider: secrets-service`. If you restart the stack, you’ll be
+prompted again to re‑inject them.
+
+Order (automatic):
+1) Start `kdcube-secrets`
+2) Wait for it to be ready
+3) Inject keys
+4) Start/restart ingress + proc (they fetch secrets)
+
+Manual re‑inject:
+
+```bash
+kdcube --secrets-prompt --workdir ~/.kdcube/kdcube-runtime
+```
+
+Or pass explicit values:
+
+```bash
+kdcube --secrets-set OPENAI_API_KEY=... --secrets-set ANTHROPIC_API_KEY=...
+```
+
+You can also override the git HTTPS token this way:
+
+```bash
+kdcube --secrets-set GIT_HTTP_TOKEN=...
+```
+
+Note: re‑inject will **restart** `kdcube-secrets`, `chat-ingress`, and `chat-proc`
+to refresh per‑run tokens (and the web proxy to keep upstreams in sync).
+Per‑run tokens are generated by the CLI and are **not stored** in `config/`.
+
+If you set LLM keys in env files (managed infra / custom setups), those env
+values still work and take precedence. The secrets sidecar is only used when
+env keys are missing.
+
+### First-run defaults
+Plain `kdcube` now seeds the full canonical descriptor set into `workdir/config/`
+from the tracked reference descriptors:
+
+- `assembly.yaml`
+- `secrets.yaml`
+- `bundles.yaml`
+- `bundles.secrets.yaml`
+- `gateway.yaml`
+
+That first local bootstrap is descriptor-first and local-first:
+
+- `storage.workspace.type=local`
+- `storage.claude_code_session.type=local`
+- `storage.kdcube=/kdcube-storage`
+- `storage.bundles=/bundle-storage`
+- `bundles.default_bundle_id=versatile@2026-03-31-13-36`
+
+When a seed descriptor sets `storage.kdcube` or `storage.bundles` to a host
+`file://...` path, `init` treats that as a host-side storage root. The staged
+runtime descriptor is rewritten to the container paths `file:///kdcube-storage`
+and `file:///bundle-storage`, and compose mounts the selected host roots there.
+This keeps descriptors portable while still allowing local host storage during
+CLI testing.
+
+On a fresh default run, the installer asks only for:
+
+- `Host bundles root (local path bundles)`
+- `OpenAI API key` (optional)
+- `Anthropic API key` (optional)
+- `Git HTTPS token` (optional)
+
+It does not ask for OpenRouter. It does not ask for Brave. It auto-seeds local
+defaults for Postgres, Redis, auth mode, UI port, managed bundle cache paths,
+bundle storage, and exec workspace.
+
+### Git HTTPS token (private bundles)
+If you choose or provide a Git HTTPS token for private bundles, the token is
+treated as a secret and is **not stored** in `.env.proc`. It is injected at
+runtime (same flow as LLM keys). You will be prompted again on the next run
+unless you pass it via `--secrets-set GIT_HTTP_TOKEN=...`.
+
+More details:
+https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/ops/local/local-setup-README.md
+
+Current scope: the wizard is **optimized for docker‑compose** (all‑in‑one).
+It creates a workdir (default: `~/.kdcube/kdcube-runtime`) and lets you:
+- generate config/data/log folders
+- choose where **all artifacts** come from (templates + images)
+- start `docker compose` (optional)
+
+Install source menu (shown only when `--path` is **not** provided):
+- **upstream**: clone/pull the repo into the workspace; use `init --build` to prebuild images before start
+- **release-latest**: pull prebuilt images for the latest release
+- **release-tag**: pull prebuilt images for a specific version (platform.ref)
+- **local**: use a local repo path you provide (build locally)
+- **workspace**: use the repo already cloned in the workspace (build locally)
+
+Defaults:
+- If the workspace repo exists → default is **workspace**
+- If it does not exist → default is **upstream**
+
+The **workspace** option only appears when a repo is already cloned there.
+
+Only **release-latest** and **release-tag** pull images. All other choices build locally.
+
+Tip: you can select the install source using the ↑/↓ arrow keys and Enter.
+
+Example workdir layout:
+
+```
+~/.kdcube/kdcube-runtime
+├─ config/
+│  ├─ .env
+│  ├─ .env.ingress
+│  ├─ .env.proc
+│  ├─ .env.metrics
+│  ├─ .env.postgres.setup
+│  ├─ .env.proxylogin
+│  ├─ frontend.config.<mode>.json
+│  ├─ nginx_ui.conf
+│  └─ nginx_proxy*.conf
+├─ data/
+│  ├─ postgres/
+│  ├─ redis/
+│  ├─ kdcube-storage/
+│  │  ├─ cb/
+│  │  │  └─ tenants/<tenant>/projects/<project>/
+│  │  │     ├─ conversation/<user>/<conversation>/<turn>/
+│  │  │     └─ executions/<user>/<conversation>/<turn>/<exec_id>/
+│  │  ├─ accounting/<tenant>/project/<YYYY.MM.DD>/<service>/<bundle_id>/
+│  │  └─ analytics/<tenant>/project/accounting/{daily,weekly,monthly}/
+│  ├─ exec-workspace/
+│  └─ bundle-storage/
+└─ logs/
+   ├─ chat-ingress/
+   └─ chat-proc/
+```
+
+## Advanced usage
+
+### Assembly descriptor (platform / frontend / infra)
+You can point the CLI to an **assembly descriptor YAML** (`assembly.yaml`) that defines
+platform metadata, frontend settings, auth, infra, and proxy defaults.
+
+The wizard prompts for this as **Assembly descriptor path**.
+**Wizard flow (descriptor usage):**
+1) Provide the `assembly.yaml` path (defaults to `workdir/config/assembly.yaml`).
+   If you provide another path, the CLI copies it into `workdir/config/assembly.yaml`
+   and uses the copied file as the source of truth.
+2) Choose whether to apply the **Frontend** section (build or image).
+
+Repo field contract:
+- `platform.repo` and `frontend.build.repo` should use a cloneable repo spec:
+  - `git@github.com:org/repo.git`
+  - `https://github.com/org/repo.git`
+  - `org/repo`
+- older single-name values such as `kdcube-ai-app` are still accepted for
+  backward compatibility, but new descriptors should use one of the cloneable
+  forms above
+
+When an assembly descriptor is provided, the wizard **writes non‑secret values back**
+into `assembly.yaml` (tenant/project, auth, infra, paths) and then renders `.env*`
+from it. This makes `assembly.yaml` the source of truth for install‑time config.
+
+The same assembly descriptor also configures runtime workspace/session bootstrap policy:
+
+- `storage.workspace.type` -> `REACT_WORKSPACE_IMPLEMENTATION`
+- `storage.workspace.repo` -> `REACT_WORKSPACE_GIT_REPO`
+- `storage.claude_code_session.type` -> `CLAUDE_CODE_SESSION_STORE_IMPLEMENTATION`
+- `storage.claude_code_session.repo` -> `CLAUDE_CODE_SESSION_GIT_REPO`
+
+### Descriptor fast path requirements
+
+The descriptor-folder fast path is used only when the descriptor set is complete
+enough for a non-interactive install. At minimum:
+
+- `assembly.yaml`, `secrets.yaml`, and `gateway.yaml` exist
+- `assembly.secrets.provider == "secrets-file"`
+- `assembly.context.tenant` and `assembly.context.project` are set
+- `assembly.paths.host_bundles_path` is set
+- `assembly.platform.ref` is set unless `--latest`, `--upstream`, or `--release` is used
+- `assembly.domain` is set when `proxy.ssl: true`
+- any git-backed workspace/session config includes its repo URL
+- Cognito auth fields are present when `auth.type` requires them
+- frontend build fields are present when `frontend` is used without `frontend.image`
+
+If any of those are missing, the CLI falls back to the normal guided flow.
+
+Reusing an initialized runtime without `--descriptors-location` requires the
+same canonical descriptor set to already exist under `workdir/config`, plus
+`workdir/config/install-meta.json` so the CLI can recover the repo context.
+
+Template:
+- [`app/ai-app/deployment/assembly.yaml`](../../../deployment/assembly.yaml) (copied into the workdir if no path is provided)
+
+References:
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/descriptors-README.md
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/assembly-descriptor-README.md
+
+### Bundles descriptor (optional)
+You can provide a **bundles descriptor** (`bundles.yaml`) and an optional
+**bundles secrets** file (`bundles.secrets.yaml`). This is the preferred way
+to define bundles and their non‑secret config, with secrets kept separate.
+
+If `workdir/config/bundles.yaml` already exists, the wizard pre-fills the prompt
+with that path so it is reused on subsequent runs.
+
+Note: secrets descriptors are **not** prefilled or cached.
+
+The CLI stages `bundles.yaml` into the workdir and, when enabled:
+- mounts the runtime workspace `config/` directory at `/config`
+- sets `BUNDLES_PRELOAD_ON_START=1` in `.env.proc` by default
+- enables bundle git resolution and env sync on startup
+
+Current proc behavior:
+
+- `config/bundles.yaml` is the normal bundle descriptor authority
+- proc can seed/reset from that descriptor directly
+
+Local bundle root contract:
+
+- `assembly.paths.host_bundles_path` is installer-facing config for non-managed local path bundles and becomes `HOST_BUNDLES_PATH`
+- compose mounts `HOST_BUNDLES_PATH` into proc as `BUNDLES_ROOT` (normally `/bundles`)
+- non-managed local bundle entries in `bundles.yaml` must use the container-visible path, for example:
+  - host folder: `/Users/you/dev/bundles/my.bundle`
+  - descriptor path: `/bundles/my.bundle`
+
+- `assembly.paths.host_managed_bundles_path` becomes `HOST_MANAGED_BUNDLES_PATH`
+- compose mounts `HOST_MANAGED_BUNDLES_PATH` into proc as `MANAGED_BUNDLES_ROOT` (normally `/managed-bundles`)
+
+Managed bundle materialization uses the dedicated managed root:
+
+- non-managed local path bundles continue to use `HOST_BUNDLES_PATH` and `/bundles/...`
+- git bundles are cloned under `HOST_MANAGED_BUNDLES_PATH` and resolved inside proc as `/managed-bundles/...`
+- built-in example bundles are also materialized under the managed root
+
+Symlink note:
+
+- if you symlink a bundle into `HOST_BUNDLES_PATH`, proc sees the symlink through the `/bundles` mount
+- this works only if Docker can also access the symlink target on the host
+- safest local pattern: keep the real bundle folder inside `HOST_BUNDLES_PATH`, or symlink only to another host path that is already accessible through the same Docker file-sharing scope
+
+`bundles.secrets.yaml` is staged into the workdir only when it is provided.
+If `assembly.yaml -> secrets.provider == "secrets-file"`, runtime resolves it
+from `/config/bundles.secrets.yaml` via `PLATFORM_DESCRIPTORS_DIR=/config`.
+
+Example (`bundles.yaml`):
+```yaml
+bundles:
+  version: "1"
+  default_bundle_id: "react@2026-02-10-02-44"
+  items:
+    - id: "react@2026-02-10-02-44"
+      name: "ReAct (example)"
+      repo: "git@github.com:kdcube/kdcube-ai-app.git"
+      ref: "v0.3.2"
+      subdir: "app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles"
+      module: "react@2026-02-10-02-44.entrypoint"
+      config:
+        embedding:
+          provider: "openai"
+          model: "text-embedding-3-small"
+        role_models:
+          solver.react.v2.decision.v2.strong:
+            provider: "anthropic"
+            model: "claude-sonnet-4-6"
+```
+
+Example (`bundles.secrets.yaml`):
+```yaml
+bundles:
+  version: "1"
+  items:
+    - id: "react@2026-02-10-02-44"
+      secrets:
+        openai:
+          api_key: null
+```
+
+Templates:
+- [`app/ai-app/deployment/bundles.yaml`](../../../deployment/bundles.yaml)
+- [`app/ai-app/deployment/bundles.secrets.yaml`](../../../deployment/bundles.secrets.yaml)
+
+For local host-edited bundle development:
+
+- define the bundle with `path: /bundles/...`
+- set `assembly.paths.host_bundles_path` to the matching host root
+- run KDCube through the CLI compose path
+- use `kdcube reload <bundle_id>` after code changes
+
+For AWS deployment:
+
+- use git bundle descriptors only
+- do not use local `path:` bundle entries
+- do not carry local `assembly.paths.host_bundles_path` values into the AWS descriptor set
+
+References:
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/bundles-descriptor-README.md
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/bundles-secrets-descriptor-README.md
+
+### Secrets descriptor (optional)
+You can provide a `secrets.yaml` path in the wizard (or via `KDCUBE_SECRETS_DESCRIPTOR_PATH`).
+The CLI stages this file into the runtime workspace `config/` directory.
+
+It is used:
+- to prefill runtime secrets (OpenAI/Anthropic/Git HTTP token and delegated Cognito client secret) during guided setup
+- or as the runtime secrets source when `assembly.yaml -> secrets.provider == "secrets-file"`
+
+In `secrets-file` mode runtime resolves `/config/secrets.yaml` via
+`PLATFORM_DESCRIPTORS_DIR=/config`.
+
+Values injected through the `secrets-service` flow are still **not** written to `.env.proc`.
+
+Secrets are keyed by **dot‑path** (e.g. `services.openai.api_key`).
+
+Template:
+- [`app/ai-app/deployment/secrets.yaml`](../../../deployment/secrets.yaml)
+
+Reference:
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/secrets-descriptor-README.md
+
+### Gateway config descriptor (optional)
+You can provide a `gateway.yaml` path in the wizard (or via `KDCUBE_GATEWAY_DESCRIPTOR_PATH`).
+The CLI stages it into `workdir/config` and points runtime at `/config` via
+`PLATFORM_DESCRIPTORS_DIR`.
+
+In current descriptor mode, gateway policy authority is therefore the staged
+workspace descriptor, not a copied field-by-field block in the service env
+files.
+
+If another platform also injects `GATEWAY_CONFIG_JSON`, that JSON still wins at
+runtime because gateway loader precedence prefers it over `gateway.yaml`.
+
+If `workdir/config/gateway.yaml` already exists, the wizard pre-fills the prompt
+with that path so it is reused on subsequent runs.
+
+Template:
+- [`app/ai-app/deployment/gateway.yaml`](../../../deployment/gateway.yaml)
+
+Reference:
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/gateway-descriptor-README.md
+
+### Custom UI via assembly descriptor (build or image)
+If your `assembly.yaml` includes a `frontend` section, the CLI will switch to
+**custom‑ui‑managed‑infra** compose mode.
+
+Minimal example:
+```yaml
+frontend:
+  build:
+    repo: "git@github.com:org/private-app.git"
+    ref: "ui-v2026.02.22"
+    dockerfile: "ops/docker/Dockerfile_UI"
+    src: "ui/chat-web-app"
+  image: "registry/private-app-ui:2026.02.22"  # optional prebuilt UI image; if set, CLI writes KDCUBE_UI_IMAGE and skips the local web-ui build
+  frontend_config: "ops/docker/config.delegated.json"  # optional
+  nginx_ui_config: "ops/docker/nginx_ui.conf"          # optional
+```
+
+Frontend/runtime config behavior:
+- `frontend.image` is optional. When present, the CLI writes `KDCUBE_UI_IMAGE` and treats the UI as a prebuilt image override.
+- If `frontend.image` is omitted but `frontend.build` is present, the CLI clones/uses the frontend source repo and builds `web-ui` locally from `build.repo`, `build.ref`, `build.dockerfile`, and `build.src`.
+- `frontend.build.repo` accepts SSH URLs, HTTPS URLs, and `owner/repo` shorthand.
+- `frontend.build.image_name` is not used by the CLI installer. That field belongs to the ECS CI/CD flow, not the local docker-compose flow.
+
+- If `frontend.frontend_config` is provided, the CLI uses it as the template for the
+  generated runtime `config.json` and patches tenant/project/auth/routesPrefix values.
+- If it is omitted, the CLI falls back to a built-in template by auth mode:
+  - `simple` -> `config.hardcoded.json`
+  - `cognito` -> `config.cognito.json`
+  - `delegated` -> `config.delegated.json`
+- If `frontend.nginx_ui_config` is omitted, the CLI falls back to the built-in `nginx_ui.conf`.
+
+How to activate:
+1) Run `kdcube`
+2) Choose **Use an assembly descriptor** → provide `assembly.yaml`
+3) Confirm **Frontend** usage when prompted.
+4) The CLI selects `deployment/docker/custom-ui-managed-infra/docker-compose.yaml`.
+
+Full details:
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/descriptors-README.md
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/assembly-descriptor-README.md
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/custom-cicd-README.md
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/cli-README.md
+
+## Where data is stored
+- **Config:** `workdir/config/` (env files, nginx config, UI config)
+- **Data:** `workdir/data/` (postgres/redis storage, bundle storage, exec workspace)
+- **Logs:** `workdir/logs/`
+
+Infra credentials (Postgres/Redis) are stored in `config/.env*` for local compose.
+LLM keys are **not** stored in files; they live only in the secrets sidecar.
+
+## Notes
+
+- The wizard **does not overwrite** existing config files in your workdir. It only fills
+  placeholders in newly created files.
+- Use `kdcube --reset` to re-enter values without deleting files.
+- Config upgrades/migrations will be added later when configs are versioned.
+- The wizard auto‑saves after major sections, so if you exit early (Ctrl+C) most
+  values entered so far are preserved in `config/` and will appear as defaults next run.
+
+Tip: you can edit `workdir/config/nginx_ui.conf` and the selected `workdir/config/nginx_proxy*.conf`
+without rebuilding images (they are mounted into the containers at runtime).
+
+## UI config source of truth
+
+The web UI loads its runtime config from `/config.json` inside the `web-ui`
+container. Docker compose mounts the host file defined by
+`PATH_TO_FRONTEND_CONFIG_JSON` to:
+
+`/usr/share/nginx/html/config.json`
+
+## Clean / reset
+Clean local Docker cache and unused KDCube images:
+```bash
+kdcube --clean
+```
+
+Reset prompts without deleting files:
+```bash
+kdcube --reset
+```
+
+Full reset (delete workdir):
+```bash
+rm -rf ~/.kdcube/kdcube-runtime
+```
+
+If the UI is calling the wrong tenant/project, check:
+- `PATH_TO_FRONTEND_CONFIG_JSON` in the generated `.env`
+- `curl http://localhost:<ui_port>/config.json`
+
+See the full local setup flow on GitHub:
+https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/ops/local/local-setup-README.md
+
+More documentation:
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/service/cicd/descriptors-README.md
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/assembly-descriptor-README.md
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/bundles-descriptor-README.md
+- https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/service-runtime-configuration-mapping-README.md
+
+## License
+MIT License. See `app/ai-app/src/kdcube-ai-app/LICENSE`.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/additional_README.md
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/additional_README.md
@@ -716,7 +716,7 @@ enough for a non-interactive install. At minimum:
 - `assembly.domain` is set when `proxy.ssl: true`
 - any git-backed workspace/session config includes its repo URL
 - Cognito auth fields are present when `auth.type` requires them
-- frontend build fields are present when `frontend` is used without `frontend.image`
+- frontend build fields are present when `frontend.build` is set without `frontend.image`
 
 If any of those are missing, the CLI falls back to the normal guided flow.
 
@@ -875,8 +875,11 @@ Reference:
 - https://github.com/kdcube/kdcube-ai-app/blob/main/app/ai-app/docs/configuration/gateway-descriptor-README.md
 
 ### Custom UI via assembly descriptor (build or image)
-If your `assembly.yaml` includes a `frontend` section, the CLI will switch to
+If your `assembly.yaml` includes `frontend.build` or `frontend.image`, the CLI will switch to
 **custom‑ui‑managed‑infra** compose mode.
+
+`frontend.config` alone (auth type, routes prefix, debug flags) is runtime metadata used in
+both modes — it does **not** trigger `custom‑ui‑managed‑infra`.
 
 Minimal example:
 ```yaml

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -1772,9 +1772,59 @@ def main() -> None:
     _sp.add_argument("--workdir", default=None, help="Namespaced runtime workdir")
     _sp.add_argument("--path", default=str(DEFAULT_DIR), help="Platform repo path")
 
-    _sp = subparsers.add_parser("bundle", help="Patch config or secrets for a staged bundle")
+    _sp = subparsers.add_parser("bundle", help="Create, update, or delete a staged bundle entry")
     _sp.add_argument("bundle_id", help="Bundle ID to patch")
     _sp.add_argument("--workdir", default=None, help="Namespaced runtime workdir")
+    # Source mode (mutually exclusive)
+    _src_grp = _sp.add_mutually_exclusive_group()
+    _src_grp.add_argument(
+        "--local-path",
+        metavar="PATH",
+        default=None,
+        dest="local_path",
+        help="Set bundle source to a local/container-visible path (clears git fields)",
+    )
+    _src_grp.add_argument(
+        "--git-repo",
+        metavar="REPO",
+        default=None,
+        dest="git_repo",
+        help="Set bundle source to a git repo URL (clears path field)",
+    )
+    _sp.add_argument(
+        "--git-ref",
+        metavar="REF",
+        default=None,
+        dest="git_ref",
+        help="Git ref/tag (required with --git-repo)",
+    )
+    _sp.add_argument(
+        "--git-subdir",
+        metavar="SUBDIR",
+        default=None,
+        dest="git_subdir",
+        help="Subdirectory within the git repo that contains the bundle",
+    )
+    # Identity fields
+    _sp.add_argument("--name", default=None, help="Display name for the bundle")
+    _sp.add_argument("--module", default=None, help="Python module name (default: entrypoint)")
+    _sg = _sp.add_mutually_exclusive_group()
+    _sg.add_argument(
+        "--singleton",
+        dest="singleton",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Mark bundle as singleton",
+    )
+    _sg.add_argument(
+        "--no-singleton",
+        dest="singleton",
+        action="store_const",
+        const=False,
+        help="Mark bundle as non-singleton",
+    )
+    # Config / secrets patch ops
     _sp.add_argument(
         "--set-config",
         nargs=2,
@@ -1808,6 +1858,12 @@ def main() -> None:
         default=[],
         dest="del_secret",
         help="Delete a secret key by dotted path",
+    )
+    _sp.add_argument(
+        "--delete",
+        action="store_true",
+        default=False,
+        help="Remove this bundle entry from bundles.yaml (and its secrets entry if present)",
     )
 
     _sp = subparsers.add_parser("export", help="Export live bundle descriptors")
@@ -1951,18 +2007,68 @@ def main() -> None:
                 )
 
             _bundle_id = str(args.bundle_id).strip()
+            _local_path: str | None = args.local_path
+            _git_repo: str | None = args.git_repo
+            _git_ref: str | None = args.git_ref
+            _git_subdir: str | None = args.git_subdir
+            _b_name: str | None = args.name
+            _b_module: str | None = args.module
+            _b_singleton: bool | None = args.singleton
             _set_config_ops: list[list[str]] = args.set_config or []
             _set_secret_ops: list[list[str]] = args.set_secret or []
             _del_config_ops: list[str] = args.del_config or []
             _del_secret_ops: list[str] = args.del_secret or []
+            _delete: bool = args.delete
 
-            if not any([_set_config_ops, _set_secret_ops, _del_config_ops, _del_secret_ops]):
+            _has_source_op = _local_path is not None or _git_repo is not None
+            _has_identity_op = _b_name is not None or _b_module is not None or _b_singleton is not None
+            _has_config_op = bool(_set_config_ops or _del_config_ops)
+            _has_secret_op = bool(_set_secret_ops or _del_secret_ops)
+
+            if _git_subdir is not None and _git_repo is None:
+                raise SystemExit("--git-subdir can only be used together with --git-repo.")
+
+            if _delete and any([_has_source_op, _has_identity_op, _has_config_op, _has_secret_op]):
+                raise SystemExit("--delete cannot be combined with other flags.")
+
+            if not any([_delete, _has_source_op, _has_identity_op, _has_config_op, _has_secret_op]):
                 raise SystemExit(
-                    "No operations specified. "
-                    "Use --set-config, --set-secret, --del-config, or --del-secret."
+                    "No operations specified. Use --local-path, --git-repo, --name, --module, "
+                    "--singleton/--no-singleton, --set-config, --set-secret, --del-config, --del-secret, or --delete."
                 )
 
-            if _set_config_ops or _del_config_ops:
+            if _git_repo is not None and not _git_ref:
+                raise SystemExit("--git-ref is required when --git-repo is specified.")
+
+            if _delete:
+                _bundles_data = installer_mod.load_release_descriptor(_bundles_path)
+                _b_block = _bundles_data.get("bundles") if isinstance(_bundles_data, dict) else None
+                _b_items = _b_block.get("items", []) if isinstance(_b_block, dict) else []
+                _b_idx = next(
+                    (i for i, it in enumerate(_b_items) if isinstance(it, dict) and str(it.get("id", "")) == _bundle_id),
+                    None,
+                )
+                if _b_idx is None:
+                    raise SystemExit(f"Bundle '{_bundle_id}' not found in {_bundles_path}")
+                del _b_items[_b_idx]
+                installer_mod.save_release_descriptor(_bundles_path, _bundles_data)
+                console.print(f"[green]Removed from bundles.yaml:[/green] {_bundle_id!r}")
+                if _bundles_secrets_path.exists():
+                    _bs_data = installer_mod.load_release_descriptor(_bundles_secrets_path)
+                    _bs_block = _bs_data.get("bundles") if isinstance(_bs_data, dict) else None
+                    _bs_items = _bs_block.get("items", []) if isinstance(_bs_block, dict) else []
+                    _bs_idx = next(
+                        (i for i, it in enumerate(_bs_items) if isinstance(it, dict) and str(it.get("id", "")) == _bundle_id),
+                        None,
+                    )
+                    if _bs_idx is not None:
+                        del _bs_items[_bs_idx]
+                        installer_mod.save_release_descriptor(_bundles_secrets_path, _bs_data)
+                        console.print(f"[green]Removed from bundles.secrets.yaml:[/green] {_bundle_id!r}")
+                return
+
+            # --- bundles.yaml operations (source mode + identity + config) ---
+            if _has_source_op or _has_identity_op or _has_config_op:
                 _bundles_data = installer_mod.load_release_descriptor(_bundles_path)
                 _b_block = _bundles_data.get("bundles") if isinstance(_bundles_data, dict) else None
                 _b_items = _b_block.get("items", []) if isinstance(_b_block, dict) else []
@@ -1971,21 +2077,66 @@ def main() -> None:
                     None,
                 )
                 if _b_item is None:
-                    raise SystemExit(f"Bundle '{_bundle_id}' not found in {_bundles_path}")
-                _cfg = _b_item.setdefault("config", {})
-                if not isinstance(_cfg, dict):
-                    _cfg = {}
-                    _b_item["config"] = _cfg
-                for _key, _raw in _set_config_ops:
-                    _val = _parse_yaml_scalar(_raw)
-                    installer_mod._set_nested(_cfg, _key.split("."), _val)
-                    console.print(f"[dim]set config[/dim] {_key} = {_val!r}")
-                for _key in _del_config_ops:
-                    _parts = _key.split(".")
-                    if not _nested_key_exists(_cfg, _parts):
-                        raise SystemExit(f"Config key '{_key}' not found in bundle '{_bundle_id}'")
-                    installer_mod._delete_nested(_cfg, _parts)
-                    console.print(f"[dim]del config[/dim] {_key}")
+                    if not _has_source_op:
+                        raise SystemExit(
+                            f"Bundle '{_bundle_id}' not found in {_bundles_path}. "
+                            "Provide --local-path or --git-repo to create a new entry."
+                        )
+                    _b_item = {"id": _bundle_id}
+                    if isinstance(_b_block, dict):
+                        _b_block.setdefault("items", []).append(_b_item)
+                    console.print(f"[dim]creating new bundle entry[/dim] {_bundle_id!r}")
+
+                if _local_path is not None:
+                    _b_item["path"] = _local_path
+                    for _stale in ("repo", "ref", "subdir"):
+                        _b_item.pop(_stale, None)
+                    console.print(f"[dim]set source[/dim] local-path = {_local_path!r}")
+
+                if _git_repo is not None:
+                    _b_item["repo"] = _git_repo
+                    _b_item["ref"] = _git_ref
+                    if _git_subdir is not None:
+                        _b_item["subdir"] = _git_subdir
+                    else:
+                        _b_item.pop("subdir", None)
+                    _b_item.pop("path", None)
+                    console.print(f"[dim]set source[/dim] git-repo = {_git_repo!r} ref = {_git_ref!r}")
+                    if _git_subdir:
+                        console.print(f"[dim]set source[/dim] git-subdir = {_git_subdir!r}")
+
+                if _b_name is not None:
+                    _b_item["name"] = _b_name
+                    console.print(f"[dim]set name[/dim] {_b_name!r}")
+
+                if _b_module is not None:
+                    _b_item["module"] = _b_module
+                    console.print(f"[dim]set module[/dim] {_b_module!r}")
+                elif "module" not in _b_item:
+                    _b_item["module"] = "entrypoint"
+
+                if _b_singleton is not None:
+                    _b_item["singleton"] = _b_singleton
+                    console.print(f"[dim]set singleton[/dim] {_b_singleton!r}")
+                elif "singleton" not in _b_item:
+                    _b_item["singleton"] = False
+
+                if _has_config_op:
+                    _cfg = _b_item.setdefault("config", {})
+                    if not isinstance(_cfg, dict):
+                        _cfg = {}
+                        _b_item["config"] = _cfg
+                    for _key, _raw in _set_config_ops:
+                        _val = _parse_yaml_scalar(_raw)
+                        installer_mod._set_nested(_cfg, _key.split("."), _val)
+                        console.print(f"[dim]set config[/dim] {_key} = {_val!r}")
+                    for _key in _del_config_ops:
+                        _parts = _key.split(".")
+                        if not _nested_key_exists(_cfg, _parts):
+                            raise SystemExit(f"Config key '{_key}' not found in bundle '{_bundle_id}'")
+                        installer_mod._delete_nested(_cfg, _parts)
+                        console.print(f"[dim]del config[/dim] {_key}")
+
                 installer_mod.save_release_descriptor(_bundles_path, _bundles_data)
                 console.print(f"[green]Updated:[/green] {_bundles_path}")
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -1248,6 +1248,10 @@ def ensure_repo(console: Console, repo: str, target: Path) -> None:
         console.print(f"Repo already exists at {target}")
         return
 
+    if _is_platform_source_tree(target):
+        console.print(f"[dim]Using local platform source at:[/dim] {target}")
+        return
+
     normalized_repo = installer_mod.normalize_git_repo_source(repo)
     target.parent.mkdir(parents=True, exist_ok=True)
     console.print(f"Cloning {normalized_repo} to {target}")
@@ -1923,53 +1927,89 @@ def main() -> None:
             _init_repo = Path(os.path.expanduser(args.path)).resolve()
             _init_descriptors_location: Path | None = None
             _init_version_selector = bool(args.upstream or args.latest or str(args.release or "").strip())
+            if sum([bool(args.latest), bool(args.upstream), bool(str(args.release or "").strip())]) > 1:
+                raise SystemExit("Choose only one of --latest, --upstream, or --release.")
             _init_local_source_copy = _init_path_provided and not _init_version_selector
+            # Pre-declare; may be set early in the no-descriptors path below.
+            _init_preset_tenant: str | None = None
+            _init_preset_project: str | None = None
+            _init_resolved: Path | None = None
             if str(args.descriptors_location or "").strip():
                 _init_descriptors_location = Path(
                     os.path.expanduser(args.descriptors_location)
                 ).resolve()
-            elif args.latest or args.upstream or str(args.release or "").strip() or args.build:
+            else:
+                # No --descriptors-location: determine tenant/project, create the
+                # scoped workdir, then clone the platform repo into <workdir>/repo
+                # and use its deployment/ directory as the descriptor source.
+                # Applies to plain init, --latest, --upstream, --release, and --build.
+                if "__" in _init_workdir.name:
+                    # --workdir already encodes tenant__project; use it directly
+                    # and derive the namespace from the directory name.
+                    _init_resolved = _init_workdir.resolve()
+                    _ns = _init_workdir.name.split("__", 1)
+                    _init_preset_tenant = _ns[0]
+                    _init_preset_project = _ns[1]
+                elif args.interactive:
+                    _init_preset_tenant = installer_mod.ask(
+                        console,
+                        "Tenant ID",
+                        default=str(args.tenant or "").strip() or "default",
+                    )
+                    _init_preset_project = installer_mod.ask(
+                        console,
+                        "Project name",
+                        default=str(args.project or "").strip() or "default",
+                    )
+                    _init_resolved = installer_mod.workspace_runtime_dir(
+                        _init_workdir, _init_preset_tenant, _init_preset_project
+                    ).resolve()
+                else:
+                    _init_preset_tenant = str(args.tenant or "").strip() or "default"
+                    _init_preset_project = str(args.project or "").strip() or "default"
+                    _init_resolved = installer_mod.workspace_runtime_dir(
+                        _init_workdir, _init_preset_tenant, _init_preset_project
+                    ).resolve()
+                _init_resolved.mkdir(parents=True, exist_ok=True)
+                _repo_target = _init_repo if _init_path_provided else _init_resolved / DEFAULT_REPO_DIRNAME
                 _init_repo, _init_descriptors_location = _bootstrap_repo_for_defaults(
                     console,
-                    repo=args.path,
-                    repo_path=_init_repo,
+                    repo=args.repo,
+                    repo_path=_repo_target,
                     path_provided=_init_path_provided,
                 )
                 console.print(
                     f"[dim]No --descriptors-location provided. "
                     f"Using repo defaults from:[/dim] {_init_descriptors_location}"
                 )
-            else:
-                raise SystemExit(
-                    "kdcube init requires a descriptor source.\n"
-                    "Pass --descriptors-location <dir>, or use --latest/--upstream/--release/--build "
-                    "to bootstrap from the platform repo."
-                )
+                if not _init_version_selector:
+                    # No explicit version selector: default to latest release.
+                    args.latest = True
 
             # For --interactive: prompt tenant/project BEFORE resolving/creating the workdir
             # so the directory is created with the correct namespace from the start.
-            _init_preset_tenant: str | None = None
-            _init_preset_project: str | None = None
-            if args.interactive:
+            # Skipped when tenant/project were already collected in the no-descriptors path above.
+            if args.interactive and _init_preset_tenant is None:
                 _src_assembly = installer_mod.load_release_descriptor_soft(
                     _init_descriptors_location / "assembly.yaml"
                 ) or {}
                 _t_default, _p_default = installer_mod.descriptor_context_from_assembly(_src_assembly)
                 _init_preset_tenant = installer_mod.ask(
-                    console, "Tenant ID", default=_t_default or "demo-tenant"
+                    console, "Tenant ID", default=_t_default or "default"
                 )
                 _init_preset_project = installer_mod.ask(
-                    console, "Project name", default=_p_default or "demo-project"
+                    console, "Project name", default=_p_default or "default"
                 )
 
-            if _init_preset_tenant and _init_preset_project:
-                _init_resolved = installer_mod.workspace_runtime_dir(
-                    _init_workdir, _init_preset_tenant, _init_preset_project
-                ).resolve()
-            else:
-                _init_resolved = _resolve_cli_workdir(
-                    _init_workdir, descriptors_location=_init_descriptors_location
-                )
+            if _init_resolved is None:
+                if _init_preset_tenant and _init_preset_project:
+                    _init_resolved = installer_mod.workspace_runtime_dir(
+                        _init_workdir, _init_preset_tenant, _init_preset_project
+                    ).resolve()
+                else:
+                    _init_resolved = _resolve_cli_workdir(
+                        _init_workdir, descriptors_location=_init_descriptors_location
+                    )
 
             if str(args.descriptors_location or "").strip():
                 _init_repo = _resolve_cli_repo_path(
@@ -2025,6 +2065,12 @@ def main() -> None:
                     path_provided=_init_path_provided,
                     assembly=_init_assembly,
                     fallback_repo=args.repo,
+                )
+
+            if _init_version_selector and not _is_git_repo(_init_repo):
+                raise SystemExit(
+                    f"Cannot use --upstream/--latest/--release with a local source tree at {_init_repo} (no .git).\n"
+                    f"Remove {_init_repo} and re-run, or use --path to point to a git repo."
                 )
 
             _init_release_ref: str | None = None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -1057,6 +1057,26 @@ def _get_nested(data: dict | None, *keys: str):
     return cur
 
 
+def _parse_yaml_scalar(raw: str) -> object:
+    """Parse a CLI string value into a typed YAML scalar (bool, int, float, str, None)."""
+    try:
+        val = yaml.safe_load(raw)
+        if isinstance(val, (bool, int, float, str)) or val is None:
+            return val
+    except Exception:
+        pass
+    return raw
+
+
+def _nested_key_exists(dct: dict, keys: list) -> bool:
+    cur: object = dct
+    for key in keys:
+        if not isinstance(cur, dict) or key not in cur:
+            return False
+        cur = cur[key]
+    return True
+
+
 def _has_value(value: object | None) -> bool:
     if value is None:
         return False
@@ -1752,6 +1772,44 @@ def main() -> None:
     _sp.add_argument("--workdir", default=None, help="Namespaced runtime workdir")
     _sp.add_argument("--path", default=str(DEFAULT_DIR), help="Platform repo path")
 
+    _sp = subparsers.add_parser("bundle", help="Patch config or secrets for a staged bundle")
+    _sp.add_argument("bundle_id", help="Bundle ID to patch")
+    _sp.add_argument("--workdir", default=None, help="Namespaced runtime workdir")
+    _sp.add_argument(
+        "--set-config",
+        nargs=2,
+        metavar=("KEY", "VALUE"),
+        action="append",
+        default=[],
+        dest="set_config",
+        help="Set a config value by dotted key path",
+    )
+    _sp.add_argument(
+        "--set-secret",
+        nargs=2,
+        metavar=("KEY", "VALUE"),
+        action="append",
+        default=[],
+        dest="set_secret",
+        help="Set a secret value by dotted key path",
+    )
+    _sp.add_argument(
+        "--del-config",
+        metavar="KEY",
+        action="append",
+        default=[],
+        dest="del_config",
+        help="Delete a config key by dotted path",
+    )
+    _sp.add_argument(
+        "--del-secret",
+        metavar="KEY",
+        action="append",
+        default=[],
+        dest="del_secret",
+        help="Delete a secret key by dotted path",
+    )
+
     _sp = subparsers.add_parser("export", help="Export live bundle descriptors")
     _sp.add_argument("--workdir", default=None, help="Namespaced runtime workdir")
     _sp.add_argument("--path", default=str(DEFAULT_DIR), help="Platform repo path")
@@ -1878,6 +1936,97 @@ def main() -> None:
                 workdir=_resolve_cli_workdir(_workdir),
                 bundle_id=str(args.bundle_id).strip(),
             )
+            return
+        if args.command == "bundle":
+            _workdir = _resolve_subcommand_workdir(args.workdir, cli_defaults)
+            _resolved = _resolve_cli_workdir(_workdir)
+            _config_dir = _resolved / "config"
+            _bundles_path = _config_dir / "bundles.yaml"
+            _bundles_secrets_path = _config_dir / "bundles.secrets.yaml"
+
+            if not _bundles_path.exists():
+                raise SystemExit(
+                    f"bundles.yaml not found at {_bundles_path}.\n"
+                    "Initialize the workdir first."
+                )
+
+            _bundle_id = str(args.bundle_id).strip()
+            _set_config_ops: list[list[str]] = args.set_config or []
+            _set_secret_ops: list[list[str]] = args.set_secret or []
+            _del_config_ops: list[str] = args.del_config or []
+            _del_secret_ops: list[str] = args.del_secret or []
+
+            if not any([_set_config_ops, _set_secret_ops, _del_config_ops, _del_secret_ops]):
+                raise SystemExit(
+                    "No operations specified. "
+                    "Use --set-config, --set-secret, --del-config, or --del-secret."
+                )
+
+            if _set_config_ops or _del_config_ops:
+                _bundles_data = installer_mod.load_release_descriptor(_bundles_path)
+                _b_block = _bundles_data.get("bundles") if isinstance(_bundles_data, dict) else None
+                _b_items = _b_block.get("items", []) if isinstance(_b_block, dict) else []
+                _b_item = next(
+                    (it for it in _b_items if isinstance(it, dict) and str(it.get("id", "")) == _bundle_id),
+                    None,
+                )
+                if _b_item is None:
+                    raise SystemExit(f"Bundle '{_bundle_id}' not found in {_bundles_path}")
+                _cfg = _b_item.setdefault("config", {})
+                if not isinstance(_cfg, dict):
+                    _cfg = {}
+                    _b_item["config"] = _cfg
+                for _key, _raw in _set_config_ops:
+                    _val = _parse_yaml_scalar(_raw)
+                    installer_mod._set_nested(_cfg, _key.split("."), _val)
+                    console.print(f"[dim]set config[/dim] {_key} = {_val!r}")
+                for _key in _del_config_ops:
+                    _parts = _key.split(".")
+                    if not _nested_key_exists(_cfg, _parts):
+                        raise SystemExit(f"Config key '{_key}' not found in bundle '{_bundle_id}'")
+                    installer_mod._delete_nested(_cfg, _parts)
+                    console.print(f"[dim]del config[/dim] {_key}")
+                installer_mod.save_release_descriptor(_bundles_path, _bundles_data)
+                console.print(f"[green]Updated:[/green] {_bundles_path}")
+
+            if _set_secret_ops or _del_secret_ops:
+                _bs_data = (
+                    installer_mod.load_release_descriptor(_bundles_secrets_path)
+                    if _bundles_secrets_path.exists()
+                    else {"bundles": {"version": "1", "items": []}}
+                )
+                _bs_block = _bs_data.setdefault("bundles", {})
+                if not isinstance(_bs_block, dict):
+                    _bs_block = {}
+                    _bs_data["bundles"] = _bs_block
+                _bs_items = _bs_block.setdefault("items", [])
+                if not isinstance(_bs_items, list):
+                    _bs_items = []
+                    _bs_block["items"] = _bs_items
+                _bs_item = next(
+                    (it for it in _bs_items if isinstance(it, dict) and str(it.get("id", "")) == _bundle_id),
+                    None,
+                )
+                if _bs_item is None:
+                    _bs_item = {"id": _bundle_id, "secrets": {}}
+                    _bs_items.append(_bs_item)
+                _sec = _bs_item.setdefault("secrets", {})
+                if not isinstance(_sec, dict):
+                    _sec = {}
+                    _bs_item["secrets"] = _sec
+                for _key, _raw in _set_secret_ops:
+                    _val = _parse_yaml_scalar(_raw)
+                    installer_mod._set_nested(_sec, _key.split("."), _val)
+                    console.print(f"[dim]set secret[/dim] {_key}")
+                for _key in _del_secret_ops:
+                    _parts = _key.split(".")
+                    if not _nested_key_exists(_sec, _parts):
+                        raise SystemExit(f"Secret key '{_key}' not found in bundle '{_bundle_id}'")
+                    installer_mod._delete_nested(_sec, _parts)
+                    console.print(f"[dim]del secret[/dim] {_key}")
+                installer_mod.save_release_descriptor(_bundles_secrets_path, _bs_data)
+                console.print(f"[green]Updated:[/green] {_bundles_secrets_path}")
+
             return
         if args.command == "export":
             _workdir = _resolve_subcommand_workdir(args.workdir, cli_defaults)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -397,7 +397,7 @@ def _resolve_cli_workdir(
 
 
 def _is_git_repo(path: Path) -> bool:
-    return path.exists() and (path / ".git").is_dir()
+    return installer_mod.is_git_repo(path)
 
 
 def _is_platform_source_tree(path: Path) -> bool:
@@ -1264,7 +1264,7 @@ def _copy_dirty_local_source(console: Console, *, source_repo: Path, workdir: Pa
 
 
 def ensure_repo(console: Console, repo: str, target: Path) -> None:
-    if target.exists() and (target / ".git").is_dir():
+    if _is_git_repo(target):
         console.print(f"Repo already exists at {target}")
         return
 
@@ -2369,7 +2369,7 @@ def main() -> None:
 
             if _init_version_selector and not _is_git_repo(_init_repo):
                 raise SystemExit(
-                    f"Cannot use --upstream/--latest/--release with a local source tree at {_init_repo} (no .git).\n"
+                    f"Cannot use --upstream/--latest/--release with a local source tree at {_init_repo} (not a git repo root).\n"
                     f"Remove {_init_repo} and re-run, or use --path to point to a git repo."
                 )
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -599,7 +599,29 @@ def _has_nested(dct: Dict[str, object], *keys: str) -> bool:
 
 
 def is_git_repo(path: Path) -> bool:
-    return path.is_dir() and (path / ".git").is_dir()
+    """Return True when path is exactly a Git working tree root.
+
+    Git worktrees and submodules store .git as a pointer file, not a directory,
+    so filesystem checks on .git reject valid local checkouts. Ask Git for the
+    top-level worktree and require it to match the requested path so callers do
+    not accidentally accept arbitrary subdirectories inside a repo.
+    """
+    resolved = Path(path).expanduser().resolve()
+    if not resolved.is_dir():
+        return False
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(resolved), "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return False
+    top = (proc.stdout or "").strip()
+    if not top:
+        return False
+    return Path(top).expanduser().resolve() == resolved
 
 
 def normalize_git_repo_source(repo: str) -> str:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -116,7 +116,7 @@ def is_default_tenant_project(value: Optional[str]) -> bool:
     if value is None:
         return True
     stripped = value.strip().strip("'\"").lower()
-    return stripped in {"default", "demo-tenant", "demo-project"}
+    return stripped == "default"
 
 
 def safe_workspace_name(value: Optional[object], *, default: str) -> str:
@@ -2156,8 +2156,8 @@ def gather_configuration(
 
     descriptor_tenant = _get_nested(assembly_data, "context", "tenant")
     descriptor_project = _get_nested(assembly_data, "context", "project")
-    tenant_default = str(descriptor_tenant) if descriptor_tenant else existing_tenant or "demo-tenant"
-    project_default = str(descriptor_project) if descriptor_project else existing_project or "demo-project"
+    tenant_default = str(descriptor_tenant) if descriptor_tenant else existing_tenant or "default"
+    project_default = str(descriptor_project) if descriptor_project else existing_project or "default"
     preset_tenant = os.getenv("KDCUBE_PRESET_TENANT", "").strip()
     preset_project = os.getenv("KDCUBE_PRESET_PROJECT", "").strip()
     if preset_tenant and preset_project and not force_prompt:
@@ -2170,9 +2170,9 @@ def gather_configuration(
         tenant = ask(console, "Tenant ID", default=tenant_default)
         project = ask(console, "Project name", default=project_default)
     if is_placeholder(tenant):
-        tenant = "demo-tenant"
+        tenant = "default"
     if is_placeholder(project):
-        project = "demo-project"
+        project = "default"
     _set_nested(assembly_data, ["context", "tenant"], tenant)
     _set_nested(assembly_data, ["context", "project"], project)
     for env in (env_ingress, env_proc, env_metrics):

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -1121,6 +1121,7 @@ def ensure_local_dirs(data_dir: Path, logs_dir: Path) -> None:
     for path in [
         data_dir / "kdcube-storage",
         data_dir / "exec-workspace",
+        data_dir / "managed-bundles",
         data_dir / "bundle-storage",
         data_dir / "bundles",
         data_dir / "postgres",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -3781,7 +3781,11 @@ def run_setup(
         env_bundles_secrets = str(staged_descriptors["bundles_secrets_path"] or "")
         env_gateway_descriptor = str(staged_descriptors["gateway_path"] or "")
         use_descriptor_bundles = bool(_get_nested(staged_assembly, "bundles"))
-        use_descriptor_frontend = bool(_get_nested(staged_assembly, "frontend"))
+        _staged_fd = _get_nested(staged_assembly, "frontend")
+        use_descriptor_frontend = bool(
+            isinstance(_staged_fd, dict)
+            and (_get_nested(_staged_fd, "build", "repo") or _staged_fd.get("image"))
+        )
         use_descriptor_platform = False
         use_bundles_descriptor = bool(staged_descriptors["bundles_path"])
         use_bundles_secrets = bool(staged_descriptors["bundles_secrets_path"])
@@ -3934,12 +3938,24 @@ def run_setup(
             elif use_descriptor_frontend is False:
                 if not compose_mode_env:
                     compose_mode = "all-in-one"
-            elif isinstance(release_descriptor, dict) and release_descriptor.get("frontend"):
-                compose_mode = "custom-ui-managed-infra"
+            elif isinstance(release_descriptor, dict):
+                _fd = release_descriptor.get("frontend")
+                _has_ui_source = isinstance(_fd, dict) and bool(
+                    _get_nested(_fd, "build", "repo") or _fd.get("image")
+                )
+                if _has_ui_source:
+                    compose_mode = "custom-ui-managed-infra"
+                elif not compose_mode_env:
+                    compose_mode = "all-in-one"
             elif not compose_mode_env:
                 compose_mode = "all-in-one"
-            if isinstance(release_descriptor, dict) and not release_descriptor.get("frontend") and use_descriptor_frontend is not True:
-                compose_mode = "all-in-one"
+            if isinstance(release_descriptor, dict) and use_descriptor_frontend is not True:
+                _fd = release_descriptor.get("frontend")
+                _has_ui_source = isinstance(_fd, dict) and bool(
+                    _get_nested(_fd, "build", "repo") or _fd.get("image")
+                )
+                if not _has_ui_source:
+                    compose_mode = "all-in-one"
     if env_use_frontend is False and not compose_mode_env:
         compose_mode = "all-in-one"
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
@@ -38,6 +38,11 @@ from kdcube_cli.installer import (
 )
 
 
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+
+
 def test_descriptor_fast_path_accepts_complete_release_descriptor():
     assembly = {
         "context": {"tenant": "acme", "project": "platform"},
@@ -161,7 +166,7 @@ def test_resolve_cli_repo_path_prefers_install_meta_repo_root(tmp_path: Path):
     config_dir.mkdir(parents=True)
     (config_dir / ".env").write_text("")
     repo_dir = runtime_dir / "checked-out-repo"
-    (repo_dir / ".git").mkdir(parents=True)
+    _init_git_repo(repo_dir)
     (config_dir / "install-meta.json").write_text(
         json.dumps({"repo_root": str(repo_dir.resolve())})
     )
@@ -206,8 +211,7 @@ def test_subcommand_repo_uses_install_meta_after_base_workdir_resolves_to_runtim
 
 def test_copy_dirty_local_source_copies_tracked_and_untracked_nonignored_files(tmp_path: Path):
     source_repo = tmp_path / "source"
-    source_repo.mkdir()
-    subprocess.run(["git", "init"], cwd=source_repo, check=True, capture_output=True, text=True)
+    _init_git_repo(source_repo)
     (source_repo / ".gitignore").write_text("ignored.txt\nignored-dir/\n", encoding="utf-8")
     tracked = source_repo / "app" / "ai-app" / "deployment" / "assembly.yaml"
     tracked.parent.mkdir(parents=True)
@@ -228,6 +232,62 @@ def test_copy_dirty_local_source_copies_tracked_and_untracked_nonignored_files(t
     assert not (copied_repo / ".git").exists()
     assert not (copied_repo / "ignored.txt").exists()
     assert not (copied_repo / "ignored-dir" / "data.txt").exists()
+
+
+def test_copy_dirty_local_source_accepts_git_worktree_with_git_file(tmp_path: Path):
+    source_repo = tmp_path / "source"
+    _init_git_repo(source_repo)
+    tracked = source_repo / "app" / "ai-app" / "deployment" / "assembly.yaml"
+    tracked.parent.mkdir(parents=True)
+    tracked.write_text("context: {}\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", str(tracked.relative_to(source_repo))],
+        cwd=source_repo,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test User",
+            "commit",
+            "-m",
+            "init",
+        ],
+        cwd=source_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    linked_worktree = tmp_path / "linked-worktree"
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(linked_worktree), "HEAD"],
+        cwd=source_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert (linked_worktree / ".git").is_file()
+
+    untracked = linked_worktree / "app" / "ai-app" / "README.md"
+    untracked.write_text("local worktree change\n", encoding="utf-8")
+
+    copied_repo = _copy_dirty_local_source(
+        Console(file=None),
+        source_repo=linked_worktree,
+        workdir=tmp_path / "runtime",
+    )
+
+    assert (
+        copied_repo / "app" / "ai-app" / "deployment" / "assembly.yaml"
+    ).read_text(encoding="utf-8") == "context: {}\n"
+    assert (
+        copied_repo / "app" / "ai-app" / "README.md"
+    ).read_text(encoding="utf-8") == "local worktree change\n"
+    assert not (copied_repo / ".git").exists()
 
 
 def test_canonical_descriptor_dir_from_initialized_workdir_uses_runtime_config(tmp_path: Path):
@@ -2178,9 +2238,9 @@ def test_gather_configuration_default_bootstrap_prompts_only_minimal_inputs(monk
 # ---------------------------------------------------------------------------
 
 def _make_fake_repo_with_deployment(base: Path) -> Path:
-    """Create a minimal fake git repo that contains app/ai-app/deployment/assembly.yaml."""
+    """Create a minimal git repo that contains app/ai-app/deployment/assembly.yaml."""
     repo = base / "repo"
-    (repo / ".git").mkdir(parents=True)
+    _init_git_repo(repo)
     deployment = repo / "app" / "ai-app" / "deployment"
     deployment.mkdir(parents=True)
     (deployment / "assembly.yaml").write_text("context:\n  tenant: demo-tenant\n  project: demo-project\n")
@@ -2244,7 +2304,7 @@ def test_bootstrap_repo_for_defaults_clones_when_path_not_provided(monkeypatch, 
 
 def test_bootstrap_repo_for_defaults_raises_when_deployment_missing(tmp_path: Path):
     repo = tmp_path / "repo"
-    (repo / ".git").mkdir(parents=True)
+    _init_git_repo(repo)
     # No app/ai-app/deployment directory created
     console = Console(quiet=True)
 


### PR DESCRIPTION
  Summary                                                                                                                      
                                                                                                                               
  - kdcube bundle subcommand — new CLI command for patching staged bundle config and secrets by dotted key path (--set-config, 
  --set-secret, --del-config, --del-secret) without editing YAML files by hand. Values are coerced to typed YAML scalars; JSON 
  strings are preserved as-is. Delete operations error out if the key doesn't exist.                                           
  - Workdir scoping fixes — kdcube init now works without --descriptors-location, defaults to default__default namespace,      
  correctly handles namespaced --workdir paths, and enforces mutual exclusion of --latest/--upstream/--release.                
  - data/managed-bundles creation — ensure_local_dirs now creates this directory on the host so HOST_MANAGED_BUNDLES_PATH is   
  always present after init.                                                                                                   
  - CLI docs overhaul — cli-README.md gets a new section documenting kdcube bundle; how-to-configure-and-run-bundle-README.md
  updated accordingly. CLI package now ships a short README.md for PyPI with workdir scopes overview and command groups; full  
  reference moved to additional_README.md. Manual docker compose invocation examples removed from all CLI docs. 
  
  
   - Source mode — --local-path PATH switches a bundle to a local/container-visible path (clears git fields); --git-repo REPO   
  --git-ref REF [--git-subdir SUBDIR] switches to a git-backed source (proc clones to /managed-bundles/ on next reload, clears path field)                                                                                                                  
  - Identity fields — --name, --module, --singleton/--no-singleton set bundle metadata; defaults (module: entrypoint,
  singleton: false) are applied on first write                                                                                 
  - Upsert — when --local-path or --git-repo is provided and the bundle does not exist in bundles.yaml, a new entry is created instead of raising an error; all other operations (identity, config, secrets) still require an existing entry                
  - --delete — removes the bundle entry from bundles.yaml and its corresponding entry from bundles.secrets.yaml; mutually exclusive with all other flags
  