### PR TITLE
Bundle interface card with APIs, MCP, and cron display

### DIFF
--- a/app/ai-app/docs/sdk/bundle/build/how-to-configure-and-run-bundle-README.md
+++ b/app/ai-app/docs/sdk/bundle/build/how-to-configure-and-run-bundle-README.md
@@ -996,7 +996,7 @@ prepare this through `BaseWorkflow.build_react(...)`; isolated execution
 prepares it through `bootstrap_bind_all(...)`. Without that prep the helper
 raises a runtime error instead of creating an unscoped artifact.
 
-## Bundle Props, Secrets, And `enabled_config`
+## Bundle Props, Secrets, And Canonical `enabled.*`
 
 Deployment-scoped non-secret bundle config goes in `bundles.yaml`.
 
@@ -1011,9 +1011,9 @@ bundles:
       config:
         api:
           header_name: "X-My-Bundle-Token"
-        features:
-          admin_export:
-            enabled: false
+        enabled:
+          api:
+            "admin_export.POST": false
 ```
 
 Deployment-scoped secret bundle config goes in `bundles.secrets.yaml`.
@@ -1052,9 +1052,19 @@ kdcube bundle <bundle_id> --del-secret key.path \
 `kdcube bundle` only patches the staged files. It does not edit the original
 source descriptor directory. Run `kdcube reload` afterward to apply the change.
 
-`enabled_config` values belong in bundle props, not in secrets.
+Feature switches for bundle surfaces live under `enabled.*` in bundle props,
+not in secrets. The platform derives the canonical path from decorator
+metadata:
 
-Example bundle code:
+| Decorator | Canonical bundle-props path |
+| --- | --- |
+| `@agentic_workflow(...)` | `enabled.bundle` |
+| `@api(alias=A, method=M, ...)` | `enabled.api["A.M"]` (flat key, literal dot) |
+| `@mcp(alias=A, ...)` | `enabled.mcp.A` |
+| `@ui_widget(alias=A, ...)` | `enabled.widget.A` |
+| `@cron(alias=A, ...)` | `enabled.cron.A` |
+
+Example bundle code and props pair:
 
 ```python
 @api(
@@ -1062,15 +1072,21 @@ Example bundle code:
     route="operations",
     method="POST",
     user_types=("privileged",),
-    enabled_config="features.admin_export.enabled",
 )
 async def admin_export(self, **kwargs):
     return {"ok": True}
 ```
 
+```yaml
+config:
+  enabled:
+    api:
+      "admin_export.POST": false
+```
+
 Operational behavior:
 
-- missing path means enabled
+- missing key means enabled
 - `false`, `0`, `disable`, `disabled`, and `off` disable the surface
 
 After changing the prop, apply it with:

--- a/app/ai-app/docs/sdk/bundle/build/how-to-write-bundle-README.md
+++ b/app/ai-app/docs/sdk/bundle/build/how-to-write-bundle-README.md
@@ -199,8 +199,8 @@ When a bundle exists in a real environment, its lifecycle is:
 3. Decorators are discovered and the bundle interface manifest is built.
 4. The bundle becomes discoverable through integrations listing, subject to:
    - roles / user-types
-   - bundle-level `enabled_config`
-   - resource-level `enabled_config`
+   - bundle-level `enabled.bundle`
+   - resource-level `enabled.{api,mcp,widget,cron}.<alias>`
 5. The bundle is then entered through one of the runtime paths:
    - chat/on-message
    - operations/public API
@@ -958,14 +958,13 @@ async def sync(self, **kwargs):
 Reference:
 - [bundle-scheduled-jobs-README.md](../bundle-scheduled-jobs-README.md)
 
-### Platform-gated surface with `enabled_config`
+### Platform-gated surface via canonical `enabled.*`
 
 ```python
 @ui_widget(
     alias="task-board",
     icon={"tailwind": "heroicons-outline:check-badge"},
     user_types=("registered",),
-    enabled_config="features.task_board.widget_enabled",
 )
 def task_board(self, **kwargs):
     return ["<div id='root'></div>"]
@@ -976,13 +975,15 @@ bundles:
   items:
     - id: "task.board@1-0"
       config:
-        features:
-          task_board:
-            widget_enabled: true
+        enabled:
+          widget:
+            task-board: true
 ```
 
-Use this when the platform should hide or suppress the surface directly instead
-of the bundle method deciding at runtime.
+The platform derives the canonical bundle-props path from decorator metadata
+(see section 4.2 for the full mapping). Use this when the platform should hide
+or suppress the surface directly instead of the bundle method deciding at
+runtime.
 
 ### Bundle props and secrets
 
@@ -1018,38 +1019,67 @@ def render_report(payload: dict) -> dict:
 Reference:
 - [bundle-venv-README.md](../bundle-venv-README.md)
 
-## 4.2 Feature Gating With `enabled_config`
+## 4.2 Feature Gating With Canonical `enabled.*`
 
 This feature is important enough to treat as a first-class authoring tool.
 
-`enabled_config` is the platform-native feature flag for bundle surfaces.
+The platform-native feature flag for bundle surfaces lives under the
+`enabled.*` section of effective bundle props. The platform derives the
+lookup path from decorator metadata.
 
-You can attach it to:
+Canonical bundle-props shape:
 
-- `@agentic_workflow(...)`
-- `@api(...)`
-- `@mcp(...)`
-- `@ui_widget(...)`
-- `@cron(...)`
+```yaml
+enabled:
+  bundle: true|false
+  api:
+    "<api-alias>.<METHOD>": true|false   # flat key with literal dot
+  mcp:
+    <mcp-alias>: true|false
+  widget:
+    <widget-alias>: true|false
+  cron:
+    <cron-alias>: true|false
+```
 
-What it does:
+Mapping per decorator:
 
-- resolves a dot-path against effective bundle props
-- if the resolved value is disabled, the platform suppresses that surface
-- missing path means enabled
-- bundle-level disable overrides resource-level settings
+| Decorator | Canonical path |
+| --- | --- |
+| `@agentic_workflow(...)` | `enabled.bundle` |
+| `@api(alias=A, method=M, ...)` | `enabled.api["A.M"]` (flat key, literal dot) |
+| `@mcp(alias=A, ...)` | `enabled.mcp.A` |
+| `@ui_widget(alias=A, ...)` | `enabled.widget.A` |
+| `@cron(alias=A, ...)` | `enabled.cron.A` |
 
-Current disabled values:
+Aliases must not contain `.`; the validator rejects them at decoration time.
+For `@api` the flat key `<alias>.<METHOD>` is the only place a literal dot
+appears inside a section key. For `@mcp` / `@ui_widget` / `@cron` the alias is
+a normal nested map key.
+
+Resolution rules:
+
+- missing section, missing sub-section, or missing key → enabled
+- bundle-level `enabled.bundle = false` overrides every resource-level value
+- resource-level value is checked only when `enabled.bundle` is enabled
+
+Disabled values:
 
 - boolean `False`
 - integer `0`
-- strings `false`, `disable`, `disabled`, `off`, `0`
+- strings `false`, `disable`, `disabled`, `off`, `0` (case-insensitive)
+
+Effect on each surface:
+
+- API / MCP / widget: platform returns 404 when the surface is disabled
+- cron: scheduler skips reconciliation for the job
+- on_message / on_job: covered transitively by `enabled.bundle`
 
 Use it for:
 
 - staged rollout
 - environment-specific exposure
-- disabling one job/widget/API without deleting code
+- disabling one job/widget/API/MCP without deleting code
 - temporarily hiding unfinished surfaces
 
 Do not use it for:
@@ -1060,9 +1090,9 @@ Do not use it for:
 
 Authoring rule:
 
-- put the flag value in bundle props under `bundles.yaml -> config:`
-- keep the decorator path stable
-- let the platform do the 404/scheduler suppression instead of duplicating the check in method bodies
+- set switches in bundle props under `bundles.yaml -> config: enabled: ...`
+- let the platform do the 404 / scheduler suppression instead of duplicating
+  the check in method bodies
 
 ## 5. Entrypoint Rules
 

--- a/app/ai-app/docs/sdk/bundle/bundle-developer-guide-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-developer-guide-README.md
@@ -286,6 +286,28 @@ Practical rule:
 - keep the switches in bundle props under `bundles.yaml -> config: enabled: ...`
 - do not invent parallel ad hoc `if self.bundle_prop(...): return 404` checks unless the logic is more complex than simple exposure gating
 
+### Runtime overrides for decorator defaults
+
+Beyond the on/off `enabled.*` switches, decorator defaults for `user_types`,
+`roles`, `transport`, `cron_expression`, and `timezone` can additionally be
+overridden from bundle props by declaring a `*_config` dot-path on the
+decorator:
+
+| Decorator | Overridable field | Parameter |
+| --- | --- | --- |
+| `@api(...)`, `@ui_widget(...)` | `user_types` | `user_types_config="..."` |
+| `@api(...)`, `@ui_widget(...)` | `roles` | `roles_config="..."` |
+| `@mcp(...)` | `transport` | `transport_config="..."` |
+| `@cron(...)` | `cron_expression` | `expr_config="..."` |
+| `@cron(...)` | `timezone` | `tz_config="..."` |
+
+When the dot-path resolves against effective bundle props, the resolved value
+replaces the decorator default at request/scheduling time. Empty list / blank
+string / invalid types fall back to the decorator default; missing path also
+falls back to the decorator default. The single exception is `@cron`'s
+`expr_config`: with `expr_config` declared, a missing path means "do not
+schedule" (see `bundle-scheduled-jobs-README.md` for the full cron contract).
+
 ## Configuration Access Rules
 
 Use the helper contract, not ad hoc access.

--- a/app/ai-app/docs/sdk/bundle/bundle-developer-guide-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-developer-guide-README.md
@@ -161,7 +161,7 @@ Practical rule:
 - use `@cron(...)` only for scheduled work
 - use `@on_job` when work is submitted to the background job stream and must be executed later by proc
 - use `@venv(...)` only for dependency-heavy leaf helpers, not general orchestration
-- `enabled_config` is available on bundle/workflow, API, MCP, widget, and cron decorators when you need runtime feature gating from bundle props
+- runtime feature gating uses canonical `enabled.*` switches in bundle props (see "Feature Gating With Canonical `enabled.*`" below)
 
 Background job rule:
 
@@ -222,34 +222,37 @@ Read the exact model here:
 - [bundle-reserved-platform-properties-README.md](bundle-reserved-platform-properties-README.md)
 - [build/how-to-configure-and-run-bundle-README.md](build/how-to-configure-and-run-bundle-README.md)
 
-## Feature Gating With `enabled_config`
+## Feature Gating With Canonical `enabled.*`
 
-`enabled_config` is the standard way to enable or disable bundle surfaces from
-bundle props instead of branching the code manually.
+The platform-native way to enable or disable bundle surfaces is the
+`enabled.*` section of effective bundle props. The platform derives the
+lookup path from decorator metadata, so there is one canonical place per
+surface.
 
-Use it on:
+Mapping per decorator:
 
-- `@agentic_workflow(...)` to gate the whole bundle
-- `@api(...)` to gate one operation
-- `@mcp(...)` to gate one MCP endpoint
-- `@ui_widget(...)` to gate one widget
-- `@cron(...)` to gate one scheduled job
+| Decorator | Canonical path |
+| --- | --- |
+| `@agentic_workflow(...)` | `enabled.bundle` |
+| `@api(alias=A, method=M, ...)` | `enabled.api["A.M"]` (flat key, literal dot) |
+| `@mcp(alias=A, ...)` | `enabled.mcp.A` |
+| `@ui_widget(alias=A, ...)` | `enabled.widget.A` |
+| `@cron(alias=A, ...)` | `enabled.cron.A` |
+
+Aliases must not contain `.`; the validator rejects them at decoration time.
+The flat `<alias>.<METHOD>` key under `enabled.api` is the only place a
+literal dot appears inside a section key.
 
 Example:
 
 ```python
-@agentic_workflow(
-    name="ops.dashboard",
-    version="1.0.0",
-    enabled_config="features.dashboard.enabled",
-)
+@agentic_workflow(name="ops.dashboard", version="1.0.0")
 @bundle_id("ops.dashboard@1.0.0")
 class OpsDashboard(BaseEntrypoint):
     @ui_widget(
         alias="dashboard",
         icon={"tailwind": "heroicons-outline:chart-bar"},
         user_types=("privileged",),
-        enabled_config="features.dashboard.widget_enabled",
     )
     def dashboard_widget(self, **kwargs):
         return ["<div>Dashboard</div>"]
@@ -260,16 +263,16 @@ bundles:
   items:
     - id: "ops.dashboard@1.0.0"
       config:
-        features:
-          dashboard:
-            enabled: true
-            widget_enabled: false
+        enabled:
+          bundle: true
+          widget:
+            dashboard: false
 ```
 
 Current rules:
 
-- the path is resolved against effective bundle props
-- missing path means enabled
+- missing section, missing sub-section, or missing key means enabled
+- bundle-level `enabled.bundle = false` overrides every resource-level value
 - disabled values are:
   - `false`
   - `0`
@@ -277,12 +280,10 @@ Current rules:
   - `disabled`
   - `off`
   - plus boolean `False` and integer `0`
-- bundle-level disable wins over resource-level enable
 
 Practical rule:
 
-- use `enabled_config` for deployment/runtime feature flags
-- keep the actual flag value in `bundles.yaml -> config:`
+- keep the switches in bundle props under `bundles.yaml -> config: enabled: ...`
 - do not invent parallel ad hoc `if self.bundle_prop(...): return 404` checks unless the logic is more complex than simple exposure gating
 
 ## Configuration Access Rules

--- a/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
@@ -149,13 +149,12 @@ Current fields relevant to access control:
   - do **not** use derived platform types here (`"registered"`, `"privileged"`)
   - empty or omitted means the bundle is visible to all authenticated users
   - OR semantics: user passes if at least one of their raw roles matches
-- `enabled_config`
-  - dot-separated path into bundle props that resolves to a boolean
+- bundle-level feature gate: `enabled.bundle` in bundle props
+  - boolean (or string equivalent) that controls the whole bundle
   - if the resolved value is falsy, the bundle is treated as disabled:
     all its HTTP routes return 404 and all its scheduled jobs are skipped,
-    regardless of any resource-level `enabled_config` values
-  - absent or `None` means always enabled
-  - prop absent in Redis also means enabled (opt-in disabling, not opt-in enabling)
+    regardless of any resource-level `enabled.*` values
+  - absent key means always enabled (opt-in disabling, not opt-in enabling)
   - enforced in `integrations.py` for HTTP resources (widgets, operations, MCP endpoints)
     and in `bundle_scheduler.py` for scheduled jobs, before any per-resource check
 
@@ -169,25 +168,48 @@ Current behavior:
 - A bundle with no `allowed_roles` is always included for any authenticated
   user (backwards-compatible default)
 
-### 1.3.1 Shared `enabled_config` Contract
+### 1.3.1 Canonical `enabled.*` Contract
 
-`enabled_config` is the platform-native feature-flag hook for bundle surfaces.
+The platform-native feature-flag hook for bundle surfaces lives under the
+`enabled.*` section of effective bundle props. The platform derives the
+lookup path from decorator metadata, so every surface has one canonical place
+to switch it on or off.
 
-It can be declared on:
+Canonical bundle-props shape:
 
-- `@agentic_workflow(...)` for the whole bundle
-- `@api(...)` for one HTTP operation
-- `@mcp(...)` for one MCP endpoint
-- `@ui_widget(...)` for one widget
-- `@cron(...)` for one scheduled job
+```yaml
+enabled:
+  bundle: true|false
+  api:
+    "<api-alias>.<METHOD>": true|false   # flat key with literal dot
+  mcp:
+    <mcp-alias>: true|false
+  widget:
+    <widget-alias>: true|false
+  cron:
+    <cron-alias>: true|false
+```
 
-The value is a dot-separated path into effective bundle props, for example:
+Mapping per decorator:
+
+| Decorator | Canonical path |
+| --- | --- |
+| `@agentic_workflow(...)` | `enabled.bundle` |
+| `@api(alias=A, method=M, ...)` | `enabled.api["A.M"]` (flat key) |
+| `@mcp(alias=A, ...)` | `enabled.mcp.A` |
+| `@ui_widget(alias=A, ...)` | `enabled.widget.A` |
+| `@cron(alias=A, ...)` | `enabled.cron.A` |
+
+Aliases must not contain `.`; the validator rejects them at decoration time.
+The flat `<alias>.<METHOD>` key under `enabled.api` is the only place a
+literal dot appears inside a section key.
+
+Example:
 
 ```python
 @agentic_workflow(
     name="News Admin",
     version="1.0.0",
-    enabled_config="features.news_admin.enabled",
 )
 ```
 
@@ -196,32 +218,33 @@ bundles:
   items:
     - id: "news.admin@1-0"
       config:
-        features:
-          news_admin:
-            enabled: true
+        enabled:
+          bundle: true
+          widget:
+            news-admin: true
+          cron:
+            news-sync: false
 ```
 
-Current resolution/enforcement rules:
+Resolution/enforcement rules:
 
-- the runtime resolves the path against effective bundle props
-- bundle-level `enabled_config` is checked first
+- bundle-level `enabled.bundle` is checked first
 - if the bundle-level check disables the bundle:
   - bundle listing hides it from the normal integrations listing
   - widget/API/MCP requests return `404`
   - scheduled jobs are not scheduled
-- resource-level `enabled_config` is checked only if the bundle itself is enabled
-- missing path means enabled
-- `None` / absent declaration means enabled
+- resource-level `enabled.<kind>.<alias>` is checked only if the bundle itself is enabled
+- missing section, missing sub-section, or missing key means enabled
 - this is opt-in disabling, not opt-in enabling
 
-Current disabled values:
+Disabled values:
 
 - boolean `False`
 - integer `0`
 - strings `false`, `disable`, `disabled`, `off`, `0`
   - case-insensitive after trimming
 
-Current enabled values:
+Enabled values:
 
 - boolean `True`
 - non-zero integers
@@ -229,11 +252,11 @@ Current enabled values:
 
 Operational rule:
 
-- keep the toggle value in bundle props under `bundles.yaml -> bundles.items[].config`
-- do not use `enabled_config` as a secrets mechanism
+- keep the switches in bundle props under `bundles.yaml -> bundles.items[].config -> enabled: ...`
+- do not use these flags as a secrets mechanism
 - do not hardcode separate enable/disable logic inside the route method when platform gating is enough
 
-Use `enabled_config` when you need:
+Use the canonical `enabled.*` switches when you need:
 
 - staged rollout of a bundle or widget
 - environment-specific feature exposure
@@ -292,11 +315,11 @@ Current fields:
     - `"bundle"`: proc forwards the request into the bundle method and the
       bundle authenticates it itself
   - default: required for `route="public"`, invalid for `route="operations"`
-- `enabled_config`
-  - dot-separated path into bundle props that resolves to a boolean
+- canonical feature gate: `enabled.api["<alias>.<METHOD>"]` (flat key)
+  - boolean (or string equivalent) under `enabled.api` in bundle props
   - if the resolved value is falsy, this endpoint returns 404
-  - absent or `None` means always enabled
-  - checked after the bundle-level `enabled_config` — if the bundle is disabled,
+  - absent key means always enabled
+  - checked after the bundle-level `enabled.bundle` — if the bundle is disabled,
     this check is never reached
 
 Important current rule:
@@ -356,11 +379,11 @@ Current fields:
   - default: `operations`
 - `transport`
   - current supported value: `streamable-http`
-- `enabled_config`
-  - dot-separated path into bundle props that resolves to a boolean
+- canonical feature gate: `enabled.mcp.<alias>`
+  - boolean (or string equivalent) nested under `enabled.mcp` in bundle props
   - if the resolved value is falsy, the MCP endpoint returns 404
-  - absent or `None` means always enabled
-  - checked after the bundle-level `enabled_config`
+  - absent key means always enabled
+  - checked after the bundle-level `enabled.bundle`
 
 Current rule:
 
@@ -440,11 +463,11 @@ Current fields:
 - `roles`
   - raw external roles allowed to see the widget
   - use values such as `kdcube:role:super-admin`
-- `enabled_config`
-  - dot-separated path into bundle props that resolves to a boolean
+- canonical feature gate: `enabled.widget.<alias>`
+  - boolean (or string equivalent) nested under `enabled.widget` in bundle props
   - if the resolved value is falsy, the widget fetch returns 404
-  - absent or `None` means always enabled
-  - checked after the bundle-level `enabled_config`
+  - absent key means always enabled
+  - checked after the bundle-level `enabled.bundle`
 
 Current rule:
 
@@ -573,11 +596,11 @@ Current fields:
 - `tz_config`
   - dot-separated path into bundle props/config for the timezone override
   - if set and resolved to a non-blank string, takes precedence over `timezone`
-- `enabled_config`
-  - dot-separated path into bundle props that resolves to a boolean
+- canonical feature gate: `enabled.cron.<alias>`
+  - boolean (or string equivalent) nested under `enabled.cron` in bundle props
   - if the resolved value is falsy, this job is not scheduled
-  - absent or `None` means always enabled
-  - checked after the bundle-level `enabled_config` in `bundle_scheduler.py` —
+  - absent key means always enabled
+  - checked after the bundle-level `enabled.bundle` in `bundle_scheduler.py` —
     if the bundle itself is disabled, no per-job check is performed
 
 Current behavior:
@@ -660,7 +683,6 @@ class APIEndpointSpec:
     route: str = "operations"
     user_types: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
-    enabled_config: str | None = None
 ```
 
 ### 2.2 `UIWidgetSpec`
@@ -673,7 +695,6 @@ class UIWidgetSpec:
     icon: dict[str, str]
     user_types: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
-    enabled_config: str | None = None
 ```
 
 ### 2.3 `MCPEndpointSpec`
@@ -685,7 +706,6 @@ class MCPEndpointSpec:
     alias: str
     route: str = "operations"
     transport: str = "streamable-http"
-    enabled_config: str | None = None
 ```
 
 ### 2.4 `OnMessageSpec`
@@ -724,7 +744,6 @@ class CronJobSpec:
     timezone: str | None = None
     tz_config: str | None = None
     span: str = "system"
-    enabled_config: str | None = None
 ```
 
 ### 2.8 `BundleInterfaceManifest`
@@ -741,7 +760,6 @@ class BundleInterfaceManifest:
     on_message: OnMessageSpec | None = None
     on_job: OnJobSpec | None = None
     scheduled_jobs: tuple[CronJobSpec, ...] = ()
-    enabled_config: str | None = None
 ```
 
 `allowed_roles` is populated from the `allowed_roles` argument of

--- a/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
@@ -306,6 +306,13 @@ Current fields:
   - tuple/list of raw external roles
   - use actual auth role ids such as `kdcube:role:super-admin`
   - empty means no raw-role restriction
+- `user_types_config` / `roles_config`
+  - optional dot-paths into bundle props
+  - when set and the path resolves to a list of strings, the resolved value
+    overrides the decorator default at request time (per-request lookup)
+  - empty list is a valid intentional override; invalid types fall back
+    silently to the decorator default
+  - missing path also falls back to the decorator default
 - `public_auth`
   - used only with `route="public"`
   - current built-in modes:
@@ -379,6 +386,12 @@ Current fields:
   - default: `operations`
 - `transport`
   - current supported value: `streamable-http`
+- `transport_config`
+  - optional dot-path into bundle props
+  - when set and the path resolves to a supported transport string, the
+    resolved value overrides the decorator default at request time
+  - invalid / unknown transport values fall back silently to the decorator default
+  - missing path also falls back to the decorator default
 - canonical feature gate: `enabled.mcp.<alias>`
   - boolean (or string equivalent) nested under `enabled.mcp` in bundle props
   - if the resolved value is falsy, the MCP endpoint returns 404
@@ -463,6 +476,13 @@ Current fields:
 - `roles`
   - raw external roles allowed to see the widget
   - use values such as `kdcube:role:super-admin`
+- `user_types_config` / `roles_config`
+  - optional dot-paths into bundle props
+  - when set and the path resolves to a list of strings, the resolved value
+    overrides the decorator default at request time (per-request lookup)
+  - empty list is a valid intentional override; invalid types fall back
+    silently to the decorator default
+  - missing path also falls back to the decorator default
 - canonical feature gate: `enabled.widget.<alias>`
   - boolean (or string equivalent) nested under `enabled.widget` in bundle props
   - if the resolved value is falsy, the widget fetch returns 404
@@ -682,7 +702,9 @@ class APIEndpointSpec:
     http_method: str = "POST"
     route: str = "operations"
     user_types: tuple[str, ...] = ()
+    user_types_config: str | None = None
     roles: tuple[str, ...] = ()
+    roles_config: str | None = None
 ```
 
 ### 2.2 `UIWidgetSpec`
@@ -694,7 +716,9 @@ class UIWidgetSpec:
     alias: str
     icon: dict[str, str]
     user_types: tuple[str, ...] = ()
+    user_types_config: str | None = None
     roles: tuple[str, ...] = ()
+    roles_config: str | None = None
 ```
 
 ### 2.3 `MCPEndpointSpec`
@@ -706,6 +730,7 @@ class MCPEndpointSpec:
     alias: str
     route: str = "operations"
     transport: str = "streamable-http"
+    transport_config: str | None = None
 ```
 
 ### 2.4 `OnMessageSpec`

--- a/app/ai-app/docs/sdk/bundle/bundle-scheduled-jobs-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-scheduled-jobs-README.md
@@ -55,32 +55,42 @@ once per hour across the whole system.
     timezone: str | None = None,
     tz_config: str | None = None,
     span: str = "system",
-    enabled_config: str | None = None,
 )
 ```
 
 | Argument | Type | Description |
 |---|---|---|
-| `alias` | `str \| None` | Stable job identifier. Used in Redis lock keys and logs. Defaults to method name. |
+| `alias` | `str \| None` | Stable job identifier. Used in Redis lock keys and logs. Defaults to method name. Must not contain `.`. |
 | `cron_expression` | `str \| None` | Inline cron expression, e.g. `"*/15 * * * *"`. |
 | `expr_config` | `str \| None` | Dot-path into bundle props/config, e.g. `"routines.reindex.cron"`. Wins over `cron_expression`. |
 | `timezone` | `str \| None` | IANA timezone for cron interpretation, e.g. `"Europe/Berlin"`. Defaults to UTC. |
 | `tz_config` | `str \| None` | Dot-path into bundle props/config for the timezone override. Wins over `timezone`. |
 | `span` | `str` | Exclusivity: `"process"`, `"instance"`, `"system"`. Default: `"system"`. |
-| `enabled_config` | `str \| None` | Dot-path into bundle props that resolves to a boolean. Falsy → job not scheduled. `None` means always enabled. |
+
+Feature gating uses the canonical bundle-props path `enabled.cron.<alias>`
+(see "Feature gating" below).
 
 ---
 
-## Bundle-level enabled override
+## Feature gating
 
-If the bundle's `@agentic_workflow(enabled_config=...)` resolves to a falsy
-value from bundle props, **all** scheduled jobs for that bundle are skipped
-during reconcile — regardless of individual job `enabled_config` or
-`expr_config` values. The per-job checks are never reached.
+Each cron job has a canonical switch in bundle props:
 
-This is enforced in `bundle_scheduler.py` (`reconcile`) before the per-job
-loop. Use it as a single kill-switch to disable the entire bundle, including
-all its cron jobs, without touching each job individually.
+```yaml
+enabled:
+  cron:
+    <alias>: true|false
+```
+
+Resolution rules:
+
+- absent key → enabled
+- falsy value (`False`, `0`, or `"false" | "disable" | "disabled" | "off" | "0"`) → job not scheduled
+- bundle-level `enabled.bundle = false` overrides every per-job switch
+
+The bundle-level kill-switch is enforced in `bundle_scheduler.py`
+(`reconcile`) before the per-job loop. Use it to disable the entire bundle —
+including all its cron jobs — without touching each job individually.
 
 ---
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
@@ -35,14 +35,14 @@ interface BundleAPIEndpoint {
     route: string;
     user_types: string[];
     roles: string[];
-    enabled_config?: string | null;
+    enabled_path?: string | null;
 }
 
 interface BundleMCPEndpoint {
     alias: string;
     route: string;
     transport: string;
-    enabled_config?: string | null;
+    enabled_path?: string | null;
 }
 
 interface BundleScheduledJob {
@@ -53,7 +53,7 @@ interface BundleScheduledJob {
     timezone?: string | null;
     tz_config?: string | null;
     span?: string | null;
-    enabled_config?: string | null;
+    enabled_path?: string | null;
 }
 
 interface BundleEntry {
@@ -73,7 +73,7 @@ interface BundleEntry {
     scheduled_jobs?: BundleScheduledJob[] | null;
     on_message?: string | null;
     on_job?: string | null;
-    enabled_config?: string | null;
+    enabled_path?: string | null;
 }
 
 interface BundlesResponse {
@@ -1675,7 +1675,7 @@ const AIBundleDashboard: React.FC = () => {
                                                             <th className="px-3 py-2 text-left font-semibold">Route</th>
                                                             <th className="px-3 py-2 text-left font-semibold">User types</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Roles</th>
-                                                            <th className="px-3 py-2 text-left font-semibold">Enabled config</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Enabled path</th>
                                                         </tr>
                                                     </thead>
                                                     <tbody className="divide-y divide-gray-100">
@@ -1686,7 +1686,7 @@ const AIBundleDashboard: React.FC = () => {
                                                                 <td className="px-3 py-2 font-mono text-gray-700">{ep.route}</td>
                                                                 <td className="px-3 py-2 text-gray-600">{ep.user_types?.join(', ') || '—'}</td>
                                                                 <td className="px-3 py-2 text-gray-600">{ep.roles?.join(', ') || '—'}</td>
-                                                                <td className="px-3 py-2 font-mono text-gray-500">{ep.enabled_config || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{ep.enabled_path || '—'}</td>
                                                             </tr>
                                                         ))}
                                                     </tbody>
@@ -1708,7 +1708,7 @@ const AIBundleDashboard: React.FC = () => {
                                                             <th className="px-3 py-2 text-left font-semibold">Alias</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Route</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Transport</th>
-                                                            <th className="px-3 py-2 text-left font-semibold">Enabled config</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Enabled path</th>
                                                         </tr>
                                                     </thead>
                                                     <tbody className="divide-y divide-gray-100">
@@ -1717,7 +1717,7 @@ const AIBundleDashboard: React.FC = () => {
                                                                 <td className="px-3 py-2 font-mono font-semibold text-gray-900">{ep.alias}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-700">{ep.route}</td>
                                                                 <td className="px-3 py-2 text-gray-600">{ep.transport}</td>
-                                                                <td className="px-3 py-2 font-mono text-gray-500">{ep.enabled_config || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{ep.enabled_path || '—'}</td>
                                                             </tr>
                                                         ))}
                                                     </tbody>
@@ -1743,7 +1743,7 @@ const AIBundleDashboard: React.FC = () => {
                                                             <th className="px-3 py-2 text-left font-semibold">Timezone</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Tz config</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Span</th>
-                                                            <th className="px-3 py-2 text-left font-semibold">Enabled config</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Enabled path</th>
                                                         </tr>
                                                     </thead>
                                                     <tbody className="divide-y divide-gray-100">
@@ -1756,7 +1756,7 @@ const AIBundleDashboard: React.FC = () => {
                                                                 <td className="px-3 py-2 text-gray-600">{job.timezone || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{job.tz_config || '—'}</td>
                                                                 <td className="px-3 py-2 text-gray-600">{job.span || '—'}</td>
-                                                                <td className="px-3 py-2 font-mono text-gray-500">{job.enabled_config || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{job.enabled_path || '—'}</td>
                                                             </tr>
                                                         ))}
                                                     </tbody>

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
@@ -1739,7 +1739,9 @@ const AIBundleDashboard: React.FC = () => {
                                                             <th className="px-3 py-2 text-left font-semibold">Alias</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Method</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Cron</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Expr config</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Timezone</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Tz config</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Span</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Enabled config</th>
                                                         </tr>
@@ -1749,8 +1751,10 @@ const AIBundleDashboard: React.FC = () => {
                                                             <tr key={i} className="hover:bg-gray-50/70">
                                                                 <td className="px-3 py-2 font-mono font-semibold text-gray-900">{job.alias || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-700">{job.method_name}</td>
-                                                                <td className="px-3 py-2 font-mono text-gray-700">{job.cron_expression || job.expr_config || '—'}</td>
-                                                                <td className="px-3 py-2 text-gray-600">{job.timezone || job.tz_config || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-700">{job.cron_expression || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{job.expr_config || '—'}</td>
+                                                                <td className="px-3 py-2 text-gray-600">{job.timezone || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{job.tz_config || '—'}</td>
                                                                 <td className="px-3 py-2 text-gray-600">{job.span || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{job.enabled_config || '—'}</td>
                                                             </tr>

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
@@ -29,6 +29,33 @@ interface TenantProjectItem {
     source?: string;
 }
 
+interface BundleAPIEndpoint {
+    alias: string;
+    http_method: string;
+    route: string;
+    user_types: string[];
+    roles: string[];
+    enabled_config?: string | null;
+}
+
+interface BundleMCPEndpoint {
+    alias: string;
+    route: string;
+    transport: string;
+    enabled_config?: string | null;
+}
+
+interface BundleScheduledJob {
+    method_name: string;
+    alias?: string | null;
+    cron_expression?: string | null;
+    expr_config?: string | null;
+    timezone?: string | null;
+    tz_config?: string | null;
+    span?: string | null;
+    enabled_config?: string | null;
+}
+
 interface BundleEntry {
     id: string;
     name?: string | null;
@@ -41,6 +68,12 @@ interface BundleEntry {
     ref?: string | null;
     subdir?: string | null;
     git_commit?: string | null;
+    apis?: BundleAPIEndpoint[] | null;
+    mcp_endpoints?: BundleMCPEndpoint[] | null;
+    scheduled_jobs?: BundleScheduledJob[] | null;
+    on_message?: string | null;
+    on_job?: string | null;
+    enabled_config?: string | null;
 }
 
 interface BundlesResponse {
@@ -680,6 +713,7 @@ const AIBundleDashboard: React.FC = () => {
     const [secretsLoading, setSecretsLoading] = useState<boolean>(false);
     const [secretsKeyPath, setSecretsKeyPath] = useState<string>('');
     const [secretsValue, setSecretsValue] = useState<string>('');
+    const [interfaceBundleId, setInterfaceBundleId] = useState<string>('');
     const registryScope = useMemo(() => normalizeScope(scopeTenant, scopeProject), [scopeTenant, scopeProject]);
     const propsScope = useMemo(() => normalizeScope(scopeTenant, scopeProject), [scopeTenant, scopeProject]);
     const draftScope = useMemo(() => parseScopeValue(scopeInput), [scopeInput]);
@@ -796,6 +830,9 @@ const AIBundleDashboard: React.FC = () => {
             }
             if (!secretsBundleId || !(secretsBundleId in (data.available_bundles || {}))) {
                 setSecretsBundleId(data.default_bundle_id || '');
+            }
+            if (!interfaceBundleId || !(interfaceBundleId in (data.available_bundles || {}))) {
+                setInterfaceBundleId(data.default_bundle_id || '');
             }
             setError(null);
         } catch (e: any) {
@@ -1566,6 +1603,166 @@ const AIBundleDashboard: React.FC = () => {
                         <div className="text-xs text-gray-500">
                             Secrets are stored under <code>bundles.&lt;bundle_id&gt;.secrets.*</code> and are write-only.
                         </div>
+                    </CardBody>
+                </Card>
+
+                <Card>
+                    <CardHeader
+                        title="Bundle interface"
+                        subtitle="Declared APIs, MCP endpoints, and scheduled jobs (cron) for the selected bundle."
+                    />
+                    <CardBody className="space-y-5">
+                        <div>
+                            <label className="block text-sm font-medium text-gray-800 mb-2">Bundle ID</label>
+                            <select
+                                className="w-full px-4 py-2.5 border border-gray-200/80 rounded-xl bg-white text-sm"
+                                value={interfaceBundleId}
+                                onChange={e => setInterfaceBundleId(e.target.value)}
+                            >
+                                <option value="">—</option>
+                                {bundleList.map(b => (
+                                    <option key={b.id} value={b.id}>{b.id}</option>
+                                ))}
+                            </select>
+                        </div>
+
+                        {(() => {
+                            const b = interfaceBundleId ? bundles[interfaceBundleId] : null;
+                            if (!b) return (
+                                <div className="text-sm text-gray-500">Select a bundle to view its interface.</div>
+                            );
+
+                            const apis = b.apis || [];
+                            const mcp = b.mcp_endpoints || [];
+                            const jobs = b.scheduled_jobs || [];
+                            const hasAny = apis.length > 0 || mcp.length > 0 || jobs.length > 0 || b.on_message || b.on_job;
+
+                            if (!hasAny) return (
+                                <div className="text-sm text-gray-500">No interface declared for this bundle.</div>
+                            );
+
+                            return (
+                                <div className="space-y-5">
+                                    {(b.on_message || b.on_job) && (
+                                        <div className="flex flex-wrap gap-3 text-xs text-gray-600">
+                                            {b.on_message && (
+                                                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-gray-100 border border-gray-200">
+                                                    <span className="font-semibold text-gray-800">on_message</span>
+                                                    <code>{b.on_message}</code>
+                                                </span>
+                                            )}
+                                            {b.on_job && (
+                                                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-gray-100 border border-gray-200">
+                                                    <span className="font-semibold text-gray-800">on_job</span>
+                                                    <code>{b.on_job}</code>
+                                                </span>
+                                            )}
+                                        </div>
+                                    )}
+
+                                    {apis.length > 0 && (
+                                        <div>
+                                            <div className="text-sm font-semibold text-gray-800 mb-2">
+                                                API Endpoints
+                                                <span className="ml-2 text-xs font-normal text-gray-500">({apis.length})</span>
+                                            </div>
+                                            <div className="overflow-x-auto rounded-xl border border-gray-200">
+                                                <table className="w-full text-xs">
+                                                    <thead className="bg-gray-50 border-b border-gray-200">
+                                                        <tr className="text-gray-600">
+                                                            <th className="px-3 py-2 text-left font-semibold">Alias</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Method</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Route</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">User types</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Roles</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Enabled config</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody className="divide-y divide-gray-100">
+                                                        {apis.map((ep, i) => (
+                                                            <tr key={i} className="hover:bg-gray-50/70">
+                                                                <td className="px-3 py-2 font-mono font-semibold text-gray-900">{ep.alias}</td>
+                                                                <td className="px-3 py-2 font-mono uppercase text-blue-700">{ep.http_method}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-700">{ep.route}</td>
+                                                                <td className="px-3 py-2 text-gray-600">{ep.user_types?.join(', ') || '—'}</td>
+                                                                <td className="px-3 py-2 text-gray-600">{ep.roles?.join(', ') || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{ep.enabled_config || '—'}</td>
+                                                            </tr>
+                                                        ))}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {mcp.length > 0 && (
+                                        <div>
+                                            <div className="text-sm font-semibold text-gray-800 mb-2">
+                                                MCP Endpoints
+                                                <span className="ml-2 text-xs font-normal text-gray-500">({mcp.length})</span>
+                                            </div>
+                                            <div className="overflow-x-auto rounded-xl border border-gray-200">
+                                                <table className="w-full text-xs">
+                                                    <thead className="bg-gray-50 border-b border-gray-200">
+                                                        <tr className="text-gray-600">
+                                                            <th className="px-3 py-2 text-left font-semibold">Alias</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Route</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Transport</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Enabled config</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody className="divide-y divide-gray-100">
+                                                        {mcp.map((ep, i) => (
+                                                            <tr key={i} className="hover:bg-gray-50/70">
+                                                                <td className="px-3 py-2 font-mono font-semibold text-gray-900">{ep.alias}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-700">{ep.route}</td>
+                                                                <td className="px-3 py-2 text-gray-600">{ep.transport}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{ep.enabled_config || '—'}</td>
+                                                            </tr>
+                                                        ))}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {jobs.length > 0 && (
+                                        <div>
+                                            <div className="text-sm font-semibold text-gray-800 mb-2">
+                                                Scheduled Jobs (Cron)
+                                                <span className="ml-2 text-xs font-normal text-gray-500">({jobs.length})</span>
+                                            </div>
+                                            <div className="overflow-x-auto rounded-xl border border-gray-200">
+                                                <table className="w-full text-xs">
+                                                    <thead className="bg-gray-50 border-b border-gray-200">
+                                                        <tr className="text-gray-600">
+                                                            <th className="px-3 py-2 text-left font-semibold">Alias</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Method</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Cron</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Timezone</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Span</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Enabled config</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody className="divide-y divide-gray-100">
+                                                        {jobs.map((job, i) => (
+                                                            <tr key={i} className="hover:bg-gray-50/70">
+                                                                <td className="px-3 py-2 font-mono font-semibold text-gray-900">{job.alias || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-700">{job.method_name}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-700">{job.cron_expression || job.expr_config || '—'}</td>
+                                                                <td className="px-3 py-2 text-gray-600">{job.timezone || job.tz_config || '—'}</td>
+                                                                <td className="px-3 py-2 text-gray-600">{job.span || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{job.enabled_config || '—'}</td>
+                                                            </tr>
+                                                        ))}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })()}
                     </CardBody>
                 </Card>
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
@@ -45,6 +45,14 @@ interface BundleMCPEndpoint {
     enabled_path?: string | null;
 }
 
+interface BundleWidget {
+    alias: string;
+    icon?: Record<string, string> | null;
+    user_types: string[];
+    roles: string[];
+    enabled_path?: string | null;
+}
+
 interface BundleScheduledJob {
     method_name: string;
     alias?: string | null;
@@ -70,10 +78,12 @@ interface BundleEntry {
     git_commit?: string | null;
     apis?: BundleAPIEndpoint[] | null;
     mcp_endpoints?: BundleMCPEndpoint[] | null;
+    widgets?: BundleWidget[] | null;
     scheduled_jobs?: BundleScheduledJob[] | null;
     on_message?: string | null;
     on_job?: string | null;
     enabled_path?: string | null;
+    allowed_roles?: string[] | null;
 }
 
 interface BundlesResponse {
@@ -1634,15 +1644,32 @@ const AIBundleDashboard: React.FC = () => {
 
                             const apis = b.apis || [];
                             const mcp = b.mcp_endpoints || [];
+                            const widgets = b.widgets || [];
                             const jobs = b.scheduled_jobs || [];
-                            const hasAny = apis.length > 0 || mcp.length > 0 || jobs.length > 0 || b.on_message || b.on_job;
+                            const allowedRoles = b.allowed_roles || [];
+                            const hasAny = apis.length > 0 || mcp.length > 0 || widgets.length > 0 || jobs.length > 0 || b.on_message || b.on_job;
 
-                            if (!hasAny) return (
+                            if (!hasAny && allowedRoles.length === 0) return (
                                 <div className="text-sm text-gray-500">No interface declared for this bundle.</div>
                             );
 
                             return (
                                 <div className="space-y-5">
+                                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                                        <span className="font-semibold text-gray-700">Bundle visibility:</span>
+                                        {allowedRoles.length === 0 ? (
+                                            <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-emerald-50 border border-emerald-200 text-emerald-800">
+                                                Visible to all authenticated users
+                                            </span>
+                                        ) : (
+                                            allowedRoles.map((r, i) => (
+                                                <span key={i} className="inline-flex items-center px-2.5 py-1 rounded-full bg-indigo-50 border border-indigo-200 font-mono text-indigo-800">
+                                                    {r}
+                                                </span>
+                                            ))
+                                        )}
+                                    </div>
+
                                     {(b.on_message || b.on_job) && (
                                         <div className="flex flex-wrap gap-3 text-xs text-gray-600">
                                             {b.on_message && (
@@ -1689,6 +1716,44 @@ const AIBundleDashboard: React.FC = () => {
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{ep.enabled_path || '—'}</td>
                                                             </tr>
                                                         ))}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {widgets.length > 0 && (
+                                        <div>
+                                            <div className="text-sm font-semibold text-gray-800 mb-2">
+                                                Widgets
+                                                <span className="ml-2 text-xs font-normal text-gray-500">({widgets.length})</span>
+                                            </div>
+                                            <div className="overflow-x-auto rounded-xl border border-gray-200">
+                                                <table className="w-full text-xs">
+                                                    <thead className="bg-gray-50 border-b border-gray-200">
+                                                        <tr className="text-gray-600">
+                                                            <th className="px-3 py-2 text-left font-semibold">Alias</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Icon</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">User types</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Roles</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Enabled path</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody className="divide-y divide-gray-100">
+                                                        {widgets.map((w, i) => {
+                                                            const iconLabel = w.icon
+                                                                ? Object.entries(w.icon).map(([k, v]) => `${k}:${v}`).join(', ')
+                                                                : '';
+                                                            return (
+                                                                <tr key={i} className="hover:bg-gray-50/70">
+                                                                    <td className="px-3 py-2 font-mono font-semibold text-gray-900">{w.alias}</td>
+                                                                    <td className="px-3 py-2 font-mono text-gray-500">{iconLabel || '—'}</td>
+                                                                    <td className="px-3 py-2 text-gray-600">{w.user_types?.join(', ') || '—'}</td>
+                                                                    <td className="px-3 py-2 text-gray-600">{w.roles?.join(', ') || '—'}</td>
+                                                                    <td className="px-3 py-2 font-mono text-gray-500">{w.enabled_path || '—'}</td>
+                                                                </tr>
+                                                            );
+                                                        })}
                                                     </tbody>
                                                 </table>
                                             </div>
@@ -1751,7 +1816,7 @@ const AIBundleDashboard: React.FC = () => {
                                                             <tr key={i} className="hover:bg-gray-50/70">
                                                                 <td className="px-3 py-2 font-mono font-semibold text-gray-900">{job.alias || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-700">{job.method_name}</td>
-                                                                <td className="px-3 py-2 font-mono text-gray-700">{job.cron_expression || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-700 whitespace-nowrap">{job.cron_expression || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{job.expr_config || '—'}</td>
                                                                 <td className="px-3 py-2 text-gray-600">{job.timezone || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{job.tz_config || '—'}</td>

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
@@ -571,6 +571,113 @@ const OverridableValue: React.FC<{
     );
 };
 
+// =============================================================================
+// Override editing helpers
+// =============================================================================
+
+// Build a nested patch object from a regular dot-path: "a.b.c" -> {a:{b:{c:value}}}
+function nestedDotPathPatch(path: string, value: unknown): Record<string, any> {
+    const parts = path.split('.').filter(Boolean);
+    if (parts.length === 0) return {};
+    const root: Record<string, any> = {};
+    let cursor: Record<string, any> = root;
+    for (let i = 0; i < parts.length - 1; i++) {
+        cursor[parts[i]] = {};
+        cursor = cursor[parts[i]];
+    }
+    cursor[parts[parts.length - 1]] = value;
+    return root;
+}
+
+// Read a value at a regular dot-path; returns undefined when the path is absent.
+function readDotPath(obj: any, path: string | null | undefined): any {
+    if (!path) return undefined;
+    const parts = path.split('.').filter(Boolean);
+    let cursor: any = obj;
+    for (const p of parts) {
+        if (cursor == null || typeof cursor !== 'object') return undefined;
+        cursor = cursor[p];
+    }
+    return cursor;
+}
+
+// enabled.api uses a flat key for "<alias>.<METHOD>" (literal dot in key).
+function buildEnabledApiPatch(alias: string, method: string, value: unknown): Record<string, any> {
+    return { enabled: { api: { [`${alias}.${method}`]: value } } };
+}
+
+// enabled.<kind>.<alias> for non-api kinds — alias is a single map key.
+function buildEnabledKindPatch(kind: 'mcp' | 'widget' | 'cron' | 'bundle', alias: string | null, value: unknown): Record<string, any> {
+    if (kind === 'bundle') return { enabled: { bundle: value } };
+    return { enabled: { [kind]: { [alias as string]: value } } };
+}
+
+// Deep-merge two record trees (used to combine multiple per-field patches into one Save call).
+function deepMergeMaps(a: Record<string, any>, b: Record<string, any>): Record<string, any> {
+    const out: Record<string, any> = { ...a };
+    for (const [k, v] of Object.entries(b)) {
+        if (v && typeof v === 'object' && !Array.isArray(v) && out[k] && typeof out[k] === 'object' && !Array.isArray(out[k])) {
+            out[k] = deepMergeMaps(out[k], v);
+        } else {
+            out[k] = v;
+        }
+    }
+    return out;
+}
+
+// Parse comma-separated string into a tuple of trimmed non-empty strings.
+function parseChips(s: string): string[] {
+    return s.split(',').map(x => x.trim()).filter(Boolean);
+}
+
+const KNOWN_USER_TYPES: ReadonlyArray<string> = ['anonymous', 'registered', 'paid', 'privileged'];
+const KNOWN_TRANSPORTS: ReadonlyArray<string> = ['streamable-http'];
+
+// Pill that renders next to a field name to flag whether the field is currently
+// overridden, configurable but not overridden, or hard-coded (no *_config).
+const FieldStatePill: React.FC<{ overridden?: boolean; configurable: boolean }> = ({ overridden, configurable }) => {
+    if (overridden) {
+        return <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-amber-50 border border-amber-200 text-amber-800 text-[10px] font-semibold uppercase tracking-wide">overridden</span>;
+    }
+    if (configurable) {
+        return <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-emerald-50 border border-emerald-200 text-emerald-800 text-[10px] font-semibold uppercase tracking-wide">configurable</span>;
+    }
+    return <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-gray-100 border border-gray-200 text-gray-500 text-[10px] font-semibold uppercase tracking-wide">hard-coded</span>;
+};
+
+const FieldHint: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <p className="mt-1 text-[11px] text-gray-500">{children}</p>
+);
+
+const FieldRow: React.FC<{
+    label: string;
+    overridden?: boolean;
+    configurable?: boolean;
+    onResetToDefault?: () => void;
+    children: React.ReactNode;
+    hint?: React.ReactNode;
+}> = ({ label, overridden, configurable, onResetToDefault, children, hint }) => (
+    <div>
+        <div className="flex items-center justify-between mb-1.5">
+            <label className="block text-sm font-medium text-gray-800">
+                <span className="mr-2">{label}</span>
+                <FieldStatePill overridden={overridden} configurable={configurable === true} />
+            </label>
+            {onResetToDefault && (
+                <button
+                    type="button"
+                    onClick={onResetToDefault}
+                    className="text-[11px] text-gray-500 hover:text-gray-700 cursor-pointer underline-offset-2 hover:underline"
+                >
+                    Reset to default
+                </button>
+            )}
+        </div>
+        {children}
+        {hint && <FieldHint>{hint}</FieldHint>}
+    </div>
+);
+
 const CardHeader: React.FC<{ title: string; subtitle?: string; action?: React.ReactNode }> = ({ title, subtitle, action }) => (
     <div className="px-6 py-5 border-b border-gray-200/70">
         <div className="flex items-start justify-between gap-4">
@@ -732,6 +839,399 @@ const deepMergeObjects = (base: Record<string, unknown>, patch: Record<string, u
 };
 
 // =============================================================================
+// ResourceEditorCard — per-kind override editor with combobox + form + Save
+// =============================================================================
+
+type EditableKind = 'api' | 'widget' | 'mcp' | 'cron';
+
+interface ResourceEditorCardProps {
+    kind: EditableKind;
+    bundle: BundleEntry;
+    editorProps: Record<string, any>;
+    editorPropsLoading: boolean;
+    onSave: (patch: Record<string, any>) => Promise<void>;
+}
+
+const ResourceEditorCard: React.FC<ResourceEditorCardProps> = ({
+    kind, bundle, editorProps, editorPropsLoading, onSave,
+}) => {
+    // Build the resource list for the combobox.
+    const resources: Array<{ key: string; label: string }> = useMemo(() => {
+        if (kind === 'api') {
+            return (bundle.apis || []).map(ep => ({
+                key: `${ep.alias}|${ep.http_method}`,
+                label: `${ep.alias} [${ep.http_method}] ${ep.route}`,
+            }));
+        }
+        if (kind === 'widget') {
+            return (bundle.widgets || []).map(w => ({ key: w.alias, label: w.alias }));
+        }
+        if (kind === 'mcp') {
+            return (bundle.mcp_endpoints || []).map(m => ({
+                key: m.alias,
+                label: `${m.alias} (${m.route})`,
+            }));
+        }
+        return (bundle.scheduled_jobs || []).map(c => ({
+            key: c.alias || c.method_name,
+            label: c.alias || c.method_name,
+        }));
+    }, [kind, bundle]);
+
+    const [selectedKey, setSelectedKey] = useState<string>(resources[0]?.key || '');
+    const [saving, setSaving] = useState(false);
+    const [flash, setFlash] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    // Reset selection when bundle changes and current key is no longer valid.
+    useEffect(() => {
+        if (!resources.find(r => r.key === selectedKey)) {
+            setSelectedKey(resources[0]?.key || '');
+        }
+    }, [resources, selectedKey]);
+
+    // Resolve the currently selected spec (typed loosely — kind-specific access below).
+    const selectedSpec: any = useMemo(() => {
+        if (!selectedKey) return null;
+        if (kind === 'api') {
+            const [alias, method] = selectedKey.split('|');
+            return (bundle.apis || []).find(ep => ep.alias === alias && ep.http_method === method) || null;
+        }
+        if (kind === 'widget') {
+            return (bundle.widgets || []).find(w => w.alias === selectedKey) || null;
+        }
+        if (kind === 'mcp') {
+            return (bundle.mcp_endpoints || []).find(m => m.alias === selectedKey) || null;
+        }
+        return (bundle.scheduled_jobs || []).find(c => (c.alias || c.method_name) === selectedKey) || null;
+    }, [kind, bundle, selectedKey]);
+
+    // Read current effective enabled value for this resource from editorProps.
+    const enabledEffective = useMemo(() => {
+        if (!selectedSpec) return true;
+        const enabledRoot = (editorProps as any)?.enabled || {};
+        let raw: any;
+        if (kind === 'api') {
+            raw = enabledRoot?.api?.[`${selectedSpec.alias}.${selectedSpec.http_method}`];
+        } else {
+            raw = enabledRoot?.[kind]?.[selectedSpec.alias];
+        }
+        if (raw === undefined) return true;
+        if (raw === false || raw === 0) return false;
+        if (typeof raw === 'string' && ['false', 'disable', 'disabled', 'off', '0'].includes(raw.trim().toLowerCase())) return false;
+        return Boolean(raw);
+    }, [kind, selectedSpec, editorProps]);
+
+    // Form state (reset to current effective values when selection changes).
+    const [formEnabled, setFormEnabled] = useState<boolean>(true);
+    const [formUserTypes, setFormUserTypes] = useState<string[]>([]);
+    const [formRoles, setFormRoles] = useState<string>('');
+    const [formTransport, setFormTransport] = useState<string>('streamable-http');
+    const [formCron, setFormCron] = useState<string>('');
+    const [formTimezone, setFormTimezone] = useState<string>('');
+
+    useEffect(() => {
+        setFlash(null);
+        setError(null);
+        if (!selectedSpec) return;
+        setFormEnabled(enabledEffective);
+        if (kind === 'api' || kind === 'widget') {
+            setFormUserTypes(Array.isArray(selectedSpec.user_types) ? [...selectedSpec.user_types] : []);
+            setFormRoles(Array.isArray(selectedSpec.roles) ? selectedSpec.roles.join(', ') : '');
+        }
+        if (kind === 'mcp') {
+            setFormTransport(selectedSpec.transport || 'streamable-http');
+        }
+        if (kind === 'cron') {
+            // Cron uses the platform contract: when expr_config is set and the
+            // path is missing/null, the job is "not scheduled" (effective is
+            // None). Mirror what's actually written at the override path so
+            // explicit values like "disable" or empty strings are visible to
+            // the operator; fall back to the decorator default when the key
+            // is absent so the form is not blank by default.
+            const rawCron = readDotPath(editorProps, selectedSpec.expr_config);
+            const cronInitial = typeof rawCron === 'string'
+                ? rawCron
+                : (selectedSpec.cron_expression_default || '');
+            setFormCron(cronInitial);
+            const rawTz = readDotPath(editorProps, selectedSpec.tz_config);
+            const tzInitial = typeof rawTz === 'string'
+                ? rawTz
+                : (selectedSpec.timezone_default || '');
+            setFormTimezone(tzInitial);
+        }
+    }, [kind, selectedSpec, enabledEffective, editorProps]);
+
+    const title = ({
+        api: 'Edit API endpoint',
+        widget: 'Edit widget',
+        mcp: 'Edit MCP endpoint',
+        cron: 'Edit cron job',
+    } as Record<EditableKind, string>)[kind];
+
+    const handleSave = async () => {
+        if (!selectedSpec) return;
+        setError(null);
+        setFlash(null);
+        try {
+            setSaving(true);
+            // Build composite patch from changed fields.
+            let patch: Record<string, any> = {};
+            // enabled toggle
+            if (kind === 'api') {
+                patch = deepMergeMaps(patch, buildEnabledApiPatch(selectedSpec.alias, selectedSpec.http_method, formEnabled));
+            } else {
+                patch = deepMergeMaps(patch, buildEnabledKindPatch(kind, selectedSpec.alias, formEnabled));
+            }
+            // kind-specific overrides via *_config (only if path declared)
+            if (kind === 'api' || kind === 'widget') {
+                if (selectedSpec.user_types_config) {
+                    patch = deepMergeMaps(patch, nestedDotPathPatch(selectedSpec.user_types_config, formUserTypes));
+                }
+                if (selectedSpec.roles_config) {
+                    patch = deepMergeMaps(patch, nestedDotPathPatch(selectedSpec.roles_config, parseChips(formRoles)));
+                }
+            }
+            if (kind === 'mcp' && selectedSpec.transport_config) {
+                patch = deepMergeMaps(patch, nestedDotPathPatch(selectedSpec.transport_config, formTransport));
+            }
+            if (kind === 'cron') {
+                if (selectedSpec.expr_config) {
+                    patch = deepMergeMaps(patch, nestedDotPathPatch(selectedSpec.expr_config, formCron));
+                }
+                if (selectedSpec.tz_config) {
+                    patch = deepMergeMaps(patch, nestedDotPathPatch(selectedSpec.tz_config, formTimezone));
+                }
+            }
+            await onSave(patch);
+            setFlash('Saved ✓');
+            window.setTimeout(() => setFlash(null), 1800);
+        } catch (e: any) {
+            setError(e?.message || 'Save failed');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const resetField = async (configPath: string | null | undefined, value: unknown = null) => {
+        if (!configPath) return;
+        setError(null);
+        try {
+            setSaving(true);
+            await onSave(nestedDotPathPatch(configPath, value));
+            setFlash('Reset ✓');
+            window.setTimeout(() => setFlash(null), 1800);
+        } catch (e: any) {
+            setError(e?.message || 'Reset failed');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (resources.length === 0) {
+        return null;
+    }
+
+    return (
+        <Card>
+            <CardHeader
+                title={title}
+                subtitle="Resource overrides are written to bundle props (op: merge). Changes apply immediately at request time."
+                action={
+                    <div className="flex items-center gap-3">
+                        {flash && <span className="text-xs text-emerald-700 font-semibold">{flash}</span>}
+                        {error && <span className="text-xs text-red-700">{error}</span>}
+                        <Button variant="primary" disabled={saving || !selectedSpec || editorPropsLoading} onClick={handleSave}>
+                            {saving ? 'Saving…' : 'Save'}
+                        </Button>
+                    </div>
+                }
+            />
+            <CardBody className="space-y-5">
+                <div>
+                    <label className="block text-sm font-medium text-gray-800 mb-2">Resource</label>
+                    <select
+                        className="w-full px-4 py-2.5 border border-gray-200/80 rounded-xl bg-white text-sm"
+                        value={selectedKey}
+                        onChange={e => setSelectedKey(e.target.value)}
+                    >
+                        {resources.map(r => (
+                            <option key={r.key} value={r.key}>{r.label}</option>
+                        ))}
+                    </select>
+                </div>
+
+                {selectedSpec && (
+                    <div className="space-y-5">
+                        <FieldRow label="Enabled" overridden={false} configurable>
+                            <label className="inline-flex items-center gap-2 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={formEnabled}
+                                    onChange={e => setFormEnabled(e.target.checked)}
+                                />
+                                <span className={formEnabled ? 'text-emerald-700 font-semibold text-sm' : 'text-gray-500 font-semibold text-sm'}>
+                                    {formEnabled ? 'enabled' : 'disabled'}
+                                </span>
+                            </label>
+                            <FieldHint>
+                                Maps to <code>{selectedSpec.enabled_path}</code>.
+                            </FieldHint>
+                        </FieldRow>
+
+                        {(kind === 'api' || kind === 'widget') && (
+                            <>
+                                <FieldRow
+                                    label="User types"
+                                    overridden={selectedSpec.user_types_overridden}
+                                    configurable={Boolean(selectedSpec.user_types_config)}
+                                    onResetToDefault={selectedSpec.user_types_config && selectedSpec.user_types_overridden ? () => resetField(selectedSpec.user_types_config, null) : undefined}
+                                >
+                                    <select
+                                        multiple
+                                        size={4}
+                                        value={formUserTypes}
+                                        onChange={e => setFormUserTypes(Array.from(e.target.selectedOptions).map(o => o.value))}
+                                        disabled={!selectedSpec.user_types_config}
+                                        className="w-full px-3 py-2 border border-gray-200/80 rounded-xl bg-white text-sm disabled:bg-gray-50 disabled:text-gray-400"
+                                    >
+                                        {KNOWN_USER_TYPES.map(ut => (
+                                            <option key={ut} value={ut}>{ut}</option>
+                                        ))}
+                                    </select>
+                                    <FieldHint>
+                                        {selectedSpec.user_types_config
+                                            ? <>Override path: <code>{selectedSpec.user_types_config}</code>. Hold ⌘/Ctrl to multi-select. Empty selection saves an explicit empty list.</>
+                                            : <>No <code>user_types_config</code> declared in the decorator — value is hard-coded.</>}
+                                    </FieldHint>
+                                </FieldRow>
+
+                                <FieldRow
+                                    label="Roles"
+                                    overridden={selectedSpec.roles_overridden}
+                                    configurable={Boolean(selectedSpec.roles_config)}
+                                    onResetToDefault={selectedSpec.roles_config && selectedSpec.roles_overridden ? () => resetField(selectedSpec.roles_config, null) : undefined}
+                                >
+                                    <input
+                                        value={formRoles}
+                                        onChange={e => setFormRoles(e.target.value)}
+                                        disabled={!selectedSpec.roles_config}
+                                        placeholder="kdcube:role:editor, kdcube:role:viewer"
+                                        className="w-full px-3 py-2 border border-gray-200/80 rounded-xl bg-white text-sm font-mono disabled:bg-gray-50 disabled:text-gray-400"
+                                    />
+                                    <FieldHint>
+                                        {selectedSpec.roles_config
+                                            ? <>Override path: <code>{selectedSpec.roles_config}</code>. Comma-separated. Empty saves an explicit empty list.</>
+                                            : <>No <code>roles_config</code> declared in the decorator — value is hard-coded.</>}
+                                    </FieldHint>
+                                </FieldRow>
+                            </>
+                        )}
+
+                        {kind === 'mcp' && (
+                            <FieldRow
+                                label="Transport"
+                                overridden={selectedSpec.transport_overridden}
+                                configurable={Boolean(selectedSpec.transport_config)}
+                                onResetToDefault={selectedSpec.transport_config && selectedSpec.transport_overridden ? () => resetField(selectedSpec.transport_config, null) : undefined}
+                            >
+                                <select
+                                    value={formTransport}
+                                    onChange={e => setFormTransport(e.target.value)}
+                                    disabled={!selectedSpec.transport_config}
+                                    className="w-full px-3 py-2 border border-gray-200/80 rounded-xl bg-white text-sm disabled:bg-gray-50 disabled:text-gray-400"
+                                >
+                                    {KNOWN_TRANSPORTS.map(t => <option key={t} value={t}>{t}</option>)}
+                                </select>
+                                <FieldHint>
+                                    {selectedSpec.transport_config
+                                        ? <>Override path: <code>{selectedSpec.transport_config}</code>.</>
+                                        : <>No <code>transport_config</code> declared in the decorator — value is hard-coded.</>}
+                                </FieldHint>
+                            </FieldRow>
+                        )}
+
+                        {kind === 'cron' && (
+                            <>
+                                <FieldRow
+                                    label="Cron expression"
+                                    overridden={selectedSpec.cron_expression_overridden}
+                                    configurable={Boolean(selectedSpec.expr_config)}
+                                    onResetToDefault={
+                                        selectedSpec.expr_config && selectedSpec.cron_expression_overridden
+                                            ? () => resetField(selectedSpec.expr_config, selectedSpec.cron_expression_default ?? null)
+                                            : undefined
+                                    }
+                                >
+                                    <input
+                                        value={formCron}
+                                        onChange={e => setFormCron(e.target.value)}
+                                        disabled={!selectedSpec.expr_config}
+                                        placeholder={selectedSpec.cron_expression_default || '*/15 * * * *'}
+                                        className="w-full px-3 py-2 border border-gray-200/80 rounded-xl bg-white text-sm font-mono disabled:bg-gray-50 disabled:text-gray-400"
+                                    />
+                                    <FieldHint>
+                                        {selectedSpec.expr_config ? (
+                                            <>
+                                                Override path: <code>{selectedSpec.expr_config}</code>.
+                                                {' '}Decorator default: <code>{selectedSpec.cron_expression_default || '—'}</code>.
+                                                <br />
+                                                <span className="text-gray-400">
+                                                    Setting the value to <code>disable</code> (or an empty string) suppresses scheduling
+                                                    without flipping <code>enabled.cron.{selectedSpec.alias}</code>.
+                                                    Removing the value entirely also stops the job. "Reset to default" therefore writes
+                                                    the decorator default back to the override path instead of clearing it.
+                                                </span>
+                                            </>
+                                        ) : (
+                                            <>No <code>expr_config</code> declared in the decorator — schedule is hard-coded.</>
+                                        )}
+                                    </FieldHint>
+                                </FieldRow>
+
+                                <FieldRow
+                                    label="Timezone"
+                                    overridden={selectedSpec.timezone_overridden}
+                                    configurable={Boolean(selectedSpec.tz_config)}
+                                    onResetToDefault={
+                                        selectedSpec.tz_config && selectedSpec.timezone_overridden
+                                            ? () => resetField(selectedSpec.tz_config, selectedSpec.timezone_default ?? null)
+                                            : undefined
+                                    }
+                                >
+                                    <input
+                                        value={formTimezone}
+                                        onChange={e => setFormTimezone(e.target.value)}
+                                        disabled={!selectedSpec.tz_config}
+                                        placeholder={selectedSpec.timezone_default || 'Europe/Berlin'}
+                                        className="w-full px-3 py-2 border border-gray-200/80 rounded-xl bg-white text-sm font-mono disabled:bg-gray-50 disabled:text-gray-400"
+                                    />
+                                    <FieldHint>
+                                        {selectedSpec.tz_config ? (
+                                            <>
+                                                Override path: <code>{selectedSpec.tz_config}</code>.
+                                                {' '}Decorator default: <code>{selectedSpec.timezone_default || 'UTC'}</code>.
+                                                <br />
+                                                <span className="text-gray-400">
+                                                    Empty / missing falls back to the decorator default. "Reset to default" writes the
+                                                    decorator default back to the override path.
+                                                </span>
+                                            </>
+                                        ) : (
+                                            <>No <code>tz_config</code> declared in the decorator — timezone is hard-coded.</>
+                                        )}
+                                    </FieldHint>
+                                </FieldRow>
+                            </>
+                        )}
+                    </div>
+                )}
+            </CardBody>
+        </Card>
+    );
+};
+
+// =============================================================================
 // Main Component
 // =============================================================================
 
@@ -767,6 +1267,8 @@ const AIBundleDashboard: React.FC = () => {
     const [secretsKeyPath, setSecretsKeyPath] = useState<string>('');
     const [secretsValue, setSecretsValue] = useState<string>('');
     const [interfaceBundleId, setInterfaceBundleId] = useState<string>('');
+    const [editorProps, setEditorProps] = useState<Record<string, any>>({});
+    const [editorPropsLoading, setEditorPropsLoading] = useState<boolean>(false);
     const registryScope = useMemo(() => normalizeScope(scopeTenant, scopeProject), [scopeTenant, scopeProject]);
     const propsScope = useMemo(() => normalizeScope(scopeTenant, scopeProject), [scopeTenant, scopeProject]);
     const draftScope = useMemo(() => parseScopeValue(scopeInput), [scopeInput]);
@@ -871,9 +1373,10 @@ const AIBundleDashboard: React.FC = () => {
         return subdir ? `${base}/${subdir}` : base;
     }, [form.repo, form.ref, form.subdir, form.id]);
 
-    const loadBundles = async (scopeOverride?: Scope) => {
+    const loadBundles = async (scopeOverride?: Scope, opts?: { quiet?: boolean }) => {
+        const quiet = opts?.quiet === true;
         try {
-            setLoading(true);
+            if (!quiet) setLoading(true);
             const data = await api.listBundles(scopeOverride ?? registryScope);
             setBundles(data.available_bundles || {});
             setDefaultBundleId(data.default_bundle_id || '');
@@ -887,12 +1390,15 @@ const AIBundleDashboard: React.FC = () => {
             if (!interfaceBundleId || !(interfaceBundleId in (data.available_bundles || {}))) {
                 setInterfaceBundleId(data.default_bundle_id || '');
             }
-            setError(null);
+            if (!quiet) setError(null);
         } catch (e: any) {
-            setError(e.message || 'Failed to load bundles');
-            setBundleAuthority(null);
+            if (!quiet) {
+                setError(e.message || 'Failed to load bundles');
+                setBundleAuthority(null);
+            }
+            throw e;
         } finally {
-            setLoading(false);
+            if (!quiet) setLoading(false);
         }
     };
 
@@ -1077,6 +1583,38 @@ const AIBundleDashboard: React.FC = () => {
         if (!secretsBundleId) return;
         loadSecrets();
     }, [secretsBundleId, scopeTenant, scopeProject]);
+
+    const loadEditorProps = async (bundleId: string) => {
+        if (!bundleId) {
+            setEditorProps({});
+            return;
+        }
+        try {
+            setEditorPropsLoading(true);
+            const data = await api.getBundleProps(bundleId, registryScope);
+            setEditorProps((data?.props as Record<string, any>) || {});
+        } catch {
+            setEditorProps({});
+        } finally {
+            setEditorPropsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadEditorProps(interfaceBundleId);
+    }, [interfaceBundleId, scopeTenant, scopeProject]);
+
+    // Apply a merge-patch to the current bundle's props, then quietly refresh
+    // both the bundles snapshot (for descriptors / pills) and editorProps
+    // (for the editor cards' form values). Avoids the global loading spinner.
+    const saveOverrideAndRefresh = async (patch: Record<string, any>) => {
+        if (!interfaceBundleId) return;
+        await api.setBundleProps(interfaceBundleId, { op: 'merge', props: patch }, registryScope);
+        await Promise.all([
+            loadBundles(registryScope, { quiet: true }).catch(() => undefined),
+            loadEditorProps(interfaceBundleId),
+        ]);
+    };
 
     const resetForm = () => {
         setEditingId(null);
@@ -1697,9 +2235,13 @@ const AIBundleDashboard: React.FC = () => {
                                 <div className="text-sm text-gray-500">No interface declared for this bundle.</div>
                             );
 
+                            const bundleEnabledRaw = (editorProps as any)?.enabled?.bundle;
+                            const bundleEnabledEffective = bundleEnabledRaw === undefined
+                                ? true
+                                : !(bundleEnabledRaw === false || bundleEnabledRaw === 0 || (typeof bundleEnabledRaw === 'string' && ['false','disable','disabled','off','0'].includes(bundleEnabledRaw.trim().toLowerCase())));
                             return (
                                 <div className="space-y-5">
-                                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                                    <div className="flex flex-wrap items-center gap-3 text-xs">
                                         <span className="font-semibold text-gray-700">Bundle visibility:</span>
                                         {allowedRoles.length === 0 ? (
                                             <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-emerald-50 border border-emerald-200 text-emerald-800">
@@ -1712,6 +2254,25 @@ const AIBundleDashboard: React.FC = () => {
                                                 </span>
                                             ))
                                         )}
+                                        <span className="ml-auto inline-flex items-center gap-2">
+                                            <span className="text-gray-700 font-semibold">enabled.bundle:</span>
+                                            <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={bundleEnabledEffective}
+                                                    onChange={async e => {
+                                                        try {
+                                                            await saveOverrideAndRefresh(buildEnabledKindPatch('bundle', null, e.target.checked));
+                                                        } catch (err: any) {
+                                                            setError(err?.message || 'Failed to update enabled.bundle');
+                                                        }
+                                                    }}
+                                                />
+                                                <span className={bundleEnabledEffective ? 'text-emerald-700 font-semibold' : 'text-gray-500 font-semibold'}>
+                                                    {bundleEnabledEffective ? 'enabled' : 'disabled'}
+                                                </span>
+                                            </label>
+                                        </span>
                                     </div>
 
                                     {(b.on_message || b.on_job) && (
@@ -1930,6 +2491,43 @@ const AIBundleDashboard: React.FC = () => {
                         })()}
                     </CardBody>
                 </Card>
+
+                {interfaceBundleId && bundles[interfaceBundleId] && (
+                    <ResourceEditorCard
+                        kind="api"
+                        bundle={bundles[interfaceBundleId]}
+                        editorProps={editorProps}
+                        editorPropsLoading={editorPropsLoading}
+                        onSave={saveOverrideAndRefresh}
+                    />
+                )}
+                {interfaceBundleId && bundles[interfaceBundleId] && (
+                    <ResourceEditorCard
+                        kind="widget"
+                        bundle={bundles[interfaceBundleId]}
+                        editorProps={editorProps}
+                        editorPropsLoading={editorPropsLoading}
+                        onSave={saveOverrideAndRefresh}
+                    />
+                )}
+                {interfaceBundleId && bundles[interfaceBundleId] && (
+                    <ResourceEditorCard
+                        kind="mcp"
+                        bundle={bundles[interfaceBundleId]}
+                        editorProps={editorProps}
+                        editorPropsLoading={editorPropsLoading}
+                        onSave={saveOverrideAndRefresh}
+                    />
+                )}
+                {interfaceBundleId && bundles[interfaceBundleId] && (
+                    <ResourceEditorCard
+                        kind="cron"
+                        bundle={bundles[interfaceBundleId]}
+                        editorProps={editorProps}
+                        editorPropsLoading={editorPropsLoading}
+                        onSave={saveOverrideAndRefresh}
+                    />
+                )}
 
                 <Card>
                     <CardHeader

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
@@ -34,7 +34,13 @@ interface BundleAPIEndpoint {
     http_method: string;
     route: string;
     user_types: string[];
+    user_types_default?: string[];
+    user_types_config?: string | null;
+    user_types_overridden?: boolean;
     roles: string[];
+    roles_default?: string[];
+    roles_config?: string | null;
+    roles_overridden?: boolean;
     enabled_path?: string | null;
 }
 
@@ -42,6 +48,9 @@ interface BundleMCPEndpoint {
     alias: string;
     route: string;
     transport: string;
+    transport_default?: string;
+    transport_config?: string | null;
+    transport_overridden?: boolean;
     enabled_path?: string | null;
 }
 
@@ -49,7 +58,13 @@ interface BundleWidget {
     alias: string;
     icon?: Record<string, string> | null;
     user_types: string[];
+    user_types_default?: string[];
+    user_types_config?: string | null;
+    user_types_overridden?: boolean;
     roles: string[];
+    roles_default?: string[];
+    roles_config?: string | null;
+    roles_overridden?: boolean;
     enabled_path?: string | null;
 }
 
@@ -57,9 +72,13 @@ interface BundleScheduledJob {
     method_name: string;
     alias?: string | null;
     cron_expression?: string | null;
+    cron_expression_default?: string | null;
     expr_config?: string | null;
+    cron_expression_overridden?: boolean;
     timezone?: string | null;
+    timezone_default?: string | null;
     tz_config?: string | null;
+    timezone_overridden?: boolean;
     span?: string | null;
     enabled_path?: string | null;
 }
@@ -527,6 +546,30 @@ const api = new IntegrationsAPI();
 const Card: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className = '' }) => (
     <div className={`bg-white rounded-2xl shadow-sm border border-gray-200/70 ${className}`}>{children}</div>
 );
+
+const OverridableValue: React.FC<{
+    value: string | string[] | null | undefined;
+    defaultValue?: string | string[] | null;
+    overridden?: boolean;
+}> = ({ value, defaultValue, overridden }) => {
+    const display = Array.isArray(value)
+        ? (value.length ? value.join(', ') : '—')
+        : (value || '—');
+    const defaultDisplay = Array.isArray(defaultValue)
+        ? (defaultValue.length ? defaultValue.join(', ') : '—')
+        : (defaultValue || '—');
+    const title = overridden ? `default: ${defaultDisplay}` : undefined;
+    return (
+        <span className="inline-flex items-center gap-1.5" title={title}>
+            <span>{display}</span>
+            {overridden && (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-amber-50 border border-amber-200 text-amber-800 text-[10px] font-semibold uppercase tracking-wide">
+                    overridden
+                </span>
+            )}
+        </span>
+    );
+};
 
 const CardHeader: React.FC<{ title: string; subtitle?: string; action?: React.ReactNode }> = ({ title, subtitle, action }) => (
     <div className="px-6 py-5 border-b border-gray-200/70">
@@ -1619,7 +1662,8 @@ const AIBundleDashboard: React.FC = () => {
                 <Card>
                     <CardHeader
                         title="Bundle interface"
-                        subtitle="Declared APIs, MCP endpoints, and scheduled jobs (cron) for the selected bundle."
+                        subtitle="Declared APIs, MCP endpoints, widgets, and scheduled jobs (cron) for the selected bundle."
+                        action={<Button variant="secondary" onClick={() => loadBundles()}>Refresh</Button>}
                     />
                     <CardBody className="space-y-5">
                         <div>
@@ -1701,7 +1745,9 @@ const AIBundleDashboard: React.FC = () => {
                                                             <th className="px-3 py-2 text-left font-semibold">Method</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Route</th>
                                                             <th className="px-3 py-2 text-left font-semibold">User types</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">User types config</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Roles</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Roles config</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Enabled path</th>
                                                         </tr>
                                                     </thead>
@@ -1711,8 +1757,22 @@ const AIBundleDashboard: React.FC = () => {
                                                                 <td className="px-3 py-2 font-mono font-semibold text-gray-900">{ep.alias}</td>
                                                                 <td className="px-3 py-2 font-mono uppercase text-blue-700">{ep.http_method}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-700">{ep.route}</td>
-                                                                <td className="px-3 py-2 text-gray-600">{ep.user_types?.join(', ') || '—'}</td>
-                                                                <td className="px-3 py-2 text-gray-600">{ep.roles?.join(', ') || '—'}</td>
+                                                                <td className="px-3 py-2 text-gray-600">
+                                                                    <OverridableValue
+                                                                        value={ep.user_types}
+                                                                        defaultValue={ep.user_types_default}
+                                                                        overridden={ep.user_types_overridden}
+                                                                    />
+                                                                </td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{ep.user_types_config || '—'}</td>
+                                                                <td className="px-3 py-2 text-gray-600">
+                                                                    <OverridableValue
+                                                                        value={ep.roles}
+                                                                        defaultValue={ep.roles_default}
+                                                                        overridden={ep.roles_overridden}
+                                                                    />
+                                                                </td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{ep.roles_config || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{ep.enabled_path || '—'}</td>
                                                             </tr>
                                                         ))}
@@ -1735,7 +1795,9 @@ const AIBundleDashboard: React.FC = () => {
                                                             <th className="px-3 py-2 text-left font-semibold">Alias</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Icon</th>
                                                             <th className="px-3 py-2 text-left font-semibold">User types</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">User types config</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Roles</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Roles config</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Enabled path</th>
                                                         </tr>
                                                     </thead>
@@ -1748,8 +1810,22 @@ const AIBundleDashboard: React.FC = () => {
                                                                 <tr key={i} className="hover:bg-gray-50/70">
                                                                     <td className="px-3 py-2 font-mono font-semibold text-gray-900">{w.alias}</td>
                                                                     <td className="px-3 py-2 font-mono text-gray-500">{iconLabel || '—'}</td>
-                                                                    <td className="px-3 py-2 text-gray-600">{w.user_types?.join(', ') || '—'}</td>
-                                                                    <td className="px-3 py-2 text-gray-600">{w.roles?.join(', ') || '—'}</td>
+                                                                    <td className="px-3 py-2 text-gray-600">
+                                                                        <OverridableValue
+                                                                            value={w.user_types}
+                                                                            defaultValue={w.user_types_default}
+                                                                            overridden={w.user_types_overridden}
+                                                                        />
+                                                                    </td>
+                                                                    <td className="px-3 py-2 font-mono text-gray-500">{w.user_types_config || '—'}</td>
+                                                                    <td className="px-3 py-2 text-gray-600">
+                                                                        <OverridableValue
+                                                                            value={w.roles}
+                                                                            defaultValue={w.roles_default}
+                                                                            overridden={w.roles_overridden}
+                                                                        />
+                                                                    </td>
+                                                                    <td className="px-3 py-2 font-mono text-gray-500">{w.roles_config || '—'}</td>
                                                                     <td className="px-3 py-2 font-mono text-gray-500">{w.enabled_path || '—'}</td>
                                                                 </tr>
                                                             );
@@ -1773,6 +1849,7 @@ const AIBundleDashboard: React.FC = () => {
                                                             <th className="px-3 py-2 text-left font-semibold">Alias</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Route</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Transport</th>
+                                                            <th className="px-3 py-2 text-left font-semibold">Transport config</th>
                                                             <th className="px-3 py-2 text-left font-semibold">Enabled path</th>
                                                         </tr>
                                                     </thead>
@@ -1781,7 +1858,14 @@ const AIBundleDashboard: React.FC = () => {
                                                             <tr key={i} className="hover:bg-gray-50/70">
                                                                 <td className="px-3 py-2 font-mono font-semibold text-gray-900">{ep.alias}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-700">{ep.route}</td>
-                                                                <td className="px-3 py-2 text-gray-600">{ep.transport}</td>
+                                                                <td className="px-3 py-2 text-gray-600">
+                                                                    <OverridableValue
+                                                                        value={ep.transport}
+                                                                        defaultValue={ep.transport_default}
+                                                                        overridden={ep.transport_overridden}
+                                                                    />
+                                                                </td>
+                                                                <td className="px-3 py-2 font-mono text-gray-500">{ep.transport_config || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{ep.enabled_path || '—'}</td>
                                                             </tr>
                                                         ))}
@@ -1816,9 +1900,21 @@ const AIBundleDashboard: React.FC = () => {
                                                             <tr key={i} className="hover:bg-gray-50/70">
                                                                 <td className="px-3 py-2 font-mono font-semibold text-gray-900">{job.alias || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-700">{job.method_name}</td>
-                                                                <td className="px-3 py-2 font-mono text-gray-700 whitespace-nowrap">{job.cron_expression || '—'}</td>
+                                                                <td className="px-3 py-2 font-mono text-gray-700 whitespace-nowrap">
+                                                                    <OverridableValue
+                                                                        value={job.cron_expression}
+                                                                        defaultValue={job.cron_expression_default}
+                                                                        overridden={job.cron_expression_overridden}
+                                                                    />
+                                                                </td>
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{job.expr_config || '—'}</td>
-                                                                <td className="px-3 py-2 text-gray-600">{job.timezone || '—'}</td>
+                                                                <td className="px-3 py-2 text-gray-600">
+                                                                    <OverridableValue
+                                                                        value={job.timezone}
+                                                                        defaultValue={job.timezone_default}
+                                                                        overridden={job.timezone_overridden}
+                                                                    />
+                                                                </td>
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{job.tz_config || '—'}</td>
                                                                 <td className="px-3 py-2 text-gray-600">{job.span || '—'}</td>
                                                                 <td className="px-3 py-2 font-mono text-gray-500">{job.enabled_path || '—'}</td>

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
@@ -53,7 +53,6 @@ from kdcube_ai_app.infra.plugin.bundle_store import (
     get_bundle_props as store_get_bundle_props,
     patch_bundle_props as store_patch_bundle_props,
     put_bundle_props as store_put_bundle_props,
-    resolve_dot_path as _resolve_prop_path,
 )
 from kdcube_ai_app.infra.plugin.agentic_loader import (
     AgenticBundleSpec,
@@ -62,6 +61,7 @@ from kdcube_ai_app.infra.plugin.agentic_loader import (
     MCPEndpointSpec,
     UIWidgetSpec,
     cache_key_for_spec,
+    canonical_enabled_path,
     discover_bundle_interface_manifest,
     get_cached_manifest,
     get_workflow_instance_async,
@@ -88,17 +88,8 @@ _integrations_semaphore = None
 _DISABLED_PROP_VALUES: frozenset = frozenset({"false", "disable", "disabled", "off", "0"})
 
 
-def _is_enabled_from_props(props: Dict[str, Any], enabled_config: Optional[str]) -> bool:
-    """Return True if the endpoint/bundle is enabled according to bundle props.
-
-    - No enabled_config declared -> always enabled.
-    - Path absent in props -> enabled (opt-in disabling, not opt-in enabling).
-    - Value is bool/int -> direct truthiness.
-    - Value is string -> disabled only for "false"/"disable"/"disabled"/"off"/"0".
-    """
-    if not enabled_config:
-        return True
-    value = _resolve_prop_path(props, enabled_config)
+def _is_truthy_enabled(value: Any) -> bool:
+    """Interpret a bundle-props value as a feature switch (default = enabled)."""
     if value is None:
         return True
     if isinstance(value, bool):
@@ -106,6 +97,49 @@ def _is_enabled_from_props(props: Dict[str, Any], enabled_config: Optional[str])
     if isinstance(value, int):
         return value != 0
     return str(value).strip().lower() not in _DISABLED_PROP_VALUES
+
+
+def _enabled_section(props: Optional[Dict[str, Any]], kind: str) -> Optional[Dict[str, Any]]:
+    """Return the ``enabled.<kind>`` sub-dict from bundle props, or None if absent."""
+    section = (props or {}).get("enabled")
+    if not isinstance(section, dict):
+        return None
+    sub = section.get(kind)
+    if not isinstance(sub, dict):
+        return None
+    return sub
+
+
+def is_bundle_enabled(props: Optional[Dict[str, Any]]) -> bool:
+    """Resolve ``enabled.bundle`` against bundle props (default = enabled)."""
+    section = (props or {}).get("enabled")
+    if not isinstance(section, dict):
+        return True
+    return _is_truthy_enabled(section.get("bundle"))
+
+
+def is_api_enabled(props: Optional[Dict[str, Any]], spec: APIEndpointSpec) -> bool:
+    """Resolve ``enabled.api["<alias>.<METHOD>"]`` (flat key with literal dot)."""
+    sub = _enabled_section(props, "api")
+    if sub is None:
+        return True
+    return _is_truthy_enabled(sub.get(f"{spec.alias}.{spec.http_method}"))
+
+
+def is_widget_enabled(props: Optional[Dict[str, Any]], spec: UIWidgetSpec) -> bool:
+    """Resolve ``enabled.widget.<alias>`` (nested)."""
+    sub = _enabled_section(props, "widget")
+    if sub is None:
+        return True
+    return _is_truthy_enabled(sub.get(spec.alias))
+
+
+def is_mcp_enabled(props: Optional[Dict[str, Any]], spec: MCPEndpointSpec) -> bool:
+    """Resolve ``enabled.mcp.<alias>`` (nested)."""
+    sub = _enabled_section(props, "mcp")
+    if sub is None:
+        return True
+    return _is_truthy_enabled(sub.get(spec.alias))
 
 
 def _resolve_integrations_limit() -> Optional[int]:
@@ -864,7 +898,7 @@ async def _get_bundle_manifest(
 def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]:
     """Serialise a full (unfiltered) manifest to a plain dict."""
     return {
-        "enabled_config": manifest.enabled_config,
+        "enabled_path": canonical_enabled_path("bundle"),
         "apis": [
             {
                 "alias": s.alias,
@@ -872,7 +906,7 @@ def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]
                 "route": s.route,
                 "user_types": list(s.user_types),
                 "roles": list(s.roles),
-                "enabled_config": s.enabled_config,
+                "enabled_path": canonical_enabled_path("api", alias=s.alias, http_method=s.http_method),
             }
             for s in manifest.api_endpoints
         ],
@@ -881,7 +915,7 @@ def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]
                 "alias": s.alias,
                 "route": s.route,
                 "transport": s.transport,
-                "enabled_config": s.enabled_config,
+                "enabled_path": canonical_enabled_path("mcp", alias=s.alias),
             }
             for s in manifest.mcp_endpoints
         ],
@@ -891,7 +925,7 @@ def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]
                 "icon": s.icon,
                 "user_types": list(s.user_types),
                 "roles": list(s.roles),
-                "enabled_config": s.enabled_config,
+                "enabled_path": canonical_enabled_path("widget", alias=s.alias),
             }
             for s in manifest.ui_widgets
         ],
@@ -906,7 +940,7 @@ def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]
                 "timezone": s.timezone,
                 "tz_config": s.tz_config,
                 "span": s.span,
-                "enabled_config": s.enabled_config,
+                "enabled_path": canonical_enabled_path("cron", alias=s.alias),
             }
             for s in manifest.scheduled_jobs
         ],
@@ -919,7 +953,7 @@ def _manifest_to_descriptor_filtered(
 ) -> Dict[str, Any]:
     """Serialise a manifest filtered to the endpoint visibility rules for session."""
     return {
-        "enabled_config": manifest.enabled_config,
+        "enabled_path": canonical_enabled_path("bundle"),
         "apis": [
             {
                 "alias": s.alias,
@@ -927,7 +961,7 @@ def _manifest_to_descriptor_filtered(
                 "route": s.route,
                 "user_types": list(s.user_types),
                 "roles": list(s.roles),
-                "enabled_config": s.enabled_config,
+                "enabled_path": canonical_enabled_path("api", alias=s.alias, http_method=s.http_method),
             }
             for s in manifest.api_endpoints
             if _endpoint_visible(s.user_types, s.roles, session)
@@ -937,7 +971,7 @@ def _manifest_to_descriptor_filtered(
                 "alias": s.alias,
                 "route": s.route,
                 "transport": s.transport,
-                "enabled_config": s.enabled_config,
+                "enabled_path": canonical_enabled_path("mcp", alias=s.alias),
             }
             for s in manifest.mcp_endpoints
         ],
@@ -947,7 +981,7 @@ def _manifest_to_descriptor_filtered(
                 "icon": s.icon,
                 "user_types": list(s.user_types),
                 "roles": list(s.roles),
-                "enabled_config": s.enabled_config,
+                "enabled_path": canonical_enabled_path("widget", alias=s.alias),
             }
             for s in manifest.ui_widgets
             if _endpoint_visible(s.user_types, s.roles, session)
@@ -963,7 +997,7 @@ def _manifest_to_descriptor_filtered(
                 "timezone": s.timezone,
                 "tz_config": s.tz_config,
                 "span": s.span,
-                "enabled_config": s.enabled_config,
+                "enabled_path": canonical_enabled_path("cron", alias=s.alias),
             }
             for s in manifest.scheduled_jobs
         ],
@@ -1056,9 +1090,9 @@ async def get_bundles(
         )
         if not _bundle_allowed_for_session(manifest, session):
             continue
-        if manifest is not None and manifest.enabled_config:
+        if manifest is not None:
             props = await store_get_bundle_props(redis, tenant=tenant_id, project=project_id, bundle_id=bid)
-            if not _is_enabled_from_props(props, manifest.enabled_config):
+            if not is_bundle_enabled(props):
                 continue
         descriptor: Dict[str, Any] = {
             "id": bid,
@@ -2054,7 +2088,7 @@ async def get_bundle_interface(
                 "timezone": spec.timezone,
                 "tz_config": spec.tz_config,
                 "span": spec.span,
-                "enabled_config": spec.enabled_config,
+                "enabled_path": canonical_enabled_path("cron", alias=spec.alias),
             }
             for spec in manifest.scheduled_jobs
         ],
@@ -2130,9 +2164,9 @@ async def _fetch_bundle_widget_payload(
         _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
     )
     workflow_props = _apply_rest_bundle_props_to_workflow(workflow=workflow, props=_props)
-    if not _is_enabled_from_props(_props, manifest.enabled_config):
+    if not is_bundle_enabled(_props):
         raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
-    if not _is_enabled_from_props(_props, widget_spec.enabled_config):
+    if not is_widget_enabled(_props, widget_spec):
         raise HTTPException(status_code=404, detail=f"Bundle widget {widget_alias} is not available")
 
     widget_static_cfg = None
@@ -2304,9 +2338,9 @@ async def _serve_static_widget_app(
         _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
     )
     workflow_props = _apply_rest_bundle_props_to_workflow(workflow=workflow, props=_props)
-    if not _is_enabled_from_props(_props, manifest.enabled_config):
+    if not is_bundle_enabled(_props):
         raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
-    if not _is_enabled_from_props(_props, widget_spec.enabled_config):
+    if not is_widget_enabled(_props, widget_spec):
         raise HTTPException(status_code=404, detail=f"Bundle widget {widget_alias} is not available")
     widget_static_cfg = None
     if not _static_widget_explicitly_disabled(_props or {}, widget_alias=widget_spec.alias):
@@ -2659,9 +2693,9 @@ async def _call_bundle_mcp_inner(
         _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
     )
     _apply_rest_bundle_props_to_workflow(workflow=workflow, props=_props)
-    if not _is_enabled_from_props(_props, manifest.enabled_config):
+    if not is_bundle_enabled(_props):
         raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
-    if not _is_enabled_from_props(_props, endpoint_spec.enabled_config):
+    if not is_mcp_enabled(_props, endpoint_spec):
         raise HTTPException(status_code=404, detail=f"Bundle MCP endpoint {endpoint_alias} is not available")
 
     try:
@@ -3068,9 +3102,9 @@ async def _call_bundle_op_inner(
         _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
     )
     _apply_rest_bundle_props_to_workflow(workflow=workflow, props=_props)
-    if not _is_enabled_from_props(_props, manifest.enabled_config):
+    if not is_bundle_enabled(_props):
         raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
-    if not _is_enabled_from_props(_props, endpoint_spec.enabled_config):
+    if not is_api_enabled(_props, endpoint_spec):
         raise HTTPException(status_code=404, detail=f"Bundle operation {operation} is not available")
 
     try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
@@ -60,6 +60,9 @@ from kdcube_ai_app.infra.plugin.agentic_loader import (
     BundleInterfaceManifest,
     MCPEndpointSpec,
     UIWidgetSpec,
+    apply_api_overrides,
+    apply_mcp_overrides,
+    apply_widget_overrides,
     cache_key_for_spec,
     canonical_enabled_path,
     discover_bundle_interface_manifest,
@@ -389,17 +392,42 @@ def _user_types_visible(required_user_types: tuple[str, ...] | list[str] | None,
     return current_rank >= min(thresholds)
 
 
-def _visible_widget_specs(manifest: BundleInterfaceManifest, session: UserSession) -> list[UIWidgetSpec]:
-    return [spec for spec in manifest.ui_widgets if _endpoint_visible(spec.user_types, spec.roles, session)]
+def _visible_widget_specs(
+        manifest: BundleInterfaceManifest,
+        session: UserSession,
+        props: Optional[Dict[str, Any]] = None,
+) -> list[UIWidgetSpec]:
+    """Return widget specs visible to ``session``, with bundle-props overrides applied."""
+    out: list[UIWidgetSpec] = []
+    for spec in manifest.ui_widgets:
+        effective = apply_widget_overrides(spec, props or {})
+        if _endpoint_visible(effective.user_types, effective.roles, session):
+            out.append(effective)
+    return out
 
 
-def _visible_api_specs(manifest: BundleInterfaceManifest, session: UserSession) -> list[APIEndpointSpec]:
-    return [spec for spec in manifest.api_endpoints if _endpoint_visible(spec.user_types, spec.roles, session)]
+def _visible_api_specs(
+        manifest: BundleInterfaceManifest,
+        session: UserSession,
+        props: Optional[Dict[str, Any]] = None,
+) -> list[APIEndpointSpec]:
+    """Return API specs visible to ``session``, with bundle-props overrides applied."""
+    out: list[APIEndpointSpec] = []
+    for spec in manifest.api_endpoints:
+        effective = apply_api_overrides(spec, props or {})
+        if _endpoint_visible(effective.user_types, effective.roles, session):
+            out.append(effective)
+    return out
 
 
-def _visible_mcp_specs(manifest: BundleInterfaceManifest, session: UserSession) -> list[MCPEndpointSpec]:
+def _visible_mcp_specs(
+        manifest: BundleInterfaceManifest,
+        session: UserSession,
+        props: Optional[Dict[str, Any]] = None,
+) -> list[MCPEndpointSpec]:
+    """Return MCP specs with bundle-props overrides applied (no visibility filtering)."""
     del session
-    return list(manifest.mcp_endpoints)
+    return [apply_mcp_overrides(spec, props or {}) for spec in manifest.mcp_endpoints]
 
 
 def _user_raw_roles(session: UserSession) -> set[str]:
@@ -895,114 +923,148 @@ async def _get_bundle_manifest(
         return None
 
 
-def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]:
-    """Serialise a full (unfiltered) manifest to a plain dict."""
+def _api_spec_descriptor(spec: APIEndpointSpec, props: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    effective = apply_api_overrides(spec, props or {})
+    return {
+        "alias": spec.alias,
+        "http_method": spec.http_method,
+        "route": spec.route,
+        "user_types": list(effective.user_types),
+        "user_types_default": list(spec.user_types),
+        "user_types_config": spec.user_types_config,
+        "user_types_overridden": tuple(effective.user_types) != tuple(spec.user_types),
+        "roles": list(effective.roles),
+        "roles_default": list(spec.roles),
+        "roles_config": spec.roles_config,
+        "roles_overridden": tuple(effective.roles) != tuple(spec.roles),
+        "enabled_path": canonical_enabled_path("api", alias=spec.alias, http_method=spec.http_method),
+    }
+
+
+def _widget_spec_descriptor(spec: UIWidgetSpec, props: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    effective = apply_widget_overrides(spec, props or {})
+    return {
+        "alias": spec.alias,
+        "icon": spec.icon,
+        "user_types": list(effective.user_types),
+        "user_types_default": list(spec.user_types),
+        "user_types_config": spec.user_types_config,
+        "user_types_overridden": tuple(effective.user_types) != tuple(spec.user_types),
+        "roles": list(effective.roles),
+        "roles_default": list(spec.roles),
+        "roles_config": spec.roles_config,
+        "roles_overridden": tuple(effective.roles) != tuple(spec.roles),
+        "enabled_path": canonical_enabled_path("widget", alias=spec.alias),
+    }
+
+
+def _mcp_spec_descriptor(spec: MCPEndpointSpec, props: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    effective = apply_mcp_overrides(spec, props or {})
+    return {
+        "alias": spec.alias,
+        "route": spec.route,
+        "transport": effective.transport,
+        "transport_default": spec.transport,
+        "transport_config": spec.transport_config,
+        "transport_overridden": effective.transport != spec.transport,
+        "enabled_path": canonical_enabled_path("mcp", alias=spec.alias),
+    }
+
+
+def _cron_spec_descriptor(spec, props: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Serialise a CronJobSpec, computing effective cron_expression / timezone
+    after expr_config / tz_config overrides applied against bundle props."""
+    from kdcube_ai_app.apps.chat.sdk.runtime.bundle_scheduler import (
+        resolve_effective_cron,
+        resolve_effective_timezone,
+    )
+    effective_cron = resolve_effective_cron(
+        cron_expression=spec.cron_expression,
+        expr_config=spec.expr_config,
+        props=props or {},
+    )
+    effective_tz = resolve_effective_timezone(
+        timezone_name=spec.timezone,
+        tz_config=spec.tz_config,
+        props=props or {},
+    )
+    default_tz = (str(spec.timezone).strip() if spec.timezone else "UTC") or "UTC"
+    return {
+        "method_name": spec.method_name,
+        "alias": spec.alias,
+        "cron_expression": effective_cron,
+        "cron_expression_default": spec.cron_expression,
+        "expr_config": spec.expr_config,
+        "cron_expression_overridden": (
+            spec.expr_config is not None and effective_cron != spec.cron_expression
+        ),
+        "timezone": effective_tz,
+        "timezone_default": default_tz,
+        "tz_config": spec.tz_config,
+        "timezone_overridden": (
+            spec.tz_config is not None and effective_tz != default_tz
+        ),
+        "span": spec.span,
+        "enabled_path": canonical_enabled_path("cron", alias=spec.alias),
+    }
+
+
+def _manifest_to_descriptor(
+        manifest: BundleInterfaceManifest,
+        props: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Serialise a full (unfiltered) manifest to a plain dict.
+
+    When ``props`` is provided, effective values reflect bundle-props overrides
+    via ``*_config`` paths; otherwise effective == decorator defaults.
+    """
     return {
         "enabled_path": canonical_enabled_path("bundle"),
         "allowed_roles": list(manifest.allowed_roles),
-        "apis": [
-            {
-                "alias": s.alias,
-                "http_method": s.http_method,
-                "route": s.route,
-                "user_types": list(s.user_types),
-                "roles": list(s.roles),
-                "enabled_path": canonical_enabled_path("api", alias=s.alias, http_method=s.http_method),
-            }
-            for s in manifest.api_endpoints
-        ],
-        "mcp_endpoints": [
-            {
-                "alias": s.alias,
-                "route": s.route,
-                "transport": s.transport,
-                "enabled_path": canonical_enabled_path("mcp", alias=s.alias),
-            }
-            for s in manifest.mcp_endpoints
-        ],
-        "widgets": [
-            {
-                "alias": s.alias,
-                "icon": s.icon,
-                "user_types": list(s.user_types),
-                "roles": list(s.roles),
-                "enabled_path": canonical_enabled_path("widget", alias=s.alias),
-            }
-            for s in manifest.ui_widgets
-        ],
+        "apis": [_api_spec_descriptor(s, props) for s in manifest.api_endpoints],
+        "mcp_endpoints": [_mcp_spec_descriptor(s, props) for s in manifest.mcp_endpoints],
+        "widgets": [_widget_spec_descriptor(s, props) for s in manifest.ui_widgets],
         "on_message": manifest.on_message.method_name if manifest.on_message else None,
         "on_job": manifest.on_job.method_name if manifest.on_job else None,
-        "scheduled_jobs": [
-            {
-                "method_name": s.method_name,
-                "alias": s.alias,
-                "cron_expression": s.cron_expression,
-                "expr_config": s.expr_config,
-                "timezone": s.timezone,
-                "tz_config": s.tz_config,
-                "span": s.span,
-                "enabled_path": canonical_enabled_path("cron", alias=s.alias),
-            }
-            for s in manifest.scheduled_jobs
-        ],
+        "scheduled_jobs": [_cron_spec_descriptor(s, props=props) for s in manifest.scheduled_jobs],
     }
 
 
 def _manifest_to_descriptor_filtered(
         manifest: BundleInterfaceManifest,
         session: UserSession,
+        props: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Serialise a manifest filtered to the endpoint visibility rules for session."""
+    """Serialise a manifest filtered to the endpoint visibility rules for session.
+
+    Visibility is checked against the **effective** user_types/roles (after
+    bundle-props overrides have been applied).
+    """
     return {
         "enabled_path": canonical_enabled_path("bundle"),
         "allowed_roles": list(manifest.allowed_roles),
         "apis": [
-            {
-                "alias": s.alias,
-                "http_method": s.http_method,
-                "route": s.route,
-                "user_types": list(s.user_types),
-                "roles": list(s.roles),
-                "enabled_path": canonical_enabled_path("api", alias=s.alias, http_method=s.http_method),
-            }
+            _api_spec_descriptor(s, props)
             for s in manifest.api_endpoints
-            if _endpoint_visible(s.user_types, s.roles, session)
+            if _endpoint_visible(
+                apply_api_overrides(s, props or {}).user_types,
+                apply_api_overrides(s, props or {}).roles,
+                session,
+            )
         ],
-        "mcp_endpoints": [
-            {
-                "alias": s.alias,
-                "route": s.route,
-                "transport": s.transport,
-                "enabled_path": canonical_enabled_path("mcp", alias=s.alias),
-            }
-            for s in manifest.mcp_endpoints
-        ],
+        "mcp_endpoints": [_mcp_spec_descriptor(s, props) for s in manifest.mcp_endpoints],
         "widgets": [
-            {
-                "alias": s.alias,
-                "icon": s.icon,
-                "user_types": list(s.user_types),
-                "roles": list(s.roles),
-                "enabled_path": canonical_enabled_path("widget", alias=s.alias),
-            }
+            _widget_spec_descriptor(s, props)
             for s in manifest.ui_widgets
-            if _endpoint_visible(s.user_types, s.roles, session)
+            if _endpoint_visible(
+                apply_widget_overrides(s, props or {}).user_types,
+                apply_widget_overrides(s, props or {}).roles,
+                session,
+            )
         ],
         "on_message": manifest.on_message.method_name if manifest.on_message else None,
         "on_job": manifest.on_job.method_name if manifest.on_job else None,
-        "scheduled_jobs": [
-            {
-                "method_name": s.method_name,
-                "alias": s.alias,
-                "cron_expression": s.cron_expression,
-                "expr_config": s.expr_config,
-                "timezone": s.timezone,
-                "tz_config": s.tz_config,
-                "span": s.span,
-                "enabled_path": canonical_enabled_path("cron", alias=s.alias),
-            }
-            for s in manifest.scheduled_jobs
-        ],
+        "scheduled_jobs": [_cron_spec_descriptor(s, props=props) for s in manifest.scheduled_jobs],
     }
 
 
@@ -1023,6 +1085,7 @@ async def get_available_bundles(
     except Exception:
         raise HTTPException(status_code=503, detail="Failed to load bundles registry for tenant/project")
 
+    redis = _get_app_redis(request)
     bundles_out = {}
     for bid, entry in reg.bundles.items():
         manifest = await _get_bundle_manifest(
@@ -1046,7 +1109,8 @@ async def get_available_bundles(
             "git_commit": getattr(entry, "git_commit", None),
         }
         if manifest is not None:
-            descriptor.update(_manifest_to_descriptor(manifest))
+            props = await store_get_bundle_props(redis, tenant=tenant_id, project=project_id, bundle_id=bid)
+            descriptor.update(_manifest_to_descriptor(manifest, props=props))
         bundles_out[bid] = descriptor
 
     return {
@@ -1092,6 +1156,7 @@ async def get_bundles(
         )
         if not _bundle_allowed_for_session(manifest, session):
             continue
+        props: Optional[Dict[str, Any]] = None
         if manifest is not None:
             props = await store_get_bundle_props(redis, tenant=tenant_id, project=project_id, bundle_id=bid)
             if not is_bundle_enabled(props):
@@ -1104,7 +1169,7 @@ async def get_bundles(
             "version": getattr(entry, "version", None),
         }
         if manifest is not None:
-            descriptor.update(_manifest_to_descriptor_filtered(manifest, session))
+            descriptor.update(_manifest_to_descriptor_filtered(manifest, session, props=props))
         bundles_out[bid] = descriptor
 
     return {
@@ -2030,9 +2095,12 @@ async def get_bundle_interface(
         )
     )
     manifest = discover_bundle_interface_manifest(workflow, bundle_id=spec_resolved.id)
-    visible_widgets = _visible_widget_specs(manifest, session)
-    visible_apis = _visible_api_specs(manifest, session)
-    visible_mcp_endpoints = _visible_mcp_specs(manifest, session)
+    _props = await store_get_bundle_props(
+        _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
+    )
+    visible_widgets = _visible_widget_specs(manifest, session, props=_props)
+    visible_apis = _visible_api_specs(manifest, session, props=_props)
+    visible_mcp_endpoints = _visible_mcp_specs(manifest, session, props=_props)
     return {
         "status": "ok",
         "tenant": tenant_id,
@@ -2081,19 +2149,7 @@ async def get_bundle_interface(
             if manifest.on_job
             else None
         ),
-        "scheduled_jobs": [
-            {
-                "method_name": spec.method_name,
-                "alias": spec.alias,
-                "cron_expression": spec.cron_expression,
-                "expr_config": spec.expr_config,
-                "timezone": spec.timezone,
-                "tz_config": spec.tz_config,
-                "span": spec.span,
-                "enabled_path": canonical_enabled_path("cron", alias=spec.alias),
-            }
-            for spec in manifest.scheduled_jobs
-        ],
+        "scheduled_jobs": [_cron_spec_descriptor(s, props=_props) for s in manifest.scheduled_jobs],
     }
 
 
@@ -2158,13 +2214,14 @@ async def _fetch_bundle_widget_payload(
     widget_spec = resolve_bundle_widget(workflow, alias=widget_alias, bundle_id=spec_resolved.id)
     if widget_spec is None:
         raise HTTPException(status_code=404, detail=f"Bundle does not define widget {widget_alias}")
-    if not _endpoint_visible(widget_spec.user_types, widget_spec.roles, session):
-        raise HTTPException(status_code=403, detail=f"Bundle widget {widget_alias} is not visible to this user")
 
     manifest = discover_bundle_interface_manifest(workflow, bundle_id=spec_resolved.id)
     _props = await store_get_bundle_props(
         _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
     )
+    widget_spec = apply_widget_overrides(widget_spec, _props)
+    if not _endpoint_visible(widget_spec.user_types, widget_spec.roles, session):
+        raise HTTPException(status_code=403, detail=f"Bundle widget {widget_alias} is not visible to this user")
     workflow_props = _apply_rest_bundle_props_to_workflow(workflow=workflow, props=_props)
     if not is_bundle_enabled(_props):
         raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
@@ -2332,13 +2389,14 @@ async def _serve_static_widget_app(
     widget_spec = resolve_bundle_widget(workflow, alias=widget_alias, bundle_id=spec_resolved.id)
     if widget_spec is None:
         raise HTTPException(status_code=404, detail=f"Bundle does not define widget {widget_alias}")
-    if not _endpoint_visible(widget_spec.user_types, widget_spec.roles, session):
-        raise HTTPException(status_code=403, detail=f"Bundle widget {widget_alias} is not visible to this user")
 
     manifest = discover_bundle_interface_manifest(workflow, bundle_id=spec_resolved.id)
     _props = await store_get_bundle_props(
         _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
     )
+    widget_spec = apply_widget_overrides(widget_spec, _props)
+    if not _endpoint_visible(widget_spec.user_types, widget_spec.roles, session):
+        raise HTTPException(status_code=403, detail=f"Bundle widget {widget_alias} is not visible to this user")
     workflow_props = _apply_rest_bundle_props_to_workflow(workflow=workflow, props=_props)
     if not is_bundle_enabled(_props):
         raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
@@ -2694,6 +2752,7 @@ async def _call_bundle_mcp_inner(
     _props = await store_get_bundle_props(
         _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
     )
+    endpoint_spec = apply_mcp_overrides(endpoint_spec, _props)
     _apply_rest_bundle_props_to_workflow(workflow=workflow, props=_props)
     if not is_bundle_enabled(_props):
         raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")
@@ -3096,13 +3155,14 @@ async def _call_bundle_op_inner(
         operation=operation,
         request=request,
     )
-    if not _endpoint_visible(endpoint_spec.user_types, endpoint_spec.roles, session):
-        raise HTTPException(status_code=403, detail=f"Bundle operation {operation} is not visible to this user")
 
     manifest = discover_bundle_interface_manifest(workflow, bundle_id=spec_resolved.id)
     _props = await store_get_bundle_props(
         _get_app_redis(request), tenant=tenant_id, project=project_id, bundle_id=spec_resolved.id,
     )
+    endpoint_spec = apply_api_overrides(endpoint_spec, _props)
+    if not _endpoint_visible(endpoint_spec.user_types, endpoint_spec.roles, session):
+        raise HTTPException(status_code=403, detail=f"Bundle operation {operation} is not visible to this user")
     _apply_rest_bundle_props_to_workflow(workflow=workflow, props=_props)
     if not is_bundle_enabled(_props):
         raise HTTPException(status_code=404, detail=f"Bundle {spec_resolved.id} is disabled")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
@@ -899,6 +899,7 @@ def _manifest_to_descriptor(manifest: BundleInterfaceManifest) -> Dict[str, Any]
     """Serialise a full (unfiltered) manifest to a plain dict."""
     return {
         "enabled_path": canonical_enabled_path("bundle"),
+        "allowed_roles": list(manifest.allowed_roles),
         "apis": [
             {
                 "alias": s.alias,
@@ -954,6 +955,7 @@ def _manifest_to_descriptor_filtered(
     """Serialise a manifest filtered to the endpoint visibility rules for session."""
     return {
         "enabled_path": canonical_enabled_path("bundle"),
+        "allowed_roles": list(manifest.allowed_roles),
         "apis": [
             {
                 "alias": s.alias,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
@@ -1742,6 +1742,20 @@ class EnhancedChatRequestProcessor:
                 backoff = 0.5
                 self._last_config_error = None
 
+                # Catch-up reconcile: pubsub does not buffer, so any
+                # bundles.update / bundles.props.update event published while
+                # this listener was disconnected was lost. Sync scheduler state
+                # to current Redis registry/props on every (re)subscribe.
+                if self._scheduler is not None:
+                    try:
+                        current_reg = await store_load(self.redis)
+                        await self._scheduler.reconcile(current_reg)
+                    except Exception:
+                        logger.warning(
+                            "Catch-up bundle scheduler reconcile after (re)subscribe failed",
+                            exc_info=True,
+                        )
+
                 while not self._stop_event.is_set():
                     try:
                         message = await asyncio.wait_for(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/bundle_scheduler.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/bundle_scheduler.py
@@ -101,35 +101,33 @@ def resolve_effective_cron(
 _SCHEDULER_DISABLED_VALUES: frozenset = frozenset({"false", "disable", "disabled", "off", "0"})
 
 
-def resolve_effective_enabled(
-    enabled_config: Optional[str],
-    props: Dict[str, Any],
-) -> bool:
-    """Return False if the job should be suppressed based on bundle props.
+def _resolve_scheduler_enabled_value(path: str, props: Dict[str, Any]) -> Any:
+    """Look up an ``enabled.*`` value with descriptor-file fallback.
 
     Resolution order (mirrors resolve_effective_cron):
     1. Redis bundle props (dot-path lookup in props dict).
     2. bundles.yaml / assembly.yaml via read_plain, when the path is absent
-       from Redis props (value is None after step 1).
-    3. Default: True (enabled) when the path is absent from both sources.
-
-    Falsy values: False (bool), 0 (int), or any of
-    "false" / "disable" / "disabled" / "off" / "0" (case-insensitive string).
+       from Redis props.
     """
-    if not enabled_config:
-        return True
     from kdcube_ai_app.infra.plugin.bundle_store import resolve_dot_path
-    value = resolve_dot_path(props, enabled_config)
-    if value is None:
-        try:
-            from kdcube_ai_app.apps.chat.sdk.config import read_plain
-            raw = read_plain(f"b:{enabled_config}", default=None)
-            if raw is None:
-                raw = read_plain(enabled_config, default=None)
-            if raw is not None:
-                value = raw
-        except Exception:
-            pass
+    value = resolve_dot_path(props, path)
+    if value is not None:
+        return value
+    try:
+        from kdcube_ai_app.apps.chat.sdk.config import read_plain
+        raw = read_plain(f"b:{path}", default=None)
+        if raw is None:
+            raw = read_plain(path, default=None)
+        if raw is not None:
+            return raw
+    except Exception:
+        pass
+    return None
+
+
+def _is_truthy_enabled(value: Any) -> bool:
+    """Default = enabled. Falsy values: False/0 or
+    "false"/"disable"/"disabled"/"off"/"0" (case-insensitive)."""
     if value is None:
         return True
     if isinstance(value, bool):
@@ -137,6 +135,18 @@ def resolve_effective_enabled(
     if isinstance(value, int):
         return value != 0
     return str(value).strip().lower() not in _SCHEDULER_DISABLED_VALUES
+
+
+def is_bundle_enabled(props: Dict[str, Any]) -> bool:
+    """Resolve the canonical ``enabled.bundle`` switch."""
+    return _is_truthy_enabled(_resolve_scheduler_enabled_value("enabled.bundle", props))
+
+
+def is_cron_job_enabled(props: Dict[str, Any], alias: str) -> bool:
+    """Resolve the canonical ``enabled.cron.<alias>`` switch."""
+    return _is_truthy_enabled(
+        _resolve_scheduler_enabled_value(f"enabled.cron.{alias}", props)
+    )
 
 
 def resolve_effective_timezone(
@@ -595,12 +605,11 @@ class BundleSchedulerManager:
                 props=props,
             )
 
-            manifest_enabled_config = getattr(manifest, "enabled_config", None)
-            if not resolve_effective_enabled(manifest_enabled_config, props):
+            if not is_bundle_enabled(props):
                 _log.info(
-                    "[scheduler] Bundle disabled via enabled_config: bundle=%s enabled_config=%r"
+                    "[scheduler] Bundle disabled via enabled.bundle: bundle=%s"
                     " - skipping all jobs",
-                    bundle_id, manifest_enabled_config,
+                    bundle_id,
                 )
                 continue
 
@@ -627,12 +636,10 @@ class BundleSchedulerManager:
                     )
                     continue
 
-                job_enabled_config = getattr(job_spec, "enabled_config", None)
-                if not resolve_effective_enabled(job_enabled_config, props):
+                if not is_cron_job_enabled(props, job_spec.alias):
                     _log.info(
-                        "[scheduler] Job disabled via enabled_config: bundle=%s alias=%s "
-                        "enabled_config=%r",
-                        bundle_id, job_spec.alias, job_enabled_config,
+                        "[scheduler] Job disabled via enabled.cron.<alias>: bundle=%s alias=%s",
+                        bundle_id, job_spec.alias,
                     )
                     continue
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_descriptor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/bundle_scheduler/test_descriptor.py
@@ -113,6 +113,8 @@ def test_descriptor_filtered_includes_scheduled_jobs_regardless_of_role():
 
 
 def test_descriptor_preserves_all_fields():
+    """Cron descriptor exposes both the effective values (after expr_config /
+    tz_config overrides) and the decorator-declared defaults."""
     job = CronJobSpec(
         method_name="my_method",
         alias="my-alias",
@@ -122,12 +124,36 @@ def test_descriptor_preserves_all_fields():
         tz_config="some.timezone.path",
         span="instance",
     )
+    # No props: expr_config / tz_config paths do not resolve; effective cron
+    # is None (job not scheduled), effective timezone falls back to decorator
+    # default.
     desc = _manifest_to_descriptor(_make_manifest([job]))
     serialized = desc["scheduled_jobs"][0]
     assert serialized["method_name"] == "my_method"
     assert serialized["alias"] == "my-alias"
-    assert serialized["cron_expression"] == "*/30 * * * *"
+    assert serialized["cron_expression"] is None
+    assert serialized["cron_expression_default"] == "*/30 * * * *"
     assert serialized["expr_config"] == "some.config.path"
     assert serialized["timezone"] == "Europe/Berlin"
+    assert serialized["timezone_default"] == "Europe/Berlin"
     assert serialized["tz_config"] == "some.timezone.path"
     assert serialized["span"] == "instance"
+
+    # With props that resolve the override paths, effective values reflect
+    # the override and the *_overridden flags are set.
+    desc2 = _manifest_to_descriptor(
+        _make_manifest([job]),
+        props={
+            "some": {
+                "config": {"path": "*/15 * * * *"},
+                "timezone": {"path": "UTC"},
+            },
+        },
+    )
+    serialized2 = desc2["scheduled_jobs"][0]
+    assert serialized2["cron_expression"] == "*/15 * * * *"
+    assert serialized2["cron_expression_default"] == "*/30 * * * *"
+    assert serialized2["cron_expression_overridden"] is True
+    assert serialized2["timezone"] == "UTC"
+    assert serialized2["timezone_default"] == "Europe/Berlin"
+    assert serialized2["timezone_overridden"] is True

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
@@ -79,7 +79,6 @@ class APIEndpointSpec:
     user_types: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
     public_auth: "PublicAPIAuthSpec | None" = None
-    enabled_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -88,7 +87,6 @@ class MCPEndpointSpec:
     alias: str
     route: str = "operations"
     transport: str = "streamable-http"
-    enabled_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -105,7 +103,6 @@ class UIWidgetSpec:
     icon: dict[str, str]
     user_types: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
-    enabled_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -132,7 +129,6 @@ class CronJobSpec:
     timezone: str | None = None
     tz_config: str | None = None
     span: str = "system"
-    enabled_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -146,7 +142,45 @@ class BundleInterfaceManifest:
     on_message: OnMessageSpec | None = None
     on_job: OnJobSpec | None = None
     scheduled_jobs: tuple[CronJobSpec, ...] = ()
-    enabled_config: str | None = None
+
+
+_VALID_ENABLED_KINDS: frozenset = frozenset({"bundle", "api", "mcp", "widget", "cron"})
+
+
+def canonical_enabled_path(
+        kind: str,
+        *,
+        alias: str | None = None,
+        http_method: str | None = None,
+) -> str:
+    """Return the canonical bundle-props dot-path for a feature switch.
+
+    Mapping:
+      - kind="bundle"           -> "enabled.bundle"
+      - kind="api"              -> "enabled.api.<alias>.<METHOD>"  (flat, with literal dot)
+      - kind in {mcp, widget, cron} -> "enabled.<kind>.<alias>"
+
+    Aliases must not contain dots; for "api" this keeps the flat key
+    "<alias>.<METHOD>" unambiguous.
+    """
+    norm_kind = str(kind or "").strip().lower()
+    if norm_kind not in _VALID_ENABLED_KINDS:
+        raise ValueError(f"Unsupported enabled kind: {kind!r}")
+    if norm_kind == "bundle":
+        return "enabled.bundle"
+    norm_alias = str(alias or "").strip()
+    if not norm_alias:
+        raise ValueError(f"alias is required for enabled kind {norm_kind!r}")
+    if "." in norm_alias:
+        raise ValueError(
+            f"alias for enabled kind {norm_kind!r} must not contain '.': {alias!r}"
+        )
+    if norm_kind == "api":
+        norm_method = str(http_method or "").strip().upper()
+        if not norm_method:
+            raise ValueError("http_method is required for enabled kind 'api'")
+        return f"enabled.api.{norm_alias}.{norm_method}"
+    return f"enabled.{norm_kind}.{norm_alias}"
 
 
 def _clean_alias(value: str | None, default: str) -> str:
@@ -317,7 +351,6 @@ def agentic_workflow(
         version: str | None = None,
         priority: int = 100,
         allowed_roles: List[str] | Tuple[str, ...] | None = None,
-        enabled_config: str | None = None,
 ):
     """
     Mark a CLASS as the bundle's workflow CLASS.
@@ -331,16 +364,16 @@ def agentic_workflow(
         the session) intersect with allowed_roles will see this bundle.
         Empty or None means visible to all authenticated users.
 
-    enabled_config: dot-separated path into bundle props that resolves to a
-        boolean. If the resolved value is falsy, all inbound routes for this
-        bundle return 404. Absent or None means always enabled.
+    Bundle-level feature gating uses the canonical bundle-props path
+    ``enabled.bundle`` (resolved by the platform). When that value is falsy,
+    all inbound routes for the bundle return 404 and scheduled jobs are not
+    reconciled.
     """
     def _wrap(cls):
         setattr(cls, AGENTIC_ROLE_ATTR, "workflow_class")
         setattr(cls, AGENTIC_META_ATTR, {
             "name": name, "version": version, "priority": priority,
             "allowed_roles": _tuple_str(allowed_roles),
-            "enabled_config": str(enabled_config).strip() if enabled_config else None,
         })
         return cls
     return _wrap
@@ -376,7 +409,6 @@ def api(
         user_types: List[str] | Tuple[str, ...] | None = None,
         roles: List[str] | Tuple[str, ...] | None = None,
         public_auth: str | Dict[str, Any] | None = None,
-        enabled_config: str | None = None,
 ):
     http_method = _normalize_http_method(method)
     resolved_route = _normalize_api_route(route)
@@ -385,21 +417,27 @@ def api(
         user_types=user_types,
         roles=roles,
     )
-    resolved_enabled_config = str(enabled_config).strip() if enabled_config else None
 
     def _wrap(fn):
+        method_name = getattr(fn, "__name__", "api_method")
+        resolved_alias = _clean_alias(alias, method_name)
+        if "." in resolved_alias:
+            raise ValueError(
+                f"@api alias must not contain '.': {resolved_alias!r}. "
+                f"Aliases are mapped to the canonical enabled path "
+                f"'enabled.api.<alias>.<METHOD>' (flat key with a literal dot)."
+            )
         setattr(
             fn,
             API_METHOD_ATTR,
             APIEndpointSpec(
-                method_name=getattr(fn, "__name__", "api_method"),
-                alias=_clean_alias(alias, getattr(fn, "__name__", "api_method")),
+                method_name=method_name,
+                alias=resolved_alias,
                 http_method=http_method,
                 route=resolved_route,
                 user_types=resolved_user_types,
                 roles=resolved_roles,
                 public_auth=resolved_public_auth,
-                enabled_config=resolved_enabled_config,
             ),
         )
         return fn
@@ -413,25 +451,30 @@ def ui_widget(
         alias: str | None = None,
         user_types: List[str] | Tuple[str, ...] | None = None,
         roles: List[str] | Tuple[str, ...] | None = None,
-        enabled_config: str | None = None,
 ):
     resolved_user_types, resolved_roles = _normalize_visibility_selectors(
         user_types=user_types,
         roles=roles,
     )
-    resolved_enabled_config = str(enabled_config).strip() if enabled_config else None
 
     def _wrap(fn):
+        method_name = getattr(fn, "__name__", "widget")
+        resolved_alias = _clean_alias(alias, method_name)
+        if "." in resolved_alias:
+            raise ValueError(
+                f"@ui_widget alias must not contain '.': {resolved_alias!r}. "
+                f"Aliases are mapped to the canonical enabled path "
+                f"'enabled.widget.<alias>'."
+            )
         setattr(
             fn,
             UI_WIDGET_ATTR,
             UIWidgetSpec(
-                method_name=getattr(fn, "__name__", "widget"),
-                alias=_clean_alias(alias, getattr(fn, "__name__", "widget")),
+                method_name=method_name,
+                alias=resolved_alias,
                 icon=_normalize_icon_spec(icon),
                 user_types=resolved_user_types,
                 roles=resolved_roles,
-                enabled_config=resolved_enabled_config,
             ),
         )
         return fn
@@ -447,7 +490,6 @@ def mcp(
         user_types: List[str] | Tuple[str, ...] | None = None,
         roles: List[str] | Tuple[str, ...] | None = None,
         public_auth: str | Dict[str, Any] | None = None,
-        enabled_config: str | None = None,
 ):
     resolved_route = _normalize_api_route(route)
     resolved_transport = _normalize_mcp_transport(transport)
@@ -456,18 +498,24 @@ def mcp(
             "@mcp(...) does not support proc-side visibility or public_auth. "
             "MCP request authentication/authorization must be handled by the bundle MCP app."
         )
-    resolved_enabled_config = str(enabled_config).strip() if enabled_config else None
 
     def _wrap(fn):
+        method_name = getattr(fn, "__name__", "mcp")
+        resolved_alias = _clean_alias(alias, method_name)
+        if "." in resolved_alias:
+            raise ValueError(
+                f"@mcp alias must not contain '.': {resolved_alias!r}. "
+                f"Aliases are mapped to the canonical enabled path "
+                f"'enabled.mcp.<alias>'."
+            )
         setattr(
             fn,
             MCP_ENDPOINT_ATTR,
             MCPEndpointSpec(
-                method_name=getattr(fn, "__name__", "mcp"),
-                alias=_clean_alias(alias, getattr(fn, "__name__", "mcp")),
+                method_name=method_name,
+                alias=resolved_alias,
                 route=resolved_route,
                 transport=resolved_transport,
-                enabled_config=resolved_enabled_config,
             ),
         )
         return fn
@@ -555,7 +603,6 @@ def cron(
         timezone: str | None = None,
         tz_config: str | None = None,
         span: str = "system",
-        enabled_config: str | None = None,
 ):
     """
     Mark a bundle method as a scheduled job.
@@ -575,31 +622,38 @@ def cron(
             it takes precedence over ``timezone`` at runtime.
         span: exclusivity level — one of ``"process"``, ``"instance"``,
             ``"system"``. Defaults to ``"system"``.
-        enabled_config: dot-separated path into bundle props that resolves to
-            a boolean. If the resolved value is falsy, the job is not scheduled.
-            Absent or None means always enabled.
+
+    Feature gating uses the canonical bundle-props path
+    ``enabled.cron.<alias>`` (resolved by the platform). When that value is
+    falsy, the job is not scheduled. Bundle-level ``enabled.bundle = false``
+    overrides per-job values.
     """
     span_norm = str(span).strip().lower() if span else "system"
     if span_norm not in _VALID_CRON_SPANS:
         raise ValueError(
             f"Invalid cron span: {span!r}. Must be one of: process, instance, system"
         )
-    resolved_enabled_config = str(enabled_config).strip() if enabled_config else None
 
     def _wrap(fn):
         method_name = getattr(fn, "__name__", "cron_job")
+        resolved_alias = _clean_alias(alias, method_name)
+        if "." in resolved_alias:
+            raise ValueError(
+                f"@cron alias must not contain '.': {resolved_alias!r}. "
+                f"Aliases are mapped to the canonical enabled path "
+                f"'enabled.cron.<alias>'."
+            )
         setattr(
             fn,
             CRON_JOB_ATTR,
             CronJobSpec(
                 method_name=method_name,
-                alias=_clean_alias(alias, method_name),
+                alias=resolved_alias,
                 cron_expression=str(cron_expression).strip() if cron_expression is not None else None,
                 expr_config=str(expr_config).strip() if expr_config is not None else None,
                 timezone=str(timezone).strip() if timezone is not None else None,
                 tz_config=str(tz_config).strip() if tz_config is not None else None,
                 span=span_norm,
-                enabled_config=resolved_enabled_config,
             ),
         )
         return fn
@@ -1739,7 +1793,6 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 user_types=tuple(api_spec.user_types or ()),
                 roles=tuple(api_spec.roles or ()),
                 public_auth=api_spec.public_auth,
-                enabled_config=api_spec.enabled_config,
             )
             api_key = (resolved.alias, resolved.http_method, resolved.route)
             if api_key in seen_api:
@@ -1757,7 +1810,6 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 alias=mcp_spec.alias,
                 route=mcp_spec.route,
                 transport=mcp_spec.transport,
-                enabled_config=mcp_spec.enabled_config,
             )
             mcp_key = (resolved.alias, resolved.route)
             if mcp_key in seen_mcp:
@@ -1776,7 +1828,6 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 icon=dict(widget_spec.icon or {}),
                 user_types=tuple(widget_spec.user_types or ()),
                 roles=tuple(widget_spec.roles or ()),
-                enabled_config=widget_spec.enabled_config,
             )
             if resolved.alias in seen_widgets:
                 raise ValueError(f"Duplicate bundle widget alias detected: {resolved.alias}")
@@ -1814,12 +1865,10 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 timezone=cron_spec.timezone,
                 tz_config=cron_spec.tz_config,
                 span=cron_spec.span,
-                enabled_config=cron_spec.enabled_config,
             ))
 
     meta = getattr(cls, AGENTIC_META_ATTR, {}) or {}
     allowed_roles: tuple[str, ...] = _tuple_str(meta.get("allowed_roles"))
-    bundle_enabled_config: str | None = str(meta.get("enabled_config") or "").strip() or None
 
     api_endpoints.sort(key=lambda item: (item.alias, item.route, item.http_method, item.method_name))
     mcp_endpoints.sort(key=lambda item: (item.alias, item.route, item.transport, item.method_name))
@@ -1828,7 +1877,6 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
     return BundleInterfaceManifest(
         bundle_id=resolved_bundle_id,
         allowed_roles=allowed_roles,
-        enabled_config=bundle_enabled_config,
         ui_widgets=tuple(ui_widgets),
         api_endpoints=tuple(api_endpoints),
         mcp_endpoints=tuple(mcp_endpoints),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
@@ -22,6 +22,7 @@ import subprocess
 import threading
 import traceback
 import time
+import dataclasses
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, Tuple, Any, Dict, List
@@ -77,7 +78,9 @@ class APIEndpointSpec:
     http_method: str = "POST"
     route: str = "operations"
     user_types: tuple[str, ...] = ()
+    user_types_config: str | None = None
     roles: tuple[str, ...] = ()
+    roles_config: str | None = None
     public_auth: "PublicAPIAuthSpec | None" = None
 
 
@@ -87,6 +90,7 @@ class MCPEndpointSpec:
     alias: str
     route: str = "operations"
     transport: str = "streamable-http"
+    transport_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -102,7 +106,9 @@ class UIWidgetSpec:
     alias: str
     icon: dict[str, str]
     user_types: tuple[str, ...] = ()
+    user_types_config: str | None = None
     roles: tuple[str, ...] = ()
+    roles_config: str | None = None
 
 
 @dataclass(frozen=True)
@@ -157,11 +163,17 @@ def canonical_enabled_path(
 
     Mapping:
       - kind="bundle"           -> "enabled.bundle"
-      - kind="api"              -> "enabled.api.<alias>.<METHOD>"  (flat, with literal dot)
+      - kind="api"              -> "enabled.api.<alias>.<METHOD>"
+        (flat key under ``enabled.api`` whose name is the literal string
+        ``<alias>.<METHOD>``; if ``<alias>`` itself contains dots they remain
+        part of the same flat key)
       - kind in {mcp, widget, cron} -> "enabled.<kind>.<alias>"
+        (alias is a single map key under ``enabled.<kind>``, dots in the alias
+        are part of that key)
 
-    Aliases must not contain dots; for "api" this keeps the flat key
-    "<alias>.<METHOD>" unambiguous.
+    The returned string is for display; runtime gating uses direct dict lookup
+    at the section level, so dots in the alias are treated as literal
+    characters in the key, not path separators.
     """
     norm_kind = str(kind or "").strip().lower()
     if norm_kind not in _VALID_ENABLED_KINDS:
@@ -171,16 +183,106 @@ def canonical_enabled_path(
     norm_alias = str(alias or "").strip()
     if not norm_alias:
         raise ValueError(f"alias is required for enabled kind {norm_kind!r}")
-    if "." in norm_alias:
-        raise ValueError(
-            f"alias for enabled kind {norm_kind!r} must not contain '.': {alias!r}"
-        )
     if norm_kind == "api":
         norm_method = str(http_method or "").strip().upper()
         if not norm_method:
             raise ValueError("http_method is required for enabled kind 'api'")
         return f"enabled.api.{norm_alias}.{norm_method}"
     return f"enabled.{norm_kind}.{norm_alias}"
+
+
+def _resolve_override_value(config_path: str | None, props: dict[str, Any]) -> Any:
+    """Resolve a ``*_config`` dot-path against bundle props, with descriptor-file
+    fallback (mirrors ``resolve_effective_cron``).
+
+    Returns ``None`` when ``config_path`` is empty or the path is unresolvable.
+    """
+    if not config_path:
+        return None
+    from kdcube_ai_app.infra.plugin.bundle_store import resolve_dot_path
+    value = resolve_dot_path(props, config_path)
+    if value is not None:
+        return value
+    try:
+        from kdcube_ai_app.apps.chat.sdk.config import read_plain
+        raw = read_plain(f"b:{config_path}", default=None)
+        if raw is None:
+            raw = read_plain(config_path, default=None)
+        if raw is not None:
+            return raw
+    except Exception:
+        pass
+    return None
+
+
+def _coerce_string_list_override(value: Any) -> tuple[str, ...] | None:
+    """Coerce a resolved override into a tuple of strings.
+
+    - ``None`` (path missing) -> ``None``
+    - single string -> 1-tuple
+    - list/tuple of strings -> tuple (empty list kept as empty tuple, intentional override)
+    - anything else -> ``None`` (invalid type, caller falls back to default)
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, (list, tuple)):
+        out: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                return None
+            out.append(item)
+        return tuple(out)
+    return None
+
+
+def _coerce_string_override(value: Any) -> str | None:
+    """Coerce a resolved override into a non-blank string, or None on miss."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def apply_api_overrides(spec: APIEndpointSpec, props: dict[str, Any]) -> APIEndpointSpec:
+    """Return a new APIEndpointSpec with bundle-props overrides applied for any
+    fields whose ``*_config`` path resolves to a valid value."""
+    user_types = _coerce_string_list_override(_resolve_override_value(spec.user_types_config, props))
+    roles = _coerce_string_list_override(_resolve_override_value(spec.roles_config, props))
+    if user_types is None and roles is None:
+        return spec
+    return dataclasses.replace(
+        spec,
+        user_types=user_types if user_types is not None else spec.user_types,
+        roles=roles if roles is not None else spec.roles,
+    )
+
+
+def apply_widget_overrides(spec: UIWidgetSpec, props: dict[str, Any]) -> UIWidgetSpec:
+    user_types = _coerce_string_list_override(_resolve_override_value(spec.user_types_config, props))
+    roles = _coerce_string_list_override(_resolve_override_value(spec.roles_config, props))
+    if user_types is None and roles is None:
+        return spec
+    return dataclasses.replace(
+        spec,
+        user_types=user_types if user_types is not None else spec.user_types,
+        roles=roles if roles is not None else spec.roles,
+    )
+
+
+def apply_mcp_overrides(spec: MCPEndpointSpec, props: dict[str, Any]) -> MCPEndpointSpec:
+    raw = _coerce_string_override(_resolve_override_value(spec.transport_config, props))
+    if raw is None:
+        return spec
+    try:
+        normalized = _normalize_mcp_transport(raw)
+    except ValueError:
+        # Invalid transport override -> keep decorator default. Caller may log.
+        return spec
+    return dataclasses.replace(spec, transport=normalized)
 
 
 def _clean_alias(value: str | None, default: str) -> str:
@@ -407,9 +509,19 @@ def api(
         alias: str | None = None,
         route: str = "operations",
         user_types: List[str] | Tuple[str, ...] | None = None,
+        user_types_config: str | None = None,
         roles: List[str] | Tuple[str, ...] | None = None,
+        roles_config: str | None = None,
         public_auth: str | Dict[str, Any] | None = None,
 ):
+    """
+    ``user_types`` / ``roles`` are decorator defaults — the contract baseline
+    declared in code. ``user_types_config`` / ``roles_config`` are dot-paths
+    into bundle props; when set and resolvable, the resolved value overrides
+    the decorator default at request time. Empty list resolves to "no
+    restriction" (intentional override). Invalid types fall back silently to
+    the decorator default.
+    """
     http_method = _normalize_http_method(method)
     resolved_route = _normalize_api_route(route)
     resolved_public_auth = _normalize_public_api_auth(resolved_route, public_auth)
@@ -417,16 +529,12 @@ def api(
         user_types=user_types,
         roles=roles,
     )
+    resolved_user_types_config = str(user_types_config).strip() if user_types_config else None
+    resolved_roles_config = str(roles_config).strip() if roles_config else None
 
     def _wrap(fn):
         method_name = getattr(fn, "__name__", "api_method")
         resolved_alias = _clean_alias(alias, method_name)
-        if "." in resolved_alias:
-            raise ValueError(
-                f"@api alias must not contain '.': {resolved_alias!r}. "
-                f"Aliases are mapped to the canonical enabled path "
-                f"'enabled.api.<alias>.<METHOD>' (flat key with a literal dot)."
-            )
         setattr(
             fn,
             API_METHOD_ATTR,
@@ -436,7 +544,9 @@ def api(
                 http_method=http_method,
                 route=resolved_route,
                 user_types=resolved_user_types,
+                user_types_config=resolved_user_types_config,
                 roles=resolved_roles,
+                roles_config=resolved_roles_config,
                 public_auth=resolved_public_auth,
             ),
         )
@@ -450,22 +560,25 @@ def ui_widget(
         icon: str | Dict[str, str],
         alias: str | None = None,
         user_types: List[str] | Tuple[str, ...] | None = None,
+        user_types_config: str | None = None,
         roles: List[str] | Tuple[str, ...] | None = None,
+        roles_config: str | None = None,
 ):
+    """
+    ``user_types`` / ``roles`` are decorator defaults. ``user_types_config`` /
+    ``roles_config`` are dot-paths into bundle props; when set and resolvable,
+    the resolved value overrides the decorator default at request time.
+    """
     resolved_user_types, resolved_roles = _normalize_visibility_selectors(
         user_types=user_types,
         roles=roles,
     )
+    resolved_user_types_config = str(user_types_config).strip() if user_types_config else None
+    resolved_roles_config = str(roles_config).strip() if roles_config else None
 
     def _wrap(fn):
         method_name = getattr(fn, "__name__", "widget")
         resolved_alias = _clean_alias(alias, method_name)
-        if "." in resolved_alias:
-            raise ValueError(
-                f"@ui_widget alias must not contain '.': {resolved_alias!r}. "
-                f"Aliases are mapped to the canonical enabled path "
-                f"'enabled.widget.<alias>'."
-            )
         setattr(
             fn,
             UI_WIDGET_ATTR,
@@ -474,7 +587,9 @@ def ui_widget(
                 alias=resolved_alias,
                 icon=_normalize_icon_spec(icon),
                 user_types=resolved_user_types,
+                user_types_config=resolved_user_types_config,
                 roles=resolved_roles,
+                roles_config=resolved_roles_config,
             ),
         )
         return fn
@@ -487,10 +602,17 @@ def mcp(
         alias: str | None = None,
         route: str = "operations",
         transport: str = "streamable-http",
+        transport_config: str | None = None,
         user_types: List[str] | Tuple[str, ...] | None = None,
         roles: List[str] | Tuple[str, ...] | None = None,
         public_auth: str | Dict[str, Any] | None = None,
 ):
+    """
+    ``transport`` is the decorator default. ``transport_config`` is a dot-path
+    into bundle props; when set and resolvable, the resolved value overrides
+    the decorator default at request time. Invalid transport values (not in
+    the supported set) fall back silently to the decorator default.
+    """
     resolved_route = _normalize_api_route(route)
     resolved_transport = _normalize_mcp_transport(transport)
     if user_types or roles or public_auth is not None:
@@ -498,16 +620,11 @@ def mcp(
             "@mcp(...) does not support proc-side visibility or public_auth. "
             "MCP request authentication/authorization must be handled by the bundle MCP app."
         )
+    resolved_transport_config = str(transport_config).strip() if transport_config else None
 
     def _wrap(fn):
         method_name = getattr(fn, "__name__", "mcp")
         resolved_alias = _clean_alias(alias, method_name)
-        if "." in resolved_alias:
-            raise ValueError(
-                f"@mcp alias must not contain '.': {resolved_alias!r}. "
-                f"Aliases are mapped to the canonical enabled path "
-                f"'enabled.mcp.<alias>'."
-            )
         setattr(
             fn,
             MCP_ENDPOINT_ATTR,
@@ -516,6 +633,7 @@ def mcp(
                 alias=resolved_alias,
                 route=resolved_route,
                 transport=resolved_transport,
+                transport_config=resolved_transport_config,
             ),
         )
         return fn
@@ -1791,7 +1909,9 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 http_method=api_spec.http_method,
                 route=api_spec.route,
                 user_types=tuple(api_spec.user_types or ()),
+                user_types_config=api_spec.user_types_config,
                 roles=tuple(api_spec.roles or ()),
+                roles_config=api_spec.roles_config,
                 public_auth=api_spec.public_auth,
             )
             api_key = (resolved.alias, resolved.http_method, resolved.route)
@@ -1810,6 +1930,7 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 alias=mcp_spec.alias,
                 route=mcp_spec.route,
                 transport=mcp_spec.transport,
+                transport_config=mcp_spec.transport_config,
             )
             mcp_key = (resolved.alias, resolved.route)
             if mcp_key in seen_mcp:
@@ -1827,7 +1948,9 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
                 alias=widget_spec.alias,
                 icon=dict(widget_spec.icon or {}),
                 user_types=tuple(widget_spec.user_types or ()),
+                user_types_config=widget_spec.user_types_config,
                 roles=tuple(widget_spec.roles or ()),
+                roles_config=widget_spec.roles_config,
             )
             if resolved.alias in seen_widgets:
                 raise ValueError(f"Duplicate bundle widget alias detected: {resolved.alias}")


### PR DESCRIPTION
## Summary                                                                                                                                                                 
                                                                                                                                                                             
  Builds out admin observability and runtime control over bundle decorator                                                                                                   
  surfaces, replacing the per-decorator `enabled_config="..."` parameter                                                                                                     
  with a canonical bundle-props convention and adding in-place editing                                                                                                       
  from the Bundle Interface dashboard.                                                                                                                                       
                                                                                                                                                                             
  ### Platform                                                                                                                                                               
                                                                                                                                                                             
  - **Canonical `enabled.*` feature gate.** Drops the `enabled_config=`                                                                                                      
    argument from `@agentic_workflow`, `@api`, `@mcp`, `@ui_widget`,                                                                                                         
    `@cron` in favour of a fixed bundle-props section the platform                                                                                                           
    derives from decorator metadata:                                                                                                                                         
      ```                                                                                                                                                                    
      enabled:                                                                                                                                                               
        bundle: true|false                                                                                                                                                   
        api:    { "<alias>.<METHOD>": true|false }   # flat key, literal dot                                                                                               
        mcp:    { <alias>: true|false }                                                                                                                                      
        widget: { <alias>: true|false }                                                                                                                                      
        cron:   { <alias>: true|false }                                                                                                                                    
      ```
  - **`*_config` opt-in for dynamic overrides.** Authors can declare                                                                                                         
    `user_types_config` / `roles_config` on `@api` and `@ui_widget`, and                                                                                                     
    `transport_config` on `@mcp` (mirroring `@cron`'s                                                                                                                        
    `expr_config` / `tz_config`). When the dot-path resolves against                                                                                                         
    bundle props, the resolved value replaces the decorator default at                                                                                                       
    request time. Empty list / invalid types fall back silently.
    
      ### Admin dashboard                                                                                                                                                        
                                                                                                                                                                           
  - New "Bundle interface" card showing every decorator surface with                                                                                                         
    effective + `*_default` + `*_config` + `*_overridden` state.
    Separate `*_config` columns; amber "overridden" pill on changed                                                                                                          
    values; widgets and `allowed_roles` surfaced.                                                                                                                            
  - 4 in-place edit cards (API / Widget / MCP / Cron) — combobox +                                                                                                           
    form + Save / Reset. Inline `enabled.bundle` toggle on the                                                                                                               
    visibility row.                                                                                                                                                          
  - Saves go through the existing `bundles/{id}/props` endpoint                                                                                                              
    (`op: merge`);
  - Cron Reset preserves the documented platform contract: writes the                                                                                                        
    decorator default back at the override path (rather than null) so                                                                                                        
    jobs keep running. Form initial values mirror the raw override path                                                                                                      
    so explicit `disable` / blank stay visible.                                                                                                                              
  - Refresh button on the card.
 