### PR TITLE
feat(bundle): make bundle allowed_roles configurable via bundle props

### DIFF
--- a/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-platform-integration-README.md
@@ -127,14 +127,16 @@ Use it when the code should declare its own stable bundle identity.
 
 ### 1.3 `@agentic_workflow(...)` — bundle-level `allowed_roles`
 
-The `@agentic_workflow` decorator accepts an optional `allowed_roles` parameter
-that restricts which users can see the bundle in the bundle listing.
+The `@agentic_workflow` decorator accepts optional `allowed_roles` and
+`allowed_roles_config` parameters that restrict which users can see the bundle
+in the bundle listing.
 
 ```python
 @agentic_workflow(
     name="Finance Copilot",
     version="1.0.0",
     allowed_roles=("kdcube:role:finance-team", "kdcube:role:super-admin"),
+    allowed_roles_config="visibility.bundle.allowed_roles",
 )
 @bundle_id("finance.copilot@1.0.0")
 class FinanceCopilot:
@@ -149,6 +151,13 @@ Current fields relevant to access control:
   - do **not** use derived platform types here (`"registered"`, `"privileged"`)
   - empty or omitted means the bundle is visible to all authenticated users
   - OR semantics: user passes if at least one of their raw roles matches
+- `allowed_roles_config`
+  - optional dot-path into bundle props, e.g. `"visibility.bundle.allowed_roles"`
+  - when set and the path resolves to a list of strings, the resolved value
+    overrides the decorator default at listing time (per-request lookup)
+  - empty list `[]` is a valid intentional override meaning "visible to all"
+  - invalid types or a missing path fall back silently to the decorator default
+  - when declared, the field becomes editable in the Bundle Admin dashboard
 - bundle-level feature gate: `enabled.bundle` in bundle props
   - boolean (or string equivalent) that controls the whole bundle
   - if the resolved value is falsy, the bundle is treated as disabled:
@@ -161,12 +170,14 @@ Current fields relevant to access control:
 Current behavior:
 
 - `GET /api/integrations/bundles` (non-admin) filters out bundles whose
-  `allowed_roles` do not intersect with the calling user's raw roles
-  (entries in the session that start with `kdcube:role:`)
+  effective `allowed_roles` do not intersect with the calling user's raw roles
+  (entries in the session that start with `kdcube:role:`).
+  Bundle props are loaded before the check so `allowed_roles_config` overrides
+  are applied at listing time.
 - `GET /api/admin/integrations/bundles` is not filtered — admin always
   sees all bundles regardless of `allowed_roles`
-- A bundle with no `allowed_roles` is always included for any authenticated
-  user (backwards-compatible default)
+- A bundle with no effective `allowed_roles` is always included for any
+  authenticated user (backwards-compatible default)
 
 ### 1.3.1 Canonical `enabled.*` Contract
 
@@ -781,6 +792,7 @@ class CronJobSpec:
 class BundleInterfaceManifest:
     bundle_id: str
     allowed_roles: tuple[str, ...] = ()
+    allowed_roles_config: str | None = None
     ui_widgets: tuple[UIWidgetSpec, ...] = ()
     api_endpoints: tuple[APIEndpointSpec, ...] = ()
     mcp_endpoints: tuple[MCPEndpointSpec, ...] = ()
@@ -792,6 +804,13 @@ class BundleInterfaceManifest:
 
 `allowed_roles` is populated from the `allowed_roles` argument of
 `@agentic_workflow`. Empty tuple means no restriction.
+
+`allowed_roles_config` is the dot-path declared via `allowed_roles_config=` on
+`@agentic_workflow`. When set, `apply_bundle_overrides(manifest, props)` resolves
+the path against bundle props and returns a new manifest with the effective
+`allowed_roles`. The admin descriptor exposes `allowed_roles_default`,
+`allowed_roles_config`, and `allowed_roles_overridden` alongside the effective
+`allowed_roles`.
 
 `scheduled_jobs` is populated from all `@cron`-decorated methods on the
 entrypoint class, sorted by `alias`.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/AIBundleDashboard.tsx
@@ -103,6 +103,9 @@ interface BundleEntry {
     on_job?: string | null;
     enabled_path?: string | null;
     allowed_roles?: string[] | null;
+    allowed_roles_default?: string[] | null;
+    allowed_roles_config?: string | null;
+    allowed_roles_overridden?: boolean;
 }
 
 interface BundlesResponse {
@@ -1278,6 +1281,10 @@ const AIBundleDashboard: React.FC = () => {
     const [interfaceBundleId, setInterfaceBundleId] = useState<string>('');
     const [editorProps, setEditorProps] = useState<Record<string, any>>({});
     const [editorPropsLoading, setEditorPropsLoading] = useState<boolean>(false);
+    const [formBundleRoles, setFormBundleRoles] = useState<string>('');
+    const [bundleRolesSaving, setBundleRolesSaving] = useState<boolean>(false);
+    const [bundleRolesFlash, setBundleRolesFlash] = useState<string | null>(null);
+    const [bundleRolesError, setBundleRolesError] = useState<string | null>(null);
     const registryScope = useMemo(() => normalizeScope(scopeTenant, scopeProject), [scopeTenant, scopeProject]);
     const propsScope = useMemo(() => normalizeScope(scopeTenant, scopeProject), [scopeTenant, scopeProject]);
     const draftScope = useMemo(() => parseScopeValue(scopeInput), [scopeInput]);
@@ -1614,6 +1621,13 @@ const AIBundleDashboard: React.FC = () => {
     useEffect(() => {
         loadEditorProps(interfaceBundleId);
     }, [interfaceBundleId, scopeTenant, scopeProject]);
+
+    useEffect(() => {
+        const b = interfaceBundleId ? bundles[interfaceBundleId] : null;
+        setBundleRolesFlash(null);
+        setBundleRolesError(null);
+        setFormBundleRoles(b && Array.isArray(b.allowed_roles) ? b.allowed_roles.join(', ') : '');
+    }, [interfaceBundleId, bundles]);
 
     // Apply a merge-patch to the current bundle's props, then quietly refresh
     // both the bundles snapshot (for descriptors / pills) and editorProps
@@ -2264,18 +2278,6 @@ const AIBundleDashboard: React.FC = () => {
                             return (
                                 <div className="space-y-5">
                                     <div className="flex flex-wrap items-center gap-3 text-xs">
-                                        <span className="font-semibold text-gray-700">Bundle visibility:</span>
-                                        {allowedRoles.length === 0 ? (
-                                            <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-emerald-50 border border-emerald-200 text-emerald-800">
-                                                Visible to all authenticated users
-                                            </span>
-                                        ) : (
-                                            allowedRoles.map((r, i) => (
-                                                <span key={i} className="inline-flex items-center px-2.5 py-1 rounded-full bg-indigo-50 border border-indigo-200 font-mono text-indigo-800">
-                                                    {r}
-                                                </span>
-                                            ))
-                                        )}
                                         <span className="ml-auto inline-flex items-center gap-2">
                                             <span className="text-gray-700 font-semibold">enabled.bundle:</span>
                                             <label className="inline-flex items-center gap-1.5 cursor-pointer">
@@ -2296,6 +2298,61 @@ const AIBundleDashboard: React.FC = () => {
                                             </label>
                                         </span>
                                     </div>
+
+                                    <FieldRow
+                                        label="Allowed roles"
+                                        overridden={b.allowed_roles_overridden}
+                                        configurable={Boolean(b.allowed_roles_config)}
+                                        onResetToDefault={b.allowed_roles_config && b.allowed_roles_overridden ? async () => {
+                                            setBundleRolesError(null);
+                                            try {
+                                                setBundleRolesSaving(true);
+                                                await saveOverrideAndRefresh(nestedDotPathPatch(b.allowed_roles_config!, null));
+                                                setBundleRolesFlash('Reset ✓');
+                                                window.setTimeout(() => setBundleRolesFlash(null), 1800);
+                                            } catch (e: any) {
+                                                setBundleRolesError(e?.message || 'Reset failed');
+                                            } finally {
+                                                setBundleRolesSaving(false);
+                                            }
+                                        } : undefined}
+                                        hint={b.allowed_roles_config
+                                            ? <>Override path: <code>{b.allowed_roles_config}</code>. Comma-separated. Empty saves an explicit empty list (visible to all).</>
+                                            : <>No <code>allowed_roles_config</code> declared in the decorator — value is hard-coded.</>}
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            <input
+                                                value={formBundleRoles}
+                                                onChange={e => setFormBundleRoles(e.target.value)}
+                                                disabled={!b.allowed_roles_config || bundleRolesSaving || editorPropsLoading}
+                                                placeholder="kdcube:role:editor, kdcube:role:viewer"
+                                                className="flex-1 px-3 py-2 border border-gray-200/80 rounded-xl bg-white text-sm font-mono disabled:bg-gray-50 disabled:text-gray-400"
+                                            />
+                                            {b.allowed_roles_config && (
+                                                <Button
+                                                    variant="primary"
+                                                    disabled={bundleRolesSaving || editorPropsLoading}
+                                                    onClick={async () => {
+                                                        setBundleRolesError(null);
+                                                        try {
+                                                            setBundleRolesSaving(true);
+                                                            await saveOverrideAndRefresh(nestedDotPathPatch(b.allowed_roles_config!, parseChips(formBundleRoles)));
+                                                            setBundleRolesFlash('Saved ✓');
+                                                            window.setTimeout(() => setBundleRolesFlash(null), 1800);
+                                                        } catch (e: any) {
+                                                            setBundleRolesError(e?.message || 'Save failed');
+                                                        } finally {
+                                                            setBundleRolesSaving(false);
+                                                        }
+                                                    }}
+                                                >
+                                                    {bundleRolesSaving ? 'Saving…' : 'Save'}
+                                                </Button>
+                                            )}
+                                            {bundleRolesFlash && <span className="text-xs text-emerald-700 font-semibold">{bundleRolesFlash}</span>}
+                                            {bundleRolesError && <span className="text-xs text-red-700">{bundleRolesError}</span>}
+                                        </div>
+                                    </FieldRow>
 
                                     {(b.on_message || b.on_job) && (
                                         <div className="flex flex-wrap gap-3 text-xs text-gray-600">

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/rest/integrations/integrations.py
@@ -61,6 +61,7 @@ from kdcube_ai_app.infra.plugin.agentic_loader import (
     MCPEndpointSpec,
     UIWidgetSpec,
     apply_api_overrides,
+    apply_bundle_overrides,
     apply_mcp_overrides,
     apply_widget_overrides,
     cache_key_for_spec,
@@ -443,12 +444,20 @@ def _endpoint_visible(
     return _user_types_visible(required_user_types, session) and _raw_roles_visible(required_roles, session)
 
 
-def _bundle_allowed_for_session(manifest: "BundleInterfaceManifest | None", session: UserSession) -> bool:
+def _bundle_allowed_for_session(
+        manifest: "BundleInterfaceManifest | None",
+        session: UserSession,
+        props: Optional[Dict[str, Any]] = None,
+) -> bool:
     """Bundle-level access check based on allowed_roles declared on @agentic_workflow.
-    No allowed_roles (empty) means the bundle is visible to all authenticated users."""
-    if manifest is None or not manifest.allowed_roles:
+    No allowed_roles (empty) means the bundle is visible to all authenticated users.
+    When props are provided, allowed_roles_config overrides are applied first."""
+    if manifest is None:
         return True
-    return bool(_user_raw_roles(session) & set(manifest.allowed_roles))
+    effective = apply_bundle_overrides(manifest, props or {})
+    if not effective.allowed_roles:
+        return True
+    return bool(_user_raw_roles(session) & set(effective.allowed_roles))
 
 
 router = APIRouter()
@@ -1018,9 +1027,13 @@ def _manifest_to_descriptor(
     When ``props`` is provided, effective values reflect bundle-props overrides
     via ``*_config`` paths; otherwise effective == decorator defaults.
     """
+    effective = apply_bundle_overrides(manifest, props or {})
     return {
         "enabled_path": canonical_enabled_path("bundle"),
-        "allowed_roles": list(manifest.allowed_roles),
+        "allowed_roles": list(effective.allowed_roles),
+        "allowed_roles_default": list(manifest.allowed_roles),
+        "allowed_roles_config": manifest.allowed_roles_config,
+        "allowed_roles_overridden": tuple(effective.allowed_roles) != tuple(manifest.allowed_roles),
         "apis": [_api_spec_descriptor(s, props) for s in manifest.api_endpoints],
         "mcp_endpoints": [_mcp_spec_descriptor(s, props) for s in manifest.mcp_endpoints],
         "widgets": [_widget_spec_descriptor(s, props) for s in manifest.ui_widgets],
@@ -1040,9 +1053,10 @@ def _manifest_to_descriptor_filtered(
     Visibility is checked against the **effective** user_types/roles (after
     bundle-props overrides have been applied).
     """
+    effective_manifest = apply_bundle_overrides(manifest, props or {})
     return {
         "enabled_path": canonical_enabled_path("bundle"),
-        "allowed_roles": list(manifest.allowed_roles),
+        "allowed_roles": list(effective_manifest.allowed_roles),
         "apis": [
             _api_spec_descriptor(s, props)
             for s in manifest.api_endpoints
@@ -1154,13 +1168,13 @@ async def get_bundles(
             request=request,
             session=session,
         )
-        if not _bundle_allowed_for_session(manifest, session):
-            continue
         props: Optional[Dict[str, Any]] = None
         if manifest is not None:
             props = await store_get_bundle_props(redis, tenant=tenant_id, project=project_id, bundle_id=bid)
             if not is_bundle_enabled(props):
                 continue
+        if not _bundle_allowed_for_session(manifest, session, props=props):
+            continue
         descriptor: Dict[str, Any] = {
             "id": bid,
             "name": entry.name,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/agentic_loader.py
@@ -141,6 +141,7 @@ class CronJobSpec:
 class BundleInterfaceManifest:
     bundle_id: str
     allowed_roles: tuple[str, ...] = ()
+    allowed_roles_config: str | None = None
     ui_widgets: tuple[UIWidgetSpec, ...] = ()
     api_endpoints: tuple[APIEndpointSpec, ...] = ()
     mcp_endpoints: tuple[MCPEndpointSpec, ...] = ()
@@ -271,6 +272,14 @@ def apply_widget_overrides(spec: UIWidgetSpec, props: dict[str, Any]) -> UIWidge
         user_types=user_types if user_types is not None else spec.user_types,
         roles=roles if roles is not None else spec.roles,
     )
+
+
+def apply_bundle_overrides(manifest: BundleInterfaceManifest, props: dict[str, Any]) -> BundleInterfaceManifest:
+    """Return a new BundleInterfaceManifest with allowed_roles overridden from props if configured."""
+    roles = _coerce_string_list_override(_resolve_override_value(manifest.allowed_roles_config, props))
+    if roles is None:
+        return manifest
+    return dataclasses.replace(manifest, allowed_roles=roles)
 
 
 def apply_mcp_overrides(spec: MCPEndpointSpec, props: dict[str, Any]) -> MCPEndpointSpec:
@@ -453,6 +462,7 @@ def agentic_workflow(
         version: str | None = None,
         priority: int = 100,
         allowed_roles: List[str] | Tuple[str, ...] | None = None,
+        allowed_roles_config: str | None = None,
 ):
     """
     Mark a CLASS as the bundle's workflow CLASS.
@@ -476,6 +486,7 @@ def agentic_workflow(
         setattr(cls, AGENTIC_META_ATTR, {
             "name": name, "version": version, "priority": priority,
             "allowed_roles": _tuple_str(allowed_roles),
+            "allowed_roles_config": str(allowed_roles_config).strip() if allowed_roles_config else None,
         })
         return cls
     return _wrap
@@ -2002,6 +2013,7 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
 
     meta = getattr(cls, AGENTIC_META_ATTR, {}) or {}
     allowed_roles: tuple[str, ...] = _tuple_str(meta.get("allowed_roles"))
+    allowed_roles_config: str | None = meta.get("allowed_roles_config") or None
 
     api_endpoints.sort(key=lambda item: (item.alias, item.route, item.http_method, item.method_name))
     mcp_endpoints.sort(key=lambda item: (item.alias, item.route, item.transport, item.method_name))
@@ -2010,6 +2022,7 @@ def discover_bundle_interface_manifest(target: Any, *, bundle_id: str | None = N
     return BundleInterfaceManifest(
         bundle_id=resolved_bundle_id,
         allowed_roles=allowed_roles,
+        allowed_roles_config=allowed_roles_config,
         ui_widgets=tuple(ui_widgets),
         api_endpoints=tuple(api_endpoints),
         mcp_endpoints=tuple(mcp_endpoints),


### PR DESCRIPTION
Add allowed_roles_config to @agentic_workflow

  Changes:
  - agentic_loader.py: add allowed_roles_config field to BundleInterfaceManifest, expose it on @agentic_workflow decorator, read it in discover_bundle_interface_manifest, add apply_bundle_overrides(manifest, props) function
  - integrations.py: import apply_bundle_overrides; update _bundle_allowed_for_session to accept props and apply overrides before the role check; update _manifest_to_descriptor and _manifest_to_descriptor_filtered to emit allowed_roles_default / allowed_roles_config / allowed_roles_overridden; in get_bundles (non-admin) load props before the allowed_roles gate so config overrides take effect at listing time
  - AIBundleDashboard.tsx: add allowed_roles_default / allowed_roles_config / allowed_roles_overridden to BundleEntry; render an editable FieldRow with Save / Reset-to-default in the bundle interface section