### PR TITLE
feat(chat): persist turn cost and timing as conv.artifacts.steps arti…

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/emitters.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/emitters.py
@@ -634,6 +634,7 @@ class ChatCommunicator:
         self.room = self.room or self.conversation.get("session_id")
         self.target_sid = self.target_sid or self.conversation.get("socket_id")
         self._delta_cache: dict[Tuple[str, str, str, str, str, str, str], _DeltaAggregate] = {}
+        self._step_events_cache: dict[Tuple[str, str], list[dict]] = {}
         self._recording_enabled: bool = False
         self._recording_filter: Any = None
         self._recording_rules: list[dict[str, Any]] = []
@@ -1355,7 +1356,43 @@ class ChatCommunicator:
         socket_event = _EVENT_MAP.get(route) or _EVENT_MAP.get(type) or "chat_step"
         if route:
             env["route"] = route
+        self._accumulate_step_event(type=type, step=step, status=status,
+                                    agent=agent, title=title,
+                                    markdown=env.get("event", {}).get("markdown"),
+                                    data=data, ts=env.get("ts"))
         await self.emit(event=socket_event, data=env, broadcast=broadcast)
+
+    _STEP_ARTIFACT_TYPES = frozenset({"accounting.usage", "chat.turn.summary"})
+
+    def _accumulate_step_event(
+            self, *, type: str, step: str, status: str,
+            agent: str | None, title: str | None,
+            markdown: str | None, data: dict | None, ts: int | None,
+    ) -> None:
+        if type not in self._STEP_ARTIFACT_TYPES:
+            return
+        conv_id = self.conversation.get("conversation_id") or ""
+        turn_id = self.conversation.get("turn_id") or ""
+        if not conv_id or not turn_id:
+            return
+        key = (conv_id, turn_id)
+        items = self._step_events_cache.setdefault(key, [])
+        event_entry: dict = {"agent": agent, "step": step, "status": status, "title": title}
+        if markdown:
+            event_entry["markdown"] = markdown
+        item: dict = {
+            "type": type,
+            "recorded_at_ms": ts or int(time.time() * 1000),
+            "event": event_entry,
+            "data": data or {},
+        }
+        items.append(item)
+
+    def get_step_events(self, *, conversation_id: str, turn_id: str) -> list[dict]:
+        return list(self._step_events_cache.get((conversation_id, turn_id), []))
+
+    def clear_step_events(self, *, conversation_id: str, turn_id: str) -> None:
+        self._step_events_cache.pop((conversation_id, turn_id), None)
 
     async def service_event(
             self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/retrieval/ctx_rag.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/retrieval/ctx_rag.py
@@ -29,6 +29,7 @@ UI_ARTIFACT_TAGS = {
     "artifact:user.attachment",
     "artifact:turn.log.reaction",
     "artifact:conv.user_shortcuts",
+    "artifact:conv.artifacts.steps",
     "chat:user",
     "chat:assistant"
 }

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
@@ -297,6 +297,7 @@ class VersatileEntrypoint(BaseEntrypointWithEconomicsAndMemory):
         econ_ctx: Optional[Dict[str, Any]] = None,
     ) -> None:
         await super().post_run_hook(state=state, result=result, econ_ctx=econ_ctx or {})
+        await self._persist_steps_artifacts(state=state)
         await self._send_recorded_events()
 
     def _bundle_id(self) -> str:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/ui/main/src/features/chat/chatReducers.ts
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/ui/main/src/features/chat/chatReducers.ts
@@ -530,6 +530,25 @@ export function hydrateHistoricalConversation(conversation: ConversationDTO): Ch
           }
           break
         }
+        case 'artifact:conv.artifacts.steps': {
+          const items = Array.isArray(payload.items) ? payload.items : []
+          let costUsd = turn.costUsd ?? null
+          let elapsedMs = turn.elapsedMs ?? null
+          for (const item of items) {
+            if (!item || typeof item !== 'object') continue
+            const row = item as Record<string, unknown>
+            const type = typeof row.type === 'string' ? row.type : ''
+            const data = (row.data && typeof row.data === 'object') ? row.data as Record<string, unknown> : {}
+            if (type === 'accounting.usage' && typeof data.cost_total_usd === 'number') {
+              costUsd = data.cost_total_usd
+            }
+            if (type === 'chat.turn.summary' && typeof data.elapsed_ms === 'number') {
+              elapsedMs = data.elapsed_ms
+            }
+          }
+          turn = { ...turn, costUsd, elapsedMs }
+          break
+        }
         case 'artifact:conv.artifacts.stream': {
           const items = Array.isArray(payload.items) ? payload.items : []
           let tempState: ChatState = {

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
@@ -2006,6 +2006,46 @@ class BaseEntrypoint:
         )
         return self.ctx_client
 
+    async def _persist_steps_artifacts(self, *, state: Dict[str, Any]) -> None:
+        """Save accounting.usage and chat.turn.summary recorded events as a conv.artifacts.steps artifact.
+
+        Call this from post_run_hook BEFORE sending/clearing the recorded-events buffer.
+        Both events must already be in the buffer: accounting.usage is emitted by run_accounting()
+        and chat.turn.summary is emitted inside finish_turn() during execute_core().
+        """
+        try:
+            ctx_client = await self.get_ctx_client()
+            if ctx_client is None:
+                return
+            tenant = state.get("tenant") or getattr(self.config, "tenant", None) or self.settings.TENANT
+            project = state.get("project") or getattr(self.config, "project", None) or self.settings.PROJECT
+            user_id = state.get("user") or state.get("fingerprint") or ""
+            user_type = state.get("user_type") or "anonymous"
+            conversation_id = state.get("conversation_id") or state.get("session_id") or ""
+            turn_id = state.get("turn_id") or getattr(self, "_turn_id", None) or ""
+            bundle_id = str(getattr(getattr(self.config, "ai_bundle_spec", None), "id", "") or "")
+            if not (tenant and project and user_id and conversation_id and turn_id):
+                return
+            step_items = self.comm.get_step_events(
+                conversation_id=conversation_id, turn_id=turn_id
+            )
+            if not step_items:
+                return
+            self.comm.clear_step_events(conversation_id=conversation_id, turn_id=turn_id)
+            await ctx_client.save_artifact(
+                kind="conv.artifacts.steps",
+                tenant=tenant, project=project,
+                turn_id=turn_id,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                bundle_id=bundle_id,
+                user_type=user_type,
+                content={"version": "v1", "items": step_items},
+                extra_tags=["conversation", "steps"],
+            )
+        except Exception:
+            self.logger.log(traceback.format_exc(), "WARNING")
+
     async def close_optional_services(self) -> None:
         if self._kb:
             try:

--- a/app/ai-app/ui/chat-web-app/src/features/conversations/conversationsMiddleware.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/conversations/conversationsMiddleware.ts
@@ -361,6 +361,8 @@ const conversationsMiddleware = (): Middleware => {
                                 })
                                 break
                             }
+                            case "artifact:conv.artifacts.steps":
+                                break
                             case "artifact:turn.log.reaction":
                                 break
                             case "artifact:conv.user_shortcuts": {


### PR DESCRIPTION
…fact

  Adds a new conv.artifacts.steps artifact type that captures accounting.usage and chat.turn.summary events at the end of each
  turn, so that turn cost and wall-clock time survive a page reload.

  Backend:
  - ChatCommunicator — new _step_events_cache buffer; _accumulate_step_event() is hooked into comm.event() and collects only the two relevant event types (accounting.usage, chat.turn.summary) keyed by (conversation_id, turn_id); exposed via get_step_events() / clear_step_events()
  - BaseEntrypoint._persist_steps_artifacts() — helper that reads the buffer and writes a conv.artifacts.steps JSON artifact via ctx_client.save_artifact(); designed to be called by any bundle that wants cost/timing persistence
  - VersatileEntrypoint.post_run_hook() — calls _persist_steps_artifacts() before flushing the telemetry buffer, ensuring accounting.usage (emitted by run_accounting()) is already in the cache
  - UI_ARTIFACT_TAGS — artifact:conv.artifacts.steps added so the artifact is included in conversation fetch responses

  Frontend (versatile bundle):
  - hydrateHistoricalConversation — new artifact:conv.artifacts.steps case restores costUsd from accounting.usage.data.cost_total_usd and elapsedMs from chat.turn.summary.data.elapsed_ms, making the $0.20 t=0.15 status line visible after reload

  Frontend (control plane):
  - conversationsMiddleware — acknowledges the new artifact type (no-op; control plane does not expose per-turn cost/timing in its UI)