### PR TITLE
Econimics fixes

### DIFF
--- a/app/ai-app/docs/economics/economic-README.md
+++ b/app/ai-app/docs/economics/economic-README.md
@@ -8,6 +8,7 @@ see_also:
   - ks:docs/economics/eco-test-README.md
   - ks:docs/economics/eco-admin-README.md
   - ks:docs/economics/eco-kickoff-README.md
+  - ks:docs/economics/economic-enforcement-engine-README.md
 ---
 # Economics Model (Control Plane)
 

--- a/app/ai-app/docs/economics/economic-enforcement-engine-README.md
+++ b/app/ai-app/docs/economics/economic-enforcement-engine-README.md
@@ -1,0 +1,167 @@
+---
+id: ks:docs/economics/economic-enforcement-engine-README.md
+title: "Economics Enforcement Engine"
+summary: "Reusable API for enforcing the economics model (quota, funding, settlement) on accountable flows outside the chat entrypoint."
+tags: ["economics", "enforcement", "engine", "api", "integration"]
+keywords: ["EconomicsGuard", "economic_preflight", "EconomicsSubject", "RoleResolver", "FlowPolicy", "reservation", "settlement", "scope_id"]
+see_also:
+  - ks:docs/economics/economic-README.md
+  - ks:docs/economics/economics-events-README.md
+---
+# Economics Enforcement Engine
+
+The economics model (roles, plans, funding lanes, reservations, settlement — see
+[economic-README.md](./economic-README.md)) is enforced for chat turns by the chat
+entrypoint. The **enforcement engine** exposes that same model as a small, reusable
+API so that any accountable flow — one that runs model calls on a user's behalf
+without a chat turn — can verify feasibility, reserve funding, and settle actual
+cost through the **same** role → plan → funding resolution, lanes, project→wallet
+overflow split, and shortfall absorption.
+
+Module:
+- [enforcement.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py)
+
+The engine reuses the owning entrypoint's runtime primitives (`cp_manager`, `rl`,
+`budget_limiter`, `run_accounting`, `comm`, `logger`). It does not change how chat
+turns are charged.
+
+## When to use which entry point
+
+The engine offers two entry points. Choose based on **who settles the cost**:
+
+| Entry point | Verifies | Reserves | Settles | Use when |
+| --- | --- | --- | --- | --- |
+| `EconomicsGuard` | ✅ | ✅ | ✅ | the accounted work runs *inside* the guard and you want it metered and charged |
+| `economic_preflight` | ✅ | — | — | you only need a feasibility gate — the cost is metered elsewhere, or the caller degrades gracefully on denial |
+
+Both verify the user's quota and funding **at the start** and raise
+`EconomicsLimitException` when the flow is not feasible.
+
+## Identity (who pays)
+
+Every flow carries an `EconomicsSubject` — the resolved economics identity:
+
+```python
+from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import EconomicsSubject
+
+subject = EconomicsSubject(
+    tenant="acme", project="main", user_id="u-123",
+    user_type="paid",          # resolved economics role; never a hardcoded default
+    timezone="Europe/Kyiv",     # optional; anchors rolling windows
+)
+```
+
+For **detached** flows (e.g. a job run later by a worker) the original session is
+gone, so re-derive `paid`/`registered` from economics state with `RoleResolver`.
+`privileged`/`admin` cannot be derived from economics state and must be carried from
+the enqueue side and passed as `carried_role`:
+
+```python
+from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import RoleResolver
+
+resolver = RoleResolver(pg_pool=entrypoint.pg_pool, tenant=tenant, project=project)
+role = await resolver.resolve(user_id="u-123", carried_role=carried_role)  # preserves privileged/admin
+subject = EconomicsSubject(tenant=tenant, project=project, user_id="u-123", user_type=role)
+```
+
+## `EconomicsGuard` — verify, reserve, settle
+
+An async context manager around a single accountable flow. On enter it resolves the
+plan and funding, runs the rate-limit admit, reserves funding, and binds accounting
+to the flow's `scope_id`. On exit it aggregates the flow's accounting events for that
+`scope_id` and settles the actual cost across the funding lanes (committing or
+releasing the reservations).
+
+```python
+from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import (
+    EconomicsGuard, EconomicsEstimate, FlowPolicy,
+)
+from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import EconomicsLimitException
+
+try:
+    async with EconomicsGuard(
+        entrypoint,                         # economics-enabled entrypoint
+        subject=subject,
+        scope_id="myflow_42",               # stable, unique accountable request id
+        flow="my.flow",                     # label for logs/events
+        estimate=EconomicsEstimate(reservation_usd=0.05),
+        policy=FlowPolicy(enforce_concurrency=False, emit_user_events=False),
+    ) as decision:
+        result = await do_the_work()        # accounted model calls run here
+except EconomicsLimitException as exc:
+    # not feasible — nothing ran; inspect exc.code / exc.data
+    ...
+```
+
+The `scope_id` is the flow's **accountable request id**: pick a stable, unique,
+self-describing value (e.g. `<flow>_<entity_id>`). Reservations, ledger entries, and
+spend are recorded under it and are traceable with
+`GET /economics/request-lineage?request_id=<scope_id>`.
+
+## `economic_preflight` — verify only
+
+Use when you only need to gate the start of a flow and will degrade gracefully on
+denial, or when the cost is metered by something else (for example a chat turn that
+already settles, or a step whose cost you choose not to charge separately). It runs
+the same admit + funding resolution but performs **no reservation and no
+settlement**.
+
+```python
+from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import (
+    economic_preflight, EconomicsEstimate, FlowPolicy,
+)
+from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import EconomicsLimitException
+
+try:
+    decision = await economic_preflight(
+        entrypoint, subject=subject,
+        estimate=EconomicsEstimate(reservation_usd=0.01),
+        flow="my.search",
+        policy=FlowPolicy(enforce_concurrency=False, emit_user_events=False),
+    )
+except EconomicsLimitException:
+    use_cheaper_path()    # e.g. skip the expensive model call, fall back
+```
+
+## Contracts
+
+### `EconomicsEstimate` — reservation size
+
+| Field | Meaning |
+| --- | --- |
+| `reservation_usd` | primary lever: fixed USD estimate for the flow (most non-chat flows cost pennies) |
+| `input_text` / `output_budget_tokens` | token-estimate path used when `reservation_usd` is not given |
+| `min_tokens` | floor for the token-estimate path (default 500) |
+
+### `FlowPolicy` — per-flow knobs
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `enforce_concurrency` | `False` | take a concurrency slot (chat-only; background flows keep this off) |
+| `reservation_ttl_sec` | `900` | reservation hold lifetime |
+| `lock_ttl_sec` | `180` | admit lock lifetime |
+| `emit_user_events` | `False` | emit `rate_limit.*` SSE events on denial (needs a `comm` channel); background flows log only |
+
+### `EconomicsDecision` — outcome (returned by both APIs)
+
+Carries the resolved `lane` (`plan` / `paid` / `bypass`), `plan_id`,
+`funding_source` (`subscription` / `project` / `wallet` / `none`),
+`funding_available_usd`, `est_turn_tokens`, `est_turn_usd`, `budget_bypass`,
+`nested`, and `scope_id`. Useful for logging the decision and the applicable limits.
+
+## Behavior notes
+
+- **Denial.** When the flow is not feasible the API raises `EconomicsLimitException`
+  before any work runs. `exc.code` is `rate_limited` (quota) or `no_funding_source`
+  (no eligible funding); `exc.data` carries the snapshot. See
+  [economics-events-README.md](./economics-events-README.md) for the event payloads
+  emitted when `emit_user_events` is on.
+- **Settlement (guard only).** On exit, actual spend is charged across the same lanes
+  as chat — plan/subscription/project first, wallet for the overflow, with project
+  budget absorbing any shortfall. Subscriptions and wallets never go negative.
+- **Nested safety.** If a guard is entered while an economics scope is already active
+  on the same logical task, it automatically degrades to verify-only (the outer scope
+  settles) so the same work is never charged twice.
+- **Accounting binding.** The guard binds an accounting context keyed by `scope_id`
+  so a detached/background flow's events are persisted and readable at settlement,
+  even without a chat turn cache.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
@@ -1,0 +1,846 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# chat/sdk/infra/economics/enforcement.py
+"""
+Reusable economics enforcement for accountable flows outside the chat run() path.
+
+This module provides:
+- EconomicsSubject / EconomicsEstimate / FlowPolicy / EconomicsDecision   (contracts)
+- RoleResolver        — thin reuse of EconomicsRoleResolver (paid/registered)
+- EconomicsGuard      — async context manager: verify quota at flow start,
+                        reserve funding, bind accounting, settle on exit
+- economic_preflight  — verify-only helper (admit, no reservation, no settle)
+
+It is intentionally built ALONGSIDE BaseEntrypointWithEconomics.run() and reuses
+its runtime primitives (cp_manager, rl, budget_limiter, run_accounting, comm,
+logger) through the owning entrypoint. run() is NOT modified.
+
+Design: docs/economics/economic-enforcement-non-chat-v2-README.md
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional, Tuple
+from uuid import UUID, uuid4
+
+from kdcube_ai_app.infra import accounting as acct
+from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import (
+    QuotaPolicy,
+    EconomicsLimitException,
+)
+from kdcube_ai_app.apps.chat.sdk.infra.economics.limiter import (
+    AdmitResult,
+    subject_id_of,
+    GLOBAL_BUNDLE_ID,
+)
+from kdcube_ai_app.apps.chat.sdk.infra.economics.project_budget import BudgetInsufficientFunds
+from kdcube_ai_app.apps.chat.sdk.infra.economics.events_resources import (
+    MSG_NO_FUNDING,
+    MSG_SUBSCRIPTION_EXHAUSTED,
+    MSG_PROJECT_EXHAUSTED,
+    MSG_DENIED_GENERIC,
+)
+
+SAFETY_MARGIN = 1.15
+# Budget rows store integer cents; a hold below $0.01 rounds to 0 and reserve()
+# raises ValueError. Below this we skip the monetary hold and settle actuals.
+_MIN_RESERVE_USD = 1.0 / 100
+
+# Marks that an economics scope (a top-level EconomicsGuard, or chat run() once it
+# opts in) is actively reserving+settling on this logical task. Nested guards check
+# THIS, not the raw accounting context: background-job workers bind an accounting
+# context (turn_id=turn_<job_id>) without doing any economics settlement, so the
+# accounting context alone must NOT be treated as a settling parent.
+_ECON_SCOPE_ACTIVE: ContextVar[Optional[str]] = ContextVar(
+    "kdcube_econ_scope_active", default=None
+)
+
+
+def active_econ_scope() -> Optional[str]:
+    """Return the scope_id of the economics scope currently settling, if any."""
+    return _ECON_SCOPE_ACTIVE.get()
+
+
+# ----------------------------------------------------------------------------
+# Contracts
+# ----------------------------------------------------------------------------
+@dataclass
+class EconomicsSubject:
+    """Who pays. role is the RESOLVED economics role, never a hardcoded default."""
+    tenant: str
+    project: str
+    user_id: str
+    user_type: str
+    timezone: Optional[str] = None
+
+
+@dataclass
+class EconomicsEstimate:
+    """
+    Drives the reservation size. reservation_usd is the primary, per-operation
+    lever — most non-chat flows (embeddings, reconciler) cost pennies.
+    """
+    reservation_usd: Optional[float] = None
+    input_text: Optional[str] = None
+    output_budget_tokens: Optional[int] = None
+    # floor used only when reservation_usd is not given (token-estimate path)
+    min_tokens: int = 500
+
+
+@dataclass
+class FlowPolicy:
+    enforce_concurrency: bool = False   # chat-only; non-chat flows keep this False
+    reservation_ttl_sec: int = 900      # configurable per flow
+    lock_ttl_sec: int = 180             # configurable per flow
+    emit_user_events: bool = False      # background flows log only, no UI delivery
+
+
+@dataclass
+class EconomicsDecision:
+    """Outcome of pre-run economics, made explicit (== the inline econ_ctx)."""
+    lane: str                           # "plan" | "paid" | "bypass"
+    plan_id: str
+    funding_source: str                 # subscription | project | wallet | none
+    funding_available_usd: float
+    est_turn_tokens: int
+    est_turn_usd: float
+    budget_bypass: bool
+    nested: bool = False                # degraded to preflight inside a parent ctx
+    scope_id: Optional[str] = None
+    admit: Optional[AdmitResult] = None
+    # reservation handles for settlement
+    app_reservation_id: Optional[UUID] = None       # subscription/project hold
+    app_reservation_source: Optional[str] = None     # which limiter holds it
+    wallet_reservation_id: Optional[str] = None       # lifetime-token hold
+    wallet_reserved_tokens: int = 0
+    extra: dict = field(default_factory=dict)
+
+
+# ----------------------------------------------------------------------------
+# Role resolution (thin reuse of EconomicsRoleResolver)
+# ----------------------------------------------------------------------------
+class RoleResolver:
+    """
+    Re-derive paid/registered from economics state for detached flows.
+
+    privileged/admin CANNOT be derived from economics state — it comes from the
+    authenticated session and must be carried across the enqueue->worker boundary.
+    Pass carried_role to preserve it.
+    """
+
+    def __init__(self, *, pg_pool, tenant: str, project: str):
+        from kdcube_ai_app.apps.middleware.economics_role import EconomicsRoleResolver
+        self._resolver = EconomicsRoleResolver(pg_pool=pg_pool, tenant=tenant, project=project)
+
+    @staticmethod
+    def _is_privileged(role: Optional[str]) -> bool:
+        return str(role or "").strip().lower() in ("privileged", "admin")
+
+    async def resolve(self, *, user_id: str, carried_role: Optional[str] = None) -> str:
+        # Preserve privileged/admin exactly (not derivable from economics).
+        if self._is_privileged(carried_role):
+            return str(carried_role).strip().lower()
+        resolved = await self._resolver.resolve_role_for_user_id(user_id)
+        if resolved is None:
+            return str(carried_role or "registered").strip().lower()
+        # UserType -> plain string ("paid"/"registered")
+        return str(getattr(resolved, "value", resolved)).strip().lower()
+
+
+# ----------------------------------------------------------------------------
+# Engine
+# ----------------------------------------------------------------------------
+def _usd_per_token() -> float:
+    from kdcube_ai_app.infra.accounting.usage import (
+        llm_output_price_usd_per_token,
+        anthropic,
+        sonnet_45,
+    )
+    return float(llm_output_price_usd_per_token(ref_provider=anthropic, ref_model=sonnet_45))
+
+
+def _estimate_tokens(estimate: EconomicsEstimate, usd_per_token: float) -> int:
+    if estimate.reservation_usd is not None and estimate.reservation_usd > 0:
+        denom = max(usd_per_token * SAFETY_MARGIN, 1e-9)
+        return max(int(estimate.min_tokens), int(math.ceil(estimate.reservation_usd / denom)))
+    in_toks = 0
+    if estimate.input_text:
+        try:
+            from kdcube_ai_app.apps.chat.sdk.util import token_count
+            in_toks = int(token_count(estimate.input_text))
+        except Exception:
+            in_toks = max(1, int(len(estimate.input_text) / 4))
+    out_toks = int(estimate.output_budget_tokens or 0)
+    return max(int(estimate.min_tokens), in_toks + out_toks)
+
+
+class EconomicsGuard:
+    """
+    Async context manager enforcing economics for a single accountable flow.
+
+    Usage:
+        async with EconomicsGuard(entrypoint, subject=subj, scope_id=sid,
+                                  flow="memory.reconciler",
+                                  estimate=EconomicsEstimate(reservation_usd=0.05)) as econ:
+            result = await do_the_work()
+
+    __aenter__:  estimate -> resolve plan/funding -> admit (verify quota at start)
+                 -> reserve funding -> bind accounting. Raises EconomicsLimitException
+                 if the flow is not economically feasible.
+    __aexit__:   run_accounting(scope_id) -> settle (commit/release + shortfall).
+
+    If an accountable accounting context is already bound, the guard degrades to
+    preflight-only (verify, no reserve, no settle) to avoid double charging.
+    """
+
+    def __init__(
+        self,
+        entrypoint: Any,
+        *,
+        subject: EconomicsSubject,
+        scope_id: str,
+        flow: str,
+        estimate: EconomicsEstimate,
+        policy: Optional[FlowPolicy] = None,
+        comm: Any = None,
+    ):
+        self.ep = entrypoint
+        self.subject = subject
+        self.scope_id = str(scope_id)
+        self.flow = str(flow)
+        self.estimate = estimate
+        self.policy = policy or FlowPolicy()
+        self.comm = comm if comm is not None else getattr(entrypoint, "comm", None)
+
+        self.logger = getattr(entrypoint, "logger", None)
+        self.cp = getattr(entrypoint, "cp_manager", None)
+        self.rl = getattr(entrypoint, "rl", None)
+        self.budget_limiter = getattr(entrypoint, "budget_limiter", None)
+        self.bundle_id = str(getattr(getattr(getattr(entrypoint, "config", None), "ai_bundle_spec", None), "id", "") or "")
+
+        self.subj = subject_id_of(subject.tenant, subject.project, subject.user_id)
+        self.usd_per_token = _usd_per_token()
+        self.now = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        self.decision: Optional[EconomicsDecision] = None
+        self._acct_cm = None
+        self._econ_token = None  # ContextVar token for the economics-scope marker
+        self._subscription_limiter = None  # SubscriptionBudgetLimiter when applicable
+        self._funding_ctx_obj = None       # funding_flow.FundingContext (plan lane)
+        self._funding_res = None           # funding_flow.PlanFundingReservation (plan lane)
+
+    # -- logging / events -----------------------------------------------------
+    def _log(self, stage: str, msg: str, level: str = "INFO", **kv):
+        if self.logger is None:
+            return
+        try:
+            self.logger.log(f"[econ-guard:{self.flow}] {stage} | {msg} | {kv}", level)
+        except Exception:
+            pass
+
+    async def _emit_denial(self, *, code: str, title: str, data: dict) -> None:
+        if not (self.policy.emit_user_events and self.comm is not None):
+            return
+        try:
+            await self.comm.service_event(
+                type="rate_limit.denied",
+                step="rate_limit",
+                status="error",
+                title=title,
+                agent=f"econ.{self.flow}",
+                data={**data, "code": code, "show_in_timeline": False},
+            )
+        except Exception as e:
+            self._log("telemetry", "failed to emit denial event", "WARN", error=str(e))
+
+    async def _deny(self, *, code: str, title: str, message: str, user_message: str, data: dict) -> None:
+        payload = {
+            **data,
+            "code": code,
+            "flow": self.flow,
+            "scope_id": self.scope_id,
+            "subject_id": self.subj,
+            "user_type": self.subject.user_type,
+            "user_message": user_message,
+            "notification_type": "error",
+        }
+        self._log("deny", message, "WARN", code=code)
+        await self._emit_denial(code=code, title=title, data=payload)
+        raise EconomicsLimitException(message, code=code, data=payload)
+
+    # -- pre-run --------------------------------------------------------------
+    async def __aenter__(self) -> EconomicsDecision:
+        parent_scope = active_econ_scope()
+        if parent_scope:
+            # Already inside a settling economics scope (guard-in-guard): verify
+            # only, the parent settles. NOTE: a bare accounting context (e.g. a
+            # background-job worker binding turn_id) does NOT count here.
+            self._log("nested", "degrading to preflight; parent settles", parent_scope=parent_scope)
+            self.decision = await self._preflight(nested=True)
+            return self.decision
+
+        self.decision = await self._enter_top_level()
+        return self.decision
+
+    async def _resolve_plan_and_funding(self) -> dict:
+        s = self.subject
+        role = str(s.user_type or "anonymous").strip().lower()
+        budget_bypass = role in ("privileged", "admin")
+
+        est_turn_tokens = _estimate_tokens(self.estimate, self.usd_per_token)
+        if self.estimate.reservation_usd and self.estimate.reservation_usd > 0:
+            est_turn_usd = float(self.estimate.reservation_usd)
+        else:
+            est_turn_usd = float(est_turn_tokens) * self.usd_per_token * SAFETY_MARGIN
+
+        plan_balance = await self.cp.get_user_plan_balance(
+            tenant=s.tenant, project=s.project, user_id=s.user_id
+        )
+        wallet_tokens = 0
+        if plan_balance and plan_balance.has_lifetime_budget():
+            bal = await self.cp.user_credits_mgr.get_lifetime_balance(
+                tenant=s.tenant, project=s.project, user_id=s.user_id
+            )
+            wallet_tokens = int(bal or 0)
+        has_wallet = wallet_tokens > 0
+
+        subscription = await self.cp.subscription_mgr.get_subscription(
+            tenant=s.tenant, project=s.project, user_id=s.user_id
+        )
+        sub_due_at = getattr(subscription, "next_charge_at", None) if subscription else None
+        sub_chargeable = bool(subscription and int(getattr(subscription, "monthly_price_cents", 0) or 0) > 0)
+        sub_past_due = bool(sub_due_at and sub_due_at <= self.now)
+        has_active_subscription = bool(
+            subscription
+            and getattr(subscription, "status", None) == "active"
+            and sub_chargeable
+            and not sub_past_due
+        )
+
+        # plan id (mirror run())
+        if budget_bypass:
+            plan_id = "admin"
+        elif role == "anonymous":
+            plan_id = "anonymous"
+        elif has_active_subscription:
+            plan_id = getattr(subscription, "plan_id", None) or "payasyougo"
+        else:
+            plan_id = "free"
+
+        base_policy = await self.cp.get_plan_quota_policy(
+            tenant=s.tenant, project=s.project, plan_id=plan_id
+        )
+        if not base_policy:
+            base_policy = QuotaPolicy(max_concurrent=None)
+        # Concurrency is chat-only: drop the concurrency dimension for non-chat flows.
+        if not self.policy.enforce_concurrency:
+            base_policy = dataclasses.replace(base_policy, max_concurrent=None)
+
+        # funding source selection — mirror run()'s plan-funding eligibility.
+        # NOTE: aligned with the economics fix that replaced the static
+        # project_budget_user_types()={"registered"} with project_budget_allowed_for_plan(...).
+        # Project budget backs the plan lane for ANY non-anonymous user (not just
+        # "registered"), unless an active subscription pays or the user is wallet-only.
+        plan_source = "subscription" if has_active_subscription else "role"
+        resolver = getattr(self.ep, "project_budget_allowed_for_plan", None)
+        if callable(resolver):
+            project_budget_allowed = bool(resolver(
+                user_type=role,
+                plan_id=plan_id,
+                plan_source=plan_source,
+                has_wallet=has_wallet,
+                has_active_subscription=has_active_subscription,
+            ))
+        else:
+            # Fallback mirrors BaseEntrypointWithEconomics.project_budget_allowed_for_plan.
+            wallet_first = getattr(self.ep, "wallet_users_use_project_budget_first", lambda: True)()
+            project_budget_allowed = (
+                not has_active_subscription
+                and not (has_wallet and not wallet_first)
+                and role != "anonymous"
+            )
+
+        return {
+            "role": role,
+            "budget_bypass": budget_bypass,
+            "est_turn_tokens": est_turn_tokens,
+            "est_turn_usd": est_turn_usd,
+            "plan_balance": plan_balance,
+            "wallet_tokens": wallet_tokens,
+            "has_wallet": has_wallet,
+            "subscription": subscription,
+            "has_active_subscription": has_active_subscription,
+            "plan_id": plan_id,
+            "base_policy": base_policy,
+            "project_budget_allowed": project_budget_allowed,
+        }
+
+    async def _admit(self, base_policy: QuotaPolicy, *, reserve_tokens: int = 0) -> AdmitResult:
+        return await self.rl.admit(
+            bundle_id=GLOBAL_BUNDLE_ID,
+            subject_id=self.subj,
+            policy=base_policy,
+            lock_id=self.scope_id,
+            lock_ttl_sec=int(self.policy.lock_ttl_sec),
+            apply_plan_override=True,
+            now=self.now,
+            reserve_tokens=int(reserve_tokens or 0),
+            reservation_id=self.scope_id,
+            reservation_ttl_sec=int(self.policy.reservation_ttl_sec),
+        )
+
+    def _funding_ctx(self, subscription_limiter=None):
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import FundingContext
+        s = self.subject
+        return FundingContext(
+            rl=self.rl, budget_limiter=self.budget_limiter, cp_manager=self.cp,
+            tenant=s.tenant, project=s.project, user_id=s.user_id, subject_id=self.subj,
+            bundle_id=self.bundle_id, rl_bundle_id=GLOBAL_BUNDLE_ID, scope_id=self.scope_id,
+            usd_per_token=self.usd_per_token, now=self.now,
+            subscription_limiter=subscription_limiter,
+            log=lambda stage, msg, level="INFO", **kv: self._log(stage, msg, level, **kv),
+        )
+
+    async def _preflight(self, *, nested: bool) -> EconomicsDecision:
+        """Verify-only: resolve + admit, no reservation, no accounting binding."""
+        r = await self._resolve_plan_and_funding()
+        admit = await self._admit(r["base_policy"])
+        if not admit.allowed and not r["budget_bypass"]:
+            await self._deny(
+                code="rate_limited",
+                title="Rate limit exceeded",
+                message=f"{self.flow}: rate limited: {admit.reason or 'unknown'}",
+                user_message=MSG_DENIED_GENERIC,
+                data={"reason": admit.reason, "snapshot": admit.snapshot, "lane": "deny"},
+            )
+        funding_source, available_usd = self._funding_summary(r)
+        if not nested and not r["budget_bypass"] and funding_source == "none":
+            await self._deny(
+                code="no_funding_source",
+                title="No funding source",
+                message=f"{self.flow}: no funding source for user",
+                user_message=MSG_NO_FUNDING,
+                data={"reason": "no_funding_source", "funding_source": "none"},
+            )
+        return EconomicsDecision(
+            lane="bypass" if r["budget_bypass"] else ("paid" if funding_source == "wallet" else "plan"),
+            plan_id=r["plan_id"],
+            funding_source=funding_source,
+            funding_available_usd=available_usd,
+            est_turn_tokens=int(r["est_turn_tokens"]),
+            est_turn_usd=float(r["est_turn_usd"]),
+            budget_bypass=r["budget_bypass"],
+            nested=nested,
+            scope_id=self.scope_id,
+            admit=admit,
+        )
+
+    def _funding_summary(self, r: dict) -> Tuple[str, float]:
+        if r["budget_bypass"]:
+            return "project", float("inf")
+        if r["has_active_subscription"]:
+            return "subscription", float("inf")  # availability checked at reserve time
+        if r["project_budget_allowed"]:
+            return "project", float("inf")
+        if r["has_wallet"]:
+            return "wallet", float(r["wallet_tokens"]) * self.usd_per_token
+        return "none", 0.0
+
+    async def _enter_top_level(self) -> EconomicsDecision:
+        r = await self._resolve_plan_and_funding()
+        est_turn_tokens = int(r["est_turn_tokens"])
+        budget_bypass = r["budget_bypass"]
+        funding_source, available_usd = self._funding_summary(r)
+
+        # 1) verify quota AND reserve RL plan tokens at the start (full run() parity)
+        admit = await self._admit(r["base_policy"], reserve_tokens=est_turn_tokens)
+        if not admit.allowed and not budget_bypass:
+            await self._deny(
+                code="rate_limited",
+                title="Rate limit exceeded",
+                message=f"{self.flow}: rate limited: {admit.reason or 'unknown'}",
+                user_message=MSG_DENIED_GENERIC,
+                data={"reason": admit.reason, "snapshot": admit.snapshot, "lane": "deny"},
+            )
+
+        est_turn_usd = float(r["est_turn_usd"])
+        decision = EconomicsDecision(
+            lane="bypass" if budget_bypass else ("paid" if funding_source == "wallet" else "plan"),
+            plan_id=r["plan_id"],
+            funding_source=funding_source,
+            funding_available_usd=available_usd,
+            est_turn_tokens=est_turn_tokens,
+            est_turn_usd=est_turn_usd,
+            budget_bypass=budget_bypass,
+            nested=False,
+            scope_id=self.scope_id,
+            admit=admit,
+            extra={
+                "effective_policy": r["base_policy"],
+                "plan_balance": r["plan_balance"],
+                "wallet_tokens": int(r["wallet_tokens"]),
+            },
+        )
+
+        if funding_source == "none" and not budget_bypass:
+            await self._deny(
+                code="no_funding_source",
+                title="No funding source",
+                message=f"{self.flow}: no funding source for user",
+                user_message=MSG_NO_FUNDING,
+                data={"reason": "no_funding_source", "funding_source": "none"},
+            )
+
+        # 2) reserve funding via the shared plan-lane flow (primary + wallet overflow)
+        try:
+            if funding_source in ("project", "subscription") or budget_bypass:
+                await self._reserve_plan_lane(decision, r, admit=admit, funding_source=funding_source)
+            elif funding_source == "wallet":
+                # wallet-primary edge (anonymous + wallet) — not a plan lane
+                await self._reserve_wallet_or_deny(decision, r, reserve_usd=est_turn_usd, exhausted=None)
+        except EconomicsLimitException as exc:
+            await self._on_funding_denied(exc)
+            raise
+
+        # 3) bind accounting (Variant A) + mark active economics scope
+        self._bind_accounting()
+        self._econ_token = _ECON_SCOPE_ACTIVE.set(self.scope_id)
+        self._log(
+            "enter", "economics ok",
+            plan_id=decision.plan_id, funding_source=decision.funding_source, lane=decision.lane,
+            est_turn_usd=round(est_turn_usd, 6),
+        )
+        return decision
+
+    async def _reserve_plan_lane(self, decision: EconomicsDecision, r: dict, *, admit: AdmitResult, funding_source: str) -> None:
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import reserve_plan_funding
+
+        est_turn_tokens = int(decision.est_turn_tokens)
+        budget_bypass = decision.budget_bypass
+
+        sub_limiter = None
+        sub_available = 0.0
+        project_snapshot = None
+        if funding_source == "subscription":
+            sub_limiter = await self._get_subscription_limiter(r["subscription"])
+            if sub_limiter is None:
+                await self._deny(
+                    code="subscription_unavailable", title="Subscription unavailable",
+                    message=f"{self.flow}: subscription budget unavailable",
+                    user_message=MSG_SUBSCRIPTION_EXHAUSTED,
+                    data={"reason": "subscription_unavailable", "funding_source": "subscription"},
+                )
+            try:
+                snap = await sub_limiter.get_subscription_budget_balance()
+                sub_available = float(snap.get("available_usd") or 0.0)
+            except Exception:
+                sub_available = 0.0
+        if funding_source == "project":
+            try:
+                project_snapshot = await self.budget_limiter.get_app_budget_balance()
+            except Exception:
+                project_snapshot = None
+
+        wallet_can_pay = int(r["wallet_tokens"]) >= est_turn_tokens
+        sub_can_pay = funding_source == "subscription" and sub_available >= float(decision.est_turn_usd)
+        personal_can_pay = bool(wallet_can_pay or sub_can_pay)
+
+        ctx = self._funding_ctx(sub_limiter)
+        res = await reserve_plan_funding(
+            ctx, admit=admit,
+            funding_source=("project" if budget_bypass else funding_source),
+            budget_bypass=budget_bypass, est_turn_tokens=est_turn_tokens,
+            has_wallet=bool(r["has_wallet"]), subscription_available_usd=sub_available,
+            project_budget_snapshot=project_snapshot, personal_can_pay_turn=personal_can_pay,
+            ttl_sec=int(self.policy.reservation_ttl_sec),
+        )
+        self._funding_ctx_obj = ctx
+        self._funding_res = res
+        decision.app_reservation_source = res.funding_source
+        decision.app_reservation_active = res.app_reservation_active
+
+    async def _on_funding_denied(self, exc: Exception) -> None:
+        """Log + optionally emit a denial, then release the RL token reservation
+        taken by admit (the funding flow releases its own money holds before raising)."""
+        code = getattr(exc, "code", "denied")
+        self._log("deny", str(exc), "WARN", code=code)
+        await self._emit_denial(
+            code=code, title="Insufficient funds",
+            data={**(getattr(exc, "data", {}) or {}), "flow": self.flow,
+                  "scope_id": self.scope_id, "subject_id": self.subj},
+        )
+        try:
+            if self._funding_res is not None and self._funding_ctx_obj is not None:
+                from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import release_plan_funding
+                await release_plan_funding(self._funding_ctx_obj, self._funding_res)
+            else:
+                await self.rl.release_token_reservation(
+                    bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj,
+                    reservation_id=self.scope_id, now=self.now,
+                )
+                await self.rl.release(bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, lock_id=self.scope_id)
+        except Exception:
+            pass
+
+    async def _reserve_wallet_or_deny(self, decision: EconomicsDecision, r: dict, *, reserve_usd: float, exhausted: Optional[str]) -> None:
+        s = self.subject
+        if not r["has_wallet"]:
+            if exhausted == "subscription":
+                await self._deny(
+                    code="subscription_budget_exhausted",
+                    title="Subscription balance exhausted",
+                    message=f"{self.flow}: subscription exhausted, no wallet",
+                    user_message=MSG_SUBSCRIPTION_EXHAUSTED,
+                    data={"reason": "subscription_budget_exhausted", "funding_source": "subscription"},
+                )
+            if exhausted == "project":
+                await self._deny(
+                    code="project_budget_exhausted",
+                    title="Project budget exhausted",
+                    message=f"{self.flow}: project exhausted, no wallet",
+                    user_message=MSG_PROJECT_EXHAUSTED,
+                    data={"reason": "project_budget_exhausted", "funding_source": "project"},
+                )
+            await self._deny(
+                code="no_funding_source",
+                title="No funding source",
+                message=f"{self.flow}: no funding source",
+                user_message=MSG_NO_FUNDING,
+                data={"reason": "no_funding_source", "funding_source": "none"},
+            )
+
+        tokens = int(decision.est_turn_tokens)
+        ok = await self.cp.user_credits_mgr.reserve_lifetime_tokens(
+            tenant=s.tenant, project=s.project, user_id=s.user_id,
+            reservation_id=self.scope_id, tokens=tokens,
+            ttl_sec=int(self.policy.reservation_ttl_sec), bundle_id=self.bundle_id,
+            notes=f"{self.flow} wallet reserve: scope={self.scope_id}",
+        )
+        if not ok:
+            await self._deny(
+                code="personal_reservation_failed",
+                title="Insufficient personal credits",
+                message=f"{self.flow}: wallet reservation failed",
+                user_message=MSG_NO_FUNDING,
+                data={"reason": "personal_reservation_failed", "funding_source": "wallet"},
+            )
+        decision.funding_source = "wallet"
+        decision.lane = "paid"
+        decision.wallet_reservation_id = self.scope_id
+        decision.wallet_reserved_tokens = tokens
+
+    async def _get_subscription_limiter(self, subscription: Any):
+        if self._subscription_limiter is not None:
+            return self._subscription_limiter
+        try:
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.subscription_budget import SubscriptionBudgetLimiter
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.subscription import build_subscription_period_descriptor
+            s = self.subject
+            period = build_subscription_period_descriptor(
+                tenant=s.tenant, project=s.project, user_id=s.user_id,
+                provider=getattr(subscription, "provider", "internal") or "internal",
+                stripe_subscription_id=getattr(subscription, "stripe_subscription_id", None),
+                period_end=getattr(subscription, "next_charge_at", None),
+                period_start=getattr(subscription, "last_charged_at", None),
+            )
+            self._subscription_limiter = SubscriptionBudgetLimiter(
+                pg_pool=self.ep.pg_pool, tenant=s.tenant, project=s.project,
+                user_id=s.user_id, period_key=period["period_key"],
+                period_start=period["period_start"], period_end=period["period_end"],
+            )
+        except Exception as e:
+            self._log("subscription", "failed to build subscription limiter", "WARN", error=str(e))
+            self._subscription_limiter = None
+        return self._subscription_limiter
+
+    # -- accounting binding (Variant A) --------------------------------------
+    @staticmethod
+    def _ensure_accounting_storage() -> None:
+        """Mirror run(): ensure a file backend is present so model-service events
+        are persisted and readable by settlement (works in detached workers)."""
+        try:
+            storage = acct._get_storage()
+            if storage is None or storage.__class__.__name__ == "NoOpAccountingStorage":
+                from kdcube_ai_app.apps.chat.sdk.config import get_settings
+                from kdcube_ai_app.storage.storage import create_storage_backend
+                acct.AccountingSystem.init_storage(
+                    create_storage_backend(get_settings().STORAGE_PATH), enabled=True
+                )
+        except Exception:
+            pass
+
+    def _bind_accounting(self) -> None:
+        s = self.subject
+        self._ensure_accounting_storage()
+        self._acct_cm = acct.with_accounting(
+            self.flow,
+            user_id=s.user_id,
+            user_type=s.user_type,
+            tenant_id=s.tenant,
+            project_id=s.project,
+            request_id=self.scope_id,
+            app_bundle_id=self.bundle_id,
+            timezone=s.timezone,
+            conversation_id=self.scope_id,   # synthetic; gives the file fallback an id prefix
+            turn_id=self.scope_id,
+            metadata={
+                "flow": self.flow,
+                "scope_id": self.scope_id,
+                "conversation_id": self.scope_id,
+                "turn_id": self.scope_id,
+                "bundle_id": self.bundle_id,
+            },
+        )
+        self._acct_cm.__enter__()
+
+    def _unbind_accounting(self) -> None:
+        if self._acct_cm is not None:
+            try:
+                self._acct_cm.__exit__(None, None, None)
+            finally:
+                self._acct_cm = None
+
+    # -- post-run -------------------------------------------------------------
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        d = self.decision
+        if d is None or d.nested:
+            return False  # nested: parent settles; nothing bound here
+
+        try:
+            ranked_tokens, cost_result = await self._run_accounting()
+            total_cost = float((cost_result or {}).get("cost_total_usd") or 0.0)
+            await self._settle(d, ranked_tokens=int(ranked_tokens or 0), total_cost=total_cost)
+            self._log(
+                "settle", "settled",
+                funding_source=d.funding_source,
+                ranked_tokens=int(ranked_tokens or 0),
+                total_cost=round(total_cost, 6),
+            )
+        except Exception as e:
+            self._log("settle", "settlement failed; releasing holds", "ERROR", error=str(e))
+            await self._cleanup_release(d)
+        finally:
+            if self._econ_token is not None:
+                try:
+                    _ECON_SCOPE_ACTIVE.reset(self._econ_token)
+                finally:
+                    self._econ_token = None
+            self._unbind_accounting()
+            await self._clear_turn_events()
+        return False  # never suppress the body's exception
+
+    async def _run_accounting(self) -> Tuple[int, dict]:
+        usage_from = self.now.date().isoformat()
+        ranked, result = await self.ep.run_accounting(
+            tenant=self.subject.tenant,
+            project=self.subject.project,
+            user_id=self.subject.user_id,
+            user_type=self.subject.user_type,
+            thread_id=self.scope_id,
+            turn_id=self.scope_id,
+            usage_from=usage_from,
+        )
+        return int(ranked or 0), (result or {})
+
+    async def _settle(self, d: EconomicsDecision, *, ranked_tokens: int, total_cost: float) -> None:
+        # Plan lane (project/subscription/bypass) -> shared funding_flow settlement
+        # (primary + wallet overflow + project absorption, via allocate_plan_wallet_settlement).
+        if self._funding_res is not None and self._funding_ctx_obj is not None:
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import settle_plan_funding
+            plan_balance = d.extra.get("plan_balance")
+            wallet_tokens = int(d.extra.get("wallet_tokens") or 0)
+            await settle_plan_funding(
+                self._funding_ctx_obj, self._funding_res,
+                ranked_tokens=int(ranked_tokens), total_cost_usd=float(total_cost),
+                effective_policy=d.extra.get("effective_policy"),
+                plan_has_lifetime_budget=bool(plan_balance and plan_balance.has_lifetime_budget()),
+                user_budget_tokens=(wallet_tokens or None),
+            )
+            return
+        # wallet-primary edge (no plan-lane reservation taken)
+        await self._settle_wallet(d, ranked_tokens=ranked_tokens, total_cost=total_cost)
+
+    async def _settle_wallet(self, d: EconomicsDecision, *, ranked_tokens: int, total_cost: float) -> None:
+        s = self.subject
+        try:
+            await self.rl.commit_with_reservation(
+                bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj,
+                tokens=int(ranked_tokens), lock_id=self.scope_id,
+                reservation_id=self.scope_id, now=self.now, inc_request=1,
+            )
+        except Exception as e:
+            self._log("rl.commit", "failed to commit rl usage", "WARN", error=str(e))
+        if d.wallet_reservation_id:
+            uncovered = await self.cp.user_credits_mgr.commit_reserved_lifetime_tokens(
+                tenant=s.tenant, project=s.project, user_id=s.user_id,
+                reservation_id=d.wallet_reservation_id, tokens=int(ranked_tokens),
+            )
+            uncovered = int(uncovered or 0)
+            if uncovered > 0 and total_cost > 0 and ranked_tokens > 0:
+                from kdcube_ai_app.apps.chat.sdk.util import safe_frac
+                shortfall = float(total_cost) * safe_frac(float(uncovered), float(ranked_tokens))
+                if shortfall > 0:
+                    await self.budget_limiter.force_project_spend(
+                        spent_usd=shortfall, bundle_id=self.bundle_id, provider=None,
+                        request_id=self.scope_id, user_id=s.user_id, note=f"{self.flow}: shortfall:wallet_paid",
+                    )
+
+    async def _cleanup_release(self, d: EconomicsDecision) -> None:
+        if self._funding_res is not None and self._funding_ctx_obj is not None:
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import release_plan_funding
+            await release_plan_funding(self._funding_ctx_obj, self._funding_res)
+            return
+        s = self.subject
+        try:
+            if d.wallet_reservation_id:
+                await self.cp.user_credits_mgr.release_lifetime_token_reservation(
+                    tenant=s.tenant, project=s.project, user_id=s.user_id,
+                    reservation_id=d.wallet_reservation_id, reason=f"{self.flow}: cleanup",
+                )
+        except Exception as e:
+            self._log("cleanup", "failed to release wallet reservation", "WARN", error=str(e))
+        try:
+            await self.rl.release_token_reservation(
+                bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, reservation_id=self.scope_id, now=self.now,
+            )
+            await self.rl.release(bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, lock_id=self.scope_id)
+        except Exception:
+            pass
+
+    async def _clear_turn_events(self) -> None:
+        try:
+            await acct.clear_turn_events(
+                tenant=self.subject.tenant, project=self.subject.project,
+                conversation_id=self.scope_id, turn_id=self.scope_id,
+            )
+        except Exception:
+            pass
+
+
+# ----------------------------------------------------------------------------
+# Verify-only helper
+# ----------------------------------------------------------------------------
+async def economic_preflight(
+    entrypoint: Any,
+    *,
+    subject: EconomicsSubject,
+    estimate: EconomicsEstimate,
+    flow: str,
+    policy: Optional[FlowPolicy] = None,
+) -> EconomicsDecision:
+    """
+    Verify the flow is economically feasible without reserving or settling.
+    Raises EconomicsLimitException if not. Use for nested or cheap flows where
+    the caller degrades gracefully (e.g. memory search -> BM25).
+    """
+    guard = EconomicsGuard(
+        entrypoint, subject=subject, scope_id=f"preflight_{uuid4().hex}",
+        flow=flow, estimate=estimate, policy=policy,
+    )
+    return await guard._preflight(nested=bool(active_econ_scope()))

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/events_resources.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/events_resources.py
@@ -19,6 +19,17 @@ def msg_denied_quota_reset(reset_text: str) -> str:
     return f"You've reached your usage limit. Your quota resets {reset_text}."
 
 
+def msg_denied_quota_insufficient_for_request(
+    needed_k: int, remaining_k: int, reset_text: str
+) -> str:
+    """Quota not exhausted but remaining tokens are fewer than this request needs."""
+    return (
+        f"Not enough tokens for this request "
+        f"(~{needed_k}K needed, ~{remaining_k}K available this hour). "
+        f"Your quota resets {reset_text}."
+    )
+
+
 MSG_DENIED_LOCK_TIMEOUT = (
     "Too many requests are being processed right now. Please try again in a moment."
 )
@@ -60,6 +71,11 @@ def msg_warning_low_tokens(tokens_k: int) -> str:
 
 
 MSG_WARNING_APPROACHING = "You're approaching your usage limit."
+
+
+def msg_warning_approaching_approx(messages_approx: int) -> str:
+    word = "message" if messages_approx == 1 else "messages"
+    return f"You're approaching your usage limit (approx. {messages_approx} {word} remaining)."
 
 
 # ── rate_limit.no_funding ────────────────────────────────────────────────────

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
@@ -1,0 +1,525 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# chat/sdk/infra/economics/funding_flow.py
+"""
+Shared plan-lane funding reserve + settlement, extracted so a single
+implementation backs BOTH the chat run() path and the reusable EconomicsGuard.
+
+It mirrors BaseEntrypointWithEconomics.run()'s plan-lane money flow:
+  reserve:  size the primary (project|subscription) cover + reserve it, then
+            reserve wallet overflow for the remainder.
+  settle:   read fresh capacities, split the actual usage with
+            allocate_plan_wallet_settlement (primary + wallet + project
+            absorption), commit each source, and commit RL token quota.
+
+It deliberately contains NO event emission, NO UI insight, and NO paid-lane
+switch — those are run()-specific concerns. Denials raise EconomicsLimitException
+(neutral) so both callers can translate them.
+
+Design: docs/economics/economic-enforcement-non-chat-v2-README.md (§4.1, §6)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+from uuid import UUID, uuid4
+
+from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import (
+    QuotaPolicy,
+    EconomicsLimitException,
+)
+from kdcube_ai_app.apps.chat.sdk.infra.economics.project_budget import BudgetInsufficientFunds
+from kdcube_ai_app.apps.chat.sdk.infra.economics.settlement_allocation import (
+    PlanWalletSettlementInput,
+    PlanWalletSettlementAllocation,
+    allocate_plan_wallet_settlement,
+)
+
+SAFETY_MARGIN = 1.15
+# Budget rows store integer cents; a hold below $0.01 rounds to 0 and reserve()
+# raises ValueError. Below this we treat the primary cover as exhausted.
+_MIN_RESERVE_USD = 1.0 / 100
+
+
+def _log_noop(stage: str, msg: str, level: str = "INFO", **kv) -> None:
+    pass
+
+
+@dataclass
+class FundingContext:
+    """Primitives + identity shared by reserve/settle. rl_bundle_id is the global
+    (per tenant/project) rate-limit subject; bundle_id is the real bundle for
+    budget attribution."""
+    rl: Any
+    budget_limiter: Any
+    cp_manager: Any
+    tenant: str
+    project: str
+    user_id: str
+    subject_id: str
+    bundle_id: str
+    rl_bundle_id: str
+    scope_id: str
+    usd_per_token: float
+    now: datetime
+    subscription_limiter: Any = None
+    log: Callable[..., None] = _log_noop
+
+
+@dataclass
+class PlanFundingReservation:
+    """Holds the pre-run reservation handles consumed by settlement."""
+    funding_source: str          # "project" | "subscription"
+    budget_bypass: bool
+    est_turn_tokens: int
+
+    # RL plan-token reservation (from admit)
+    plan_reservation_id: Optional[str] = None
+    plan_reserved_tokens: int = 0
+    plan_reservation_active: bool = False
+
+    # primary (project/subscription) money hold
+    app_reservation_id: Optional[UUID] = None
+    app_reserved_usd: float = 0.0
+    app_reservation_active: bool = False
+    plan_project_tokens_est: int = 0
+
+    # wallet overflow hold
+    wallet_reservation_id: Optional[str] = None
+    wallet_reserved_tokens: int = 0
+    wallet_reservation_active: bool = False
+
+    has_wallet: bool = False
+
+
+@dataclass
+class SettlementResult:
+    ranked_tokens: int
+    total_cost_usd: float
+    primary_funding_usd: float = 0.0
+    wallet_usd: float = 0.0
+    project_absorption_usd: float = 0.0
+    quota_commit_tokens: int = 0
+    allocation: Optional[PlanWalletSettlementAllocation] = None
+    extra_project_items: list = field(default_factory=list)
+
+
+def _cost_for_tokens(*, tokens: int, ranked_tokens: int, total_cost: float) -> float:
+    if tokens <= 0 or ranked_tokens <= 0 or total_cost <= 0:
+        return 0.0
+    return float(total_cost) * (float(tokens) / float(ranked_tokens))
+
+
+def _cap_tokens_for_usd(*, available_usd: float, usd_per_token: float) -> int:
+    if usd_per_token <= 0:
+        return 0
+    cap_usd = max(float(available_usd or 0.0), 0.0)
+    return int(cap_usd / (usd_per_token * SAFETY_MARGIN))
+
+
+# ---------------------------------------------------------------------------
+# Pre-run reservation
+# ---------------------------------------------------------------------------
+async def reserve_plan_funding(
+    ctx: FundingContext,
+    *,
+    admit: Any,
+    funding_source: str,
+    budget_bypass: bool,
+    est_turn_tokens: int,
+    has_wallet: bool,
+    subscription_available_usd: float,
+    project_budget_snapshot: Optional[dict],
+    personal_can_pay_turn: bool,
+    ttl_sec: int = 900,
+) -> PlanFundingReservation:
+    """
+    Plan-lane reservation: size the primary cover, reserve it, then reserve
+    wallet overflow. Mirrors run() (plan lane). Raises EconomicsLimitException
+    when the user cannot fund the request.
+    """
+    usd_per_token = ctx.usd_per_token
+    funding_limiter = ctx.subscription_limiter if funding_source == "subscription" else ctx.budget_limiter
+
+    plan_reserved_tokens = int(getattr(admit, "reserved_tokens", 0) or 0)
+    plan_reservation_id = getattr(admit, "reservation_id", None)
+    plan_reservation_active = plan_reserved_tokens > 0 and plan_reservation_id is not None
+
+    res = PlanFundingReservation(
+        funding_source=funding_source,
+        budget_bypass=budget_bypass,
+        est_turn_tokens=int(est_turn_tokens),
+        plan_reservation_id=plan_reservation_id,
+        plan_reserved_tokens=plan_reserved_tokens,
+        plan_reservation_active=plan_reservation_active,
+        has_wallet=has_wallet,
+    )
+
+    # --- size the primary (project/subscription) cover -------------------
+    plan_project_tokens_est = int(plan_reserved_tokens)
+    if funding_source == "subscription":
+        plan_project_tokens_est = int(est_turn_tokens)
+        if has_wallet:
+            cap_tokens = _cap_tokens_for_usd(available_usd=subscription_available_usd, usd_per_token=usd_per_token)
+            plan_project_tokens_est = min(int(est_turn_tokens), int(cap_tokens))
+    elif funding_source == "project" and project_budget_snapshot:
+        od_lim = project_budget_snapshot.get("overdraft_limit_usd")
+        if od_lim is not None:
+            cap_usd = float(project_budget_snapshot.get("available_usd") or 0.0) + float(od_lim or 0.0)
+            cap_tokens = _cap_tokens_for_usd(available_usd=cap_usd, usd_per_token=usd_per_token)
+            plan_project_tokens_est = min(int(plan_project_tokens_est), int(cap_tokens))
+        # od_lim is None => unlimited overdraft => keep full plan_project_tokens_est
+
+    # sub-cent primary cover can't be reserved (cents granularity) -> treat as 0
+    if plan_project_tokens_est > 0 and (float(plan_project_tokens_est) * usd_per_token * SAFETY_MARGIN) < _MIN_RESERVE_USD:
+        ctx.log("reserve.plan", "primary cover below minimum chargeable; treating as exhausted", "WARN",
+                plan_project_tokens_est=plan_project_tokens_est)
+        plan_project_tokens_est = 0
+
+    # --- reserve the primary cover ---------------------------------------
+    if plan_project_tokens_est <= 0:
+        if budget_bypass:
+            pass  # admin: no money hold
+        elif not personal_can_pay_turn:
+            _deny(
+                code="plan_exhausted_no_personal",
+                message="Plan funding exhausted and user cannot pay from personal credits.",
+                funding_source=funding_source,
+                est_turn_tokens=est_turn_tokens,
+            )
+        # else: wallet covers the whole request via overflow below
+    elif not budget_bypass:
+        app_reserved_usd = float(plan_project_tokens_est) * usd_per_token * SAFETY_MARGIN
+        app_reservation_id = uuid4()
+        reserve_kwargs = dict(
+            reservation_id=app_reservation_id,
+            bundle_id=ctx.bundle_id,
+            provider=None,
+            request_id=ctx.scope_id,
+            amount_usd=float(app_reserved_usd),
+            ttl_sec=int(ttl_sec),
+            notes=f"plan reserve: scope={ctx.scope_id}, plan_cover_est={plan_project_tokens_est}",
+        )
+        if funding_source == "project":
+            reserve_kwargs["user_id"] = ctx.user_id
+        try:
+            await funding_limiter.reserve(**reserve_kwargs)
+            res.app_reservation_id = app_reservation_id
+            res.app_reserved_usd = float(app_reserved_usd)
+            res.app_reservation_active = True
+        except BudgetInsufficientFunds as e:
+            ctx.log("reserve.app", "primary reservation denied", "WARN", error=str(e))
+            if not personal_can_pay_turn:
+                _deny(
+                    code=f"{funding_source}_budget_reservation_failed_no_personal",
+                    message=f"{funding_source} funding cannot reserve and user cannot pay.",
+                    funding_source=funding_source,
+                    est_turn_tokens=est_turn_tokens,
+                )
+            # fall back to wallet-only for this request
+            plan_project_tokens_est = 0
+
+    res.plan_project_tokens_est = int(plan_project_tokens_est)
+
+    # --- reserve wallet overflow -----------------------------------------
+    # Subscription-only users (no wallet) don't overflow; everyone else does.
+    if funding_source != "subscription" or has_wallet:
+        overflow_tokens_est = max(int(est_turn_tokens) - int(plan_project_tokens_est), 0)
+        if overflow_tokens_est > 0 and has_wallet:
+            ok = await ctx.cp_manager.user_credits_mgr.reserve_lifetime_tokens(
+                tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+                reservation_id=ctx.scope_id, tokens=int(overflow_tokens_est),
+                ttl_sec=int(ttl_sec), bundle_id=ctx.bundle_id,
+                notes=f"overflow reserve: scope={ctx.scope_id}, overflow={overflow_tokens_est}",
+            )
+            if not ok:
+                # release the primary hold we already took before denying
+                if res.app_reservation_active and res.app_reservation_id:
+                    try:
+                        if funding_source == "subscription" and ctx.subscription_limiter is not None:
+                            await ctx.subscription_limiter.release_reservation(
+                                reservation_id=res.app_reservation_id, project_budget=ctx.budget_limiter,
+                            )
+                        else:
+                            await ctx.budget_limiter.release_reservation(reservation_id=res.app_reservation_id)
+                    except Exception:
+                        pass
+                    res.app_reservation_active = False
+                _deny(
+                    code="personal_reservation_failed_plan",
+                    message="Insufficient personal credits to cover overflow.",
+                    funding_source=funding_source,
+                    est_turn_tokens=est_turn_tokens,
+                )
+            res.wallet_reservation_id = ctx.scope_id
+            res.wallet_reserved_tokens = int(overflow_tokens_est)
+            res.wallet_reservation_active = True
+        elif overflow_tokens_est > 0 and not has_wallet and plan_project_tokens_est <= 0 and not budget_bypass:
+            # no primary cover and no wallet -> nothing can pay
+            _deny(
+                code="no_funding_source",
+                message="No plan, subscription, project, or wallet funding can cover this request.",
+                funding_source=funding_source,
+                est_turn_tokens=est_turn_tokens,
+            )
+
+    return res
+
+
+def _deny(*, code: str, message: str, funding_source: str, est_turn_tokens: int) -> None:
+    raise EconomicsLimitException(
+        message,
+        code=code,
+        data={
+            "reason": code,
+            "funding_source": funding_source,
+            "min_tokens_required": int(est_turn_tokens),
+            "lane": "deny",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Post-run settlement
+# ---------------------------------------------------------------------------
+async def settle_plan_funding(
+    ctx: FundingContext,
+    res: PlanFundingReservation,
+    *,
+    ranked_tokens: int,
+    total_cost_usd: float,
+    effective_policy: QuotaPolicy,
+    plan_has_lifetime_budget: bool,
+    user_budget_tokens: Optional[int],
+) -> SettlementResult:
+    """
+    Settle a completed plan-lane request: split actual usage across primary,
+    wallet, and project absorption (via allocate_plan_wallet_settlement), commit
+    each source, and commit RL token quota. Mirrors run() (plan lane).
+    """
+    ranked_tokens = int(ranked_tokens or 0)
+    total_cost = float(total_cost_usd or 0.0)
+    funding_source = res.funding_source
+    out = SettlementResult(ranked_tokens=ranked_tokens, total_cost_usd=total_cost)
+
+    if res.budget_bypass:
+        if total_cost > 0:
+            await ctx.budget_limiter.force_project_spend(
+                spent_usd=float(total_cost), bundle_id=ctx.bundle_id, provider=None,
+                request_id=ctx.scope_id, user_id=ctx.user_id, note="settle: admin bypass",
+            )
+        await _commit_rl(ctx, res, tokens=ranked_tokens)
+        out.primary_funding_usd = float(total_cost)
+        out.quota_commit_tokens = ranked_tokens
+        return out
+
+    # --- fresh capacity reads (net of OTHER reservations; add back our own) ---
+    quota_available_tokens: Optional[int] = None
+    quota_reserved_tokens = 0
+    try:
+        cap = await ctx.rl.token_capacity_for_reservation(
+            bundle_id=ctx.rl_bundle_id, subject_id=ctx.subject_id, policy=effective_policy,
+            reservation_id=res.plan_reservation_id if res.plan_reservation_active else None,
+            reserved_tokens=int(res.plan_reserved_tokens or 0) if res.plan_reservation_active else 0,
+            now=ctx.now,
+        )
+        quota_available_tokens = cap.get("available_tokens")
+        quota_reserved_tokens = int(cap.get("own_reserved_tokens") or 0)
+    except Exception as ex:
+        quota_available_tokens = 0 if res.plan_reservation_active else int(res.plan_project_tokens_est or 0)
+        quota_reserved_tokens = int(res.plan_reserved_tokens or 0) if res.plan_reservation_active else 0
+        ctx.log("charge.capacity", "fresh quota read failed; using reservation estimate", "WARN", error=str(ex))
+
+    primary_available_usd: Optional[float] = 0.0
+    if funding_source == "project":
+        try:
+            fresh = await ctx.budget_limiter.get_app_budget_balance()
+            primary_available_usd = float(fresh.get("available_usd") or 0.0)
+        except Exception as ex:
+            primary_available_usd = 0.0 if res.app_reservation_active else None
+            ctx.log("charge.capacity", "fresh project read failed", "WARN", error=str(ex))
+    elif funding_source == "subscription" and ctx.subscription_limiter is not None:
+        try:
+            fresh = await ctx.subscription_limiter.get_subscription_budget_balance()
+            primary_available_usd = float(fresh.get("available_usd") or 0.0)
+        except Exception as ex:
+            primary_available_usd = 0.0 if res.app_reservation_active else None
+            ctx.log("charge.capacity", "fresh subscription read failed", "WARN", error=str(ex))
+
+    wallet_available_tokens = 0
+    if plan_has_lifetime_budget:
+        try:
+            bal = await ctx.cp_manager.user_credits_mgr.get_lifetime_balance(
+                tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+            )
+            wallet_available_tokens = int(bal or 0)
+        except Exception as ex:
+            wallet_available_tokens = max(
+                int(user_budget_tokens or 0)
+                - (int(res.wallet_reserved_tokens or 0) if res.wallet_reservation_active else 0),
+                0,
+            )
+            ctx.log("charge.capacity", "fresh wallet read failed", "WARN", error=str(ex))
+
+    alloc = allocate_plan_wallet_settlement(
+        PlanWalletSettlementInput(
+            actual_tokens=ranked_tokens,
+            actual_cost_usd=total_cost,
+            quota_available_tokens=quota_available_tokens,
+            quota_reserved_tokens=int(quota_reserved_tokens),
+            primary_funding_available_usd=primary_available_usd,
+            primary_funding_reserved_usd=float(res.app_reserved_usd or 0.0) if res.app_reservation_active else 0.0,
+            primary_funding_reserved_tokens=int(res.plan_project_tokens_est or 0),
+            wallet_available_tokens=int(wallet_available_tokens),
+            wallet_reserved_tokens=int(res.wallet_reserved_tokens or 0) if res.wallet_reservation_active else 0,
+        )
+    )
+    out.allocation = alloc
+    plan_covered_usd = float(alloc.primary_funding_usd)
+    project_absorption_usd = float(alloc.project_absorption_usd)
+    plan_quota_commit_tokens = int(alloc.quota_tokens)
+    user_target_tokens = int(alloc.wallet_tokens)
+
+    # --- charge wallet (reserved part first, then reservation-free consume) ---
+    user_uncovered_tokens = 0
+    if user_target_tokens > 0:
+        remaining = int(user_target_tokens)
+        if res.wallet_reservation_active and res.wallet_reservation_id and res.wallet_reserved_tokens > 0:
+            reserved_target = min(remaining, int(res.wallet_reserved_tokens))
+            try:
+                reserved_uncovered = await ctx.cp_manager.user_credits_mgr.commit_reserved_lifetime_tokens(
+                    tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+                    reservation_id=str(res.wallet_reservation_id), tokens=int(reserved_target),
+                )
+            finally:
+                res.wallet_reservation_active = False
+            reserved_consumed = max(int(reserved_target) - int(reserved_uncovered or 0), 0)
+            remaining = max(remaining - reserved_consumed, 0)
+        if remaining > 0:
+            user_uncovered_tokens = await ctx.cp_manager.user_credits_mgr.consume_lifetime_tokens(
+                tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id, tokens=int(remaining),
+            )
+    elif res.wallet_reservation_active and res.wallet_reservation_id:
+        try:
+            await ctx.cp_manager.user_credits_mgr.release_lifetime_token_reservation(
+                tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+                reservation_id=str(res.wallet_reservation_id), reason="settle: no_wallet_spend",
+            )
+        finally:
+            res.wallet_reservation_active = False
+
+    user_uncovered_tokens = int(user_uncovered_tokens or 0)
+    user_uncovered_usd = _cost_for_tokens(tokens=user_uncovered_tokens, ranked_tokens=ranked_tokens, total_cost=total_cost)
+
+    # wallet shortfall can re-consume any remaining plan quota room
+    if user_uncovered_tokens > 0:
+        extra_room = max(int(alloc.quota_capacity_tokens) - int(plan_quota_commit_tokens), 0)
+        plan_quota_commit_tokens += min(int(user_uncovered_tokens), int(extra_room))
+
+    # --- charge primary + project absorption ------------------------------
+    extra_project_items: list[tuple[float, str]] = []
+    app_spend_usd = float(plan_covered_usd)
+    if funding_source == "subscription":
+        if project_absorption_usd > 0:
+            extra_project_items.append((float(project_absorption_usd), "shortfall:subscription_overage"))
+        if user_uncovered_usd > 0:
+            extra_project_items.append((float(user_uncovered_usd), "shortfall:wallet_subscription"))
+    else:  # project
+        if project_absorption_usd > 0:
+            note = "shortfall:wallet_plan" if (res.has_wallet or user_target_tokens > 0) else "shortfall:free_plan"
+            extra_project_items.append((float(project_absorption_usd), note))
+        if user_uncovered_usd > 0:
+            extra_project_items.append((float(user_uncovered_usd), "shortfall:wallet_plan"))
+
+    if app_spend_usd > 0 or (res.app_reservation_active and res.app_reservation_id):
+        if res.app_reservation_active and res.app_reservation_id:
+            if funding_source == "subscription":
+                await ctx.subscription_limiter.commit_reserved_spend(
+                    reservation_id=res.app_reservation_id, spent_usd=float(app_spend_usd),
+                    project_budget=ctx.budget_limiter,
+                )
+            else:
+                await ctx.budget_limiter.commit_reserved_spend(
+                    reservation_id=res.app_reservation_id, spent_usd=float(app_spend_usd),
+                )
+            res.app_reservation_active = False
+        else:
+            await ctx.budget_limiter.force_project_spend(
+                spent_usd=float(app_spend_usd), bundle_id=ctx.bundle_id, provider=None,
+                request_id=ctx.scope_id, user_id=ctx.user_id,
+                note=("settle: subscription_cost; no_reservation" if funding_source == "subscription" else "settle: plan_cost"),
+            )
+
+    for spend_usd, note in extra_project_items:
+        if spend_usd <= 0:
+            continue
+        await ctx.budget_limiter.force_project_spend(
+            spent_usd=float(spend_usd), bundle_id=ctx.bundle_id, provider=None,
+            request_id=ctx.scope_id, user_id=ctx.user_id, note=note,
+        )
+
+    await _commit_rl(ctx, res, tokens=int(plan_quota_commit_tokens))
+
+    out.primary_funding_usd = float(plan_covered_usd)
+    out.wallet_usd = float(alloc.wallet_usd)
+    out.project_absorption_usd = float(project_absorption_usd)
+    out.quota_commit_tokens = int(plan_quota_commit_tokens)
+    out.extra_project_items = extra_project_items
+    return out
+
+
+async def _commit_rl(ctx: FundingContext, res: PlanFundingReservation, *, tokens: int) -> None:
+    try:
+        await ctx.rl.commit_with_reservation(
+            bundle_id=ctx.rl_bundle_id, subject_id=ctx.subject_id,
+            tokens=int(tokens), lock_id=ctx.scope_id,
+            reservation_id=res.plan_reservation_id if res.plan_reservation_active else None,
+            now=ctx.now, inc_request=1,
+        )
+        res.plan_reservation_active = False
+        res.plan_reservation_id = None
+    except Exception as ex:
+        ctx.log("rl.commit", "RL commit failed", "WARN", error=str(ex))
+
+
+# ---------------------------------------------------------------------------
+# Cleanup (error/abort paths)
+# ---------------------------------------------------------------------------
+async def release_plan_funding(ctx: FundingContext, res: PlanFundingReservation) -> None:
+    """Release any still-held reservations (used on failure before settlement)."""
+    try:
+        if res.app_reservation_active and res.app_reservation_id:
+            if res.funding_source == "subscription" and ctx.subscription_limiter is not None:
+                await ctx.subscription_limiter.release_reservation(
+                    reservation_id=res.app_reservation_id, project_budget=ctx.budget_limiter,
+                )
+            else:
+                await ctx.budget_limiter.release_reservation(reservation_id=res.app_reservation_id)
+            res.app_reservation_active = False
+    except Exception as ex:
+        ctx.log("cleanup", "failed to release primary reservation", "WARN", error=str(ex))
+    try:
+        if res.wallet_reservation_active and res.wallet_reservation_id:
+            await ctx.cp_manager.user_credits_mgr.release_lifetime_token_reservation(
+                tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+                reservation_id=str(res.wallet_reservation_id), reason="cleanup",
+            )
+            res.wallet_reservation_active = False
+    except Exception as ex:
+        ctx.log("cleanup", "failed to release wallet reservation", "WARN", error=str(ex))
+    try:
+        if res.plan_reservation_active and res.plan_reservation_id:
+            await ctx.rl.release_token_reservation(
+                bundle_id=ctx.rl_bundle_id, subject_id=ctx.subject_id,
+                reservation_id=res.plan_reservation_id, now=ctx.now,
+            )
+            res.plan_reservation_active = False
+    except Exception as ex:
+        ctx.log("cleanup", "failed to release plan RL reservation", "WARN", error=str(ex))
+    try:
+        await ctx.rl.release(bundle_id=ctx.rl_bundle_id, subject_id=ctx.subject_id, lock_id=ctx.scope_id)
+    except Exception:
+        pass

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Phase-1 unit tests for the reusable economics enforcement engine.
+
+Redis-free: covers estimate sizing, nested-context detection, role carry,
+funding-source selection, denial-at-start, the nested degrade path, and a
+project-funded top-level happy path with fakes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kdcube_ai_app.infra import accounting as acct
+from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import QuotaPolicy, EconomicsLimitException
+from kdcube_ai_app.apps.chat.sdk.infra.economics.limiter import AdmitResult
+from kdcube_ai_app.apps.chat.sdk.infra.economics import enforcement as enf
+from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import (
+    EconomicsGuard,
+    EconomicsSubject,
+    EconomicsEstimate,
+    FlowPolicy,
+    RoleResolver,
+    economic_preflight,
+)
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+class _PlanBalance:
+    def __init__(self, wallet: bool = False):
+        self._wallet = wallet
+
+    def has_lifetime_budget(self) -> bool:
+        return self._wallet
+
+    def has_plan_override(self) -> bool:
+        return False
+
+    def plan_override_is_active(self) -> bool:
+        return False
+
+
+class _Sub:
+    def __init__(self, active: bool = True, plan_id: str = "beta-30"):
+        self.status = "active" if active else "canceled"
+        self.monthly_price_cents = 3000
+        self.next_charge_at = None
+        self.plan_id = plan_id
+        self.provider = "internal"
+        self.stripe_subscription_id = None
+        self.last_charged_at = None
+
+
+class _Credits:
+    def __init__(self, balance: int = 0):
+        self.balance = balance
+        self.reserved = []
+        self.committed = []
+        self.consumed = []
+        self.released = []
+
+    async def get_lifetime_balance(self, **kw):
+        return self.balance
+
+    async def reserve_lifetime_tokens(self, **kw):
+        self.reserved.append(kw)
+        return True
+
+    async def commit_reserved_lifetime_tokens(self, **kw):
+        self.committed.append(kw)
+        return 0
+
+    async def consume_lifetime_tokens(self, **kw):
+        self.consumed.append(kw)
+        return 0
+
+    async def release_lifetime_token_reservation(self, **kw):
+        self.released.append(kw)
+
+
+class _SubMgr:
+    def __init__(self, sub=None):
+        self.sub = sub
+
+    async def get_subscription(self, **kw):
+        return self.sub
+
+
+class _CP:
+    def __init__(self, *, plan_balance=None, sub=None, wallet=0, policy=None):
+        self._plan_balance = plan_balance or _PlanBalance(wallet=bool(wallet))
+        self.user_credits_mgr = _Credits(balance=wallet)
+        self.subscription_mgr = _SubMgr(sub=sub)
+        self._policy = policy or QuotaPolicy(max_concurrent=2, requests_per_day=100, tokens_per_month=10_000)
+
+    async def get_user_plan_balance(self, **kw):
+        return self._plan_balance
+
+    async def get_plan_quota_policy(self, **kw):
+        return self._policy
+
+
+class _RL:
+    def __init__(self, allowed: bool = True, reason=None):
+        self.allowed = allowed
+        self.reason = reason
+        self.admit_calls = []
+        self.commits = []
+        self.releases = []
+
+    async def admit(self, **kw):
+        self.admit_calls.append(kw)
+        reserve = int(kw.get("reserve_tokens") or 0)
+        return AdmitResult(
+            allowed=self.allowed,
+            reason=None if self.allowed else (self.reason or "tokens_per_month"),
+            lock_id=kw.get("lock_id") if self.allowed else None,
+            snapshot={"tok_month": 0, "req_day": 0},
+            reserved_tokens=reserve if self.allowed else 0,
+            reservation_id=(kw.get("reservation_id") if (self.allowed and reserve > 0) else None),
+        )
+
+    async def commit_with_reservation(self, **kw):
+        self.commits.append(kw)
+
+    async def token_capacity_for_reservation(self, **kw):
+        return {"available_tokens": 10**9, "own_reserved_tokens": int(kw.get("reserved_tokens") or 0)}
+
+    async def release_token_reservation(self, **kw):
+        self.releases.append(("tok", kw))
+        return 1
+
+    async def release(self, **kw):
+        self.releases.append(("lock", kw))
+        return 0
+
+
+class _Budget:
+    def __init__(self):
+        self.reserved = []
+        self.committed = []
+        self.released = []
+        self.forced = []
+
+    async def get_app_budget_balance(self):
+        return {"available_usd": 1000.0, "overdraft_limit_usd": None}
+
+    async def reserve(self, **kw):
+        self.reserved.append(kw)
+        return type("RR", (), {"reservation_id": kw.get("reservation_id")})()
+
+    async def commit_reserved_spend(self, **kw):
+        self.committed.append(kw)
+
+    async def release_reservation(self, **kw):
+        self.released.append(kw)
+
+    async def force_project_spend(self, **kw):
+        self.forced.append(kw)
+
+
+class _Spec:
+    id = "test-bundle@1"
+
+
+class _Config:
+    ai_bundle_spec = _Spec()
+
+
+class _EP:
+    def __init__(self, *, cp, rl, budget, accounting_result=(1000, {"cost_total_usd": 0.03})):
+        self.cp_manager = cp
+        self.rl = rl
+        self.budget_limiter = budget
+        self.logger = None
+        self.comm = None
+        self.config = _Config()
+        self.pg_pool = None
+        self._acct = accounting_result
+        self.run_accounting_calls = []
+
+    def wallet_users_use_project_budget_first(self) -> bool:
+        return True
+
+    def project_budget_allowed_for_plan(self, *, user_type, plan_id, plan_source, has_wallet, has_active_subscription):
+        # Mirrors BaseEntrypointWithEconomics.project_budget_allowed_for_plan
+        if has_active_subscription:
+            return False
+        if has_wallet and not self.wallet_users_use_project_budget_first():
+            return False
+        return str(user_type or "").lower() != "anonymous"
+
+    async def run_accounting(self, **kw):
+        self.run_accounting_calls.append(kw)
+        return self._acct
+
+
+def _subject(role="registered"):
+    return EconomicsSubject(tenant="t", project="p", user_id="u1", user_type=role, timezone="UTC")
+
+
+def _ep(*, sub=None, wallet=0, allowed=True, reason=None, accounting=(1000, {"cost_total_usd": 0.03})):
+    cp = _CP(sub=sub, wallet=wallet, plan_balance=_PlanBalance(wallet=bool(wallet)))
+    rl = _RL(allowed=allowed, reason=reason)
+    budget = _Budget()
+    return _EP(cp=cp, rl=rl, budget=budget, accounting_result=accounting)
+
+
+# --------------------------------------------------------------------------
+# Estimate sizing
+# --------------------------------------------------------------------------
+def test_estimate_reservation_usd_drives_tokens():
+    upt = enf._usd_per_token()
+    est = EconomicsEstimate(reservation_usd=0.05, min_tokens=10)
+    tokens = enf._estimate_tokens(est, upt)
+    # tokens ~= reservation_usd / (upt * SAFETY_MARGIN)
+    assert tokens > 10
+    assert tokens == max(10, __import__("math").ceil(0.05 / (upt * enf.SAFETY_MARGIN)))
+
+
+def test_estimate_text_path_uses_floor():
+    est = EconomicsEstimate(input_text="hello world", output_budget_tokens=0, min_tokens=500)
+    tokens = enf._estimate_tokens(est, enf._usd_per_token())
+    assert tokens >= 500
+
+
+# --------------------------------------------------------------------------
+# Economics-scope detection (NOT raw accounting context)
+# --------------------------------------------------------------------------
+def test_active_econ_scope_none_by_default():
+    assert enf.active_econ_scope() is None
+
+
+def test_accounting_context_alone_is_not_an_econ_scope():
+    # A bare accounting context (as a background-job worker binds) must NOT be
+    # treated as a settling economics parent — otherwise top-level background
+    # flows wrongly degrade to preflight and never reserve/settle.
+    with acct.with_accounting("chat", turn_id="turn-123", conversation_id="conv-1"):
+        assert enf.active_econ_scope() is None
+
+
+# --------------------------------------------------------------------------
+# Role carry
+# --------------------------------------------------------------------------
+def test_role_resolver_is_privileged():
+    assert RoleResolver._is_privileged("privileged")
+    assert RoleResolver._is_privileged("admin")
+    assert not RoleResolver._is_privileged("registered")
+    assert not RoleResolver._is_privileged(None)
+
+
+async def test_role_resolver_preserves_privileged_without_db():
+    rr = RoleResolver(pg_pool=None, tenant="t", project="p")
+    # privileged is carried, resolver (DB) is never touched
+    assert await rr.resolve(user_id="u1", carried_role="privileged") == "privileged"
+    assert await rr.resolve(user_id="u1", carried_role="admin") == "admin"
+
+
+# --------------------------------------------------------------------------
+# Funding-source selection
+# --------------------------------------------------------------------------
+async def test_funding_summary_subscription():
+    ep = _ep(sub=_Sub(active=True))
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="s1", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05))
+    r = await g._resolve_plan_and_funding()
+    assert r["has_active_subscription"] is True
+    assert g._funding_summary(r)[0] == "subscription"
+
+
+async def test_funding_summary_project_for_registered():
+    ep = _ep()  # no sub, no wallet
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="s1", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05))
+    r = await g._resolve_plan_and_funding()
+    assert g._funding_summary(r)[0] == "project"
+
+
+async def test_funding_summary_wallet_when_no_project():
+    ep = _ep(wallet=1_000_000)
+    g = EconomicsGuard(ep, subject=_subject("anonymous"), scope_id="s1", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05))
+    r = await g._resolve_plan_and_funding()
+    # anonymous: project not allowed, wallet present -> wallet
+    assert g._funding_summary(r)[0] == "wallet"
+
+
+async def test_funding_summary_paid_wallet_user_uses_project():
+    # Alignment with run()'s project_budget_allowed_for_plan: a wallet-first paid
+    # user's plan lane is backed by PROJECT (wallet is overflow only), NOT wallet.
+    ep = _ep(wallet=1_000_000)
+    g = EconomicsGuard(ep, subject=_subject("paid"), scope_id="s1", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05))
+    r = await g._resolve_plan_and_funding()
+    assert r["project_budget_allowed"] is True
+    assert g._funding_summary(r)[0] == "project"
+
+
+async def test_funding_summary_none():
+    ep = _ep()
+    g = EconomicsGuard(ep, subject=_subject("anonymous"), scope_id="s1", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05))
+    r = await g._resolve_plan_and_funding()
+    assert g._funding_summary(r)[0] == "none"
+
+
+async def test_concurrency_dropped_for_non_chat():
+    ep = _ep()
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="s1", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05),
+                       policy=FlowPolicy(enforce_concurrency=False))
+    r = await g._resolve_plan_and_funding()
+    assert r["base_policy"].max_concurrent is None
+
+
+# --------------------------------------------------------------------------
+# Denial at start
+# --------------------------------------------------------------------------
+async def test_preflight_denies_when_rate_limited():
+    ep = _ep(allowed=False, reason="tokens_per_month")
+    with pytest.raises(EconomicsLimitException) as ei:
+        await economic_preflight(
+            ep, subject=_subject("registered"),
+            estimate=EconomicsEstimate(reservation_usd=0.05), flow="memory.search",
+        )
+    assert ei.value.code == "rate_limited"
+
+
+async def test_preflight_denies_when_no_funding():
+    ep = _ep()  # anonymous -> none
+    with pytest.raises(EconomicsLimitException) as ei:
+        await economic_preflight(
+            ep, subject=_subject("anonymous"),
+            estimate=EconomicsEstimate(reservation_usd=0.05), flow="memory.search",
+        )
+    assert ei.value.code == "no_funding_source"
+
+
+async def test_guard_enter_denies_before_body_and_no_reservation():
+    ep = _ep(allowed=False, reason="tokens_per_month")
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="s1", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05))
+    with pytest.raises(EconomicsLimitException):
+        await g.__aenter__()
+    assert ep.budget_limiter.reserved == []  # never reserved on denial
+
+
+# --------------------------------------------------------------------------
+# Nested degrade (anti double-charge)
+# --------------------------------------------------------------------------
+async def test_guard_degrades_to_preflight_when_inside_active_guard():
+    ep = _ep()
+    # Simulate an outer settling economics scope (guard-in-guard).
+    token = enf._ECON_SCOPE_ACTIVE.set("outer-scope")
+    try:
+        g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="s1", flow="f",
+                           estimate=EconomicsEstimate(reservation_usd=0.05))
+        decision = await g.__aenter__()
+        assert decision.nested is True
+        # no reservation, no accounting bind of our own
+        assert ep.budget_limiter.reserved == []
+        assert g._acct_cm is None
+        # __aexit__ on a nested decision is a no-op
+        await g.__aexit__(None, None, None)
+        assert ep.budget_limiter.committed == []
+    finally:
+        enf._ECON_SCOPE_ACTIVE.reset(token)
+
+
+async def test_guard_runs_top_level_inside_bare_accounting_context():
+    # Regression: a background-job-style accounting context must NOT make the
+    # guard nested — it must reserve and settle (own scope).
+    ep = _ep()
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="bg-scope", flow="memory.reconciler",
+                       estimate=EconomicsEstimate(reservation_usd=0.05))
+    with acct.with_accounting("job.worker", turn_id="turn_bg", conversation_id="turn_bg"):
+        decision = await g.__aenter__()
+        assert decision.nested is False
+        assert len(ep.budget_limiter.reserved) == 1
+        # while inside, the marker is our scope
+        assert enf.active_econ_scope() == "bg-scope"
+        await g.__aexit__(None, None, None)
+    assert enf.active_econ_scope() is None
+    assert len(ep.budget_limiter.committed) == 1
+
+
+# --------------------------------------------------------------------------
+# Top-level happy path (project funded)
+# --------------------------------------------------------------------------
+async def test_top_level_project_lifecycle_reserves_and_settles():
+    ep = _ep(accounting=(1000, {"cost_total_usd": 0.03}))
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="scope-xyz", flow="memory.reconciler",
+                       estimate=EconomicsEstimate(reservation_usd=0.05))
+    decision = await g.__aenter__()
+    assert decision.nested is False
+    assert decision.funding_source == "project"
+    assert decision.app_reservation_source == "project"
+    assert len(ep.budget_limiter.reserved) == 1
+    # accounting bound under scope_id
+    assert enf.active_econ_scope() == "scope-xyz"
+
+    await g.__aexit__(None, None, None)
+    # settled: project reservation committed, rl usage committed, accounting unbound
+    assert len(ep.budget_limiter.committed) == 1
+    assert len(ep.rl.commits) == 1
+    assert ep.run_accounting_calls and ep.run_accounting_calls[0]["turn_id"] == "scope-xyz"
+    assert enf.active_econ_scope() is None
+
+
+async def test_top_level_releases_reservation_on_accounting_failure():
+    class _BadEP(_EP):
+        async def run_accounting(self, **kw):
+            raise RuntimeError("boom")
+
+    cp = _CP(plan_balance=_PlanBalance(False))
+    ep = _BadEP(cp=cp, rl=_RL(), budget=_Budget())
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="s9", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05))
+    await g.__aenter__()
+    await g.__aexit__(None, None, None)
+    # settlement failed -> reservation released, accounting unbound
+    assert len(ep.budget_limiter.released) == 1
+    assert enf.active_econ_scope() is None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_memory_search.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_memory_search.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Phase-4 wiring tests: memory semantic search -> economic_preflight + BM25 downgrade.
+
+Exercises the search economics helpers added to the memory entrypoint without
+standing up the store/embedder. `economic_preflight` is monkeypatched to drive
+the allow / limit branches; methods are called unbound against a light stub.
+"""
+
+from __future__ import annotations
+
+import types
+
+from kdcube_ai_app.apps.chat.sdk.solutions.chatbot.entrypoint_with_memory import (
+    MemoryEntrypointMixin as M,
+)
+from kdcube_ai_app.apps.chat.sdk.infra.economics import enforcement as enf
+from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import EconomicsLimitException
+
+
+class _Spec:
+    id = "b@1"
+
+
+class _Config:
+    ai_bundle_spec = _Spec()
+
+
+class _StubSearchEP:
+    """Minimal stand-in for the memory entrypoint, synchronous (widget) shape."""
+
+    def __init__(self, *, economics=True, user_type="registered", user_id="u1", reservation=0.01):
+        self.cp_manager = object() if economics else None
+        self.rl = object() if economics else None
+        self.budget_limiter = object() if economics else None
+        self._reservation = reservation
+        self.embed_calls: list[str] = []
+        self.comm_context = types.SimpleNamespace(
+            actor=types.SimpleNamespace(tenant_id="t", project_id="p"),
+            user=types.SimpleNamespace(user_id=user_id, user_type=user_type),
+        )
+        self.comm = types.SimpleNamespace(user_id=user_id)
+        self.settings = types.SimpleNamespace(TENANT="t", PROJECT="p")
+        self.config = _Config()
+
+    def _memory_widget_config(self):
+        return {"search_reservation_amount_dollars": self._reservation}
+
+    async def _memory_embed_one(self, text):
+        self.embed_calls.append(text)
+        return [0.1, 0.2, 0.3]
+
+    # delegate to the real mixin implementations
+    def _memory_economics_enabled(self):
+        return M._memory_economics_enabled(self)
+
+    def _memory_scope(self):
+        return M._memory_scope(self)
+
+    def _memory_effective_user_type(self, default="registered"):
+        return M._memory_effective_user_type(self, default)
+
+    def _memory_search_reservation_usd(self):
+        return M._memory_search_reservation_usd(self)
+
+    def _memory_search_econ_subject(self):
+        return M._memory_search_econ_subject(self)
+
+    async def _memory_search_embed_or_downgrade(self, query):
+        return await M._memory_search_embed_or_downgrade(self, query)
+
+
+def test_search_reservation_usd_from_config_and_default():
+    assert M._memory_search_reservation_usd(_StubSearchEP(reservation=0.03)) == 0.03
+    # bad value -> default
+    assert M._memory_search_reservation_usd(_StubSearchEP(reservation="nope")) == 0.01
+
+
+def test_search_subject_uses_session_role():
+    subj = M._memory_search_econ_subject(_StubSearchEP(user_type="paid", user_id="u9"))
+    assert (subj.tenant, subj.project, subj.user_id) == ("t", "p", "u9")
+    assert subj.user_type == "paid"
+
+
+async def test_empty_query_skips_embed_and_preflight(monkeypatch):
+    called = {"preflight": 0}
+
+    async def _pf(*a, **k):
+        called["preflight"] += 1
+
+    monkeypatch.setattr(enf, "economic_preflight", _pf)
+    ep = _StubSearchEP()
+    assert await ep._memory_search_embed_or_downgrade("   ") is None
+    assert ep.embed_calls == []
+    assert called["preflight"] == 0
+
+
+async def test_economics_disabled_embeds_without_preflight(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("preflight must not run when economics disabled")
+
+    monkeypatch.setattr(enf, "economic_preflight", _boom)
+    ep = _StubSearchEP(economics=False)
+    out = await ep._memory_search_embed_or_downgrade("hello")
+    assert out == [0.1, 0.2, 0.3]
+    assert ep.embed_calls == ["hello"]
+
+
+async def test_preflight_ok_embeds(monkeypatch):
+    seen = {}
+
+    async def _pf(entrypoint, *, subject, estimate, flow, policy=None):
+        seen["flow"] = flow
+        seen["reservation"] = estimate.reservation_usd
+        seen["role"] = subject.user_type
+        return object()
+
+    monkeypatch.setattr(enf, "economic_preflight", _pf)
+    ep = _StubSearchEP(user_type="paid", reservation=0.02)
+    out = await ep._memory_search_embed_or_downgrade("query text")
+    assert out == [0.1, 0.2, 0.3]
+    assert ep.embed_calls == ["query text"]
+    assert seen == {"flow": "memory.search", "reservation": 0.02, "role": "paid"}
+
+
+async def test_economics_limit_downgrades_to_bm25(monkeypatch):
+    async def _pf(*a, **k):
+        raise EconomicsLimitException("rate limited", code="rate_limited")
+
+    monkeypatch.setattr(enf, "economic_preflight", _pf)
+    ep = _StubSearchEP()
+    out = await ep._memory_search_embed_or_downgrade("query text")
+    assert out is None             # query_embedding=None -> store falls back to FTS/BM25
+    assert ep.embed_calls == []    # embedding cost was NOT paid
+
+
+async def test_anonymous_skips_preflight_and_embeds(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("preflight must not run for anonymous user")
+
+    monkeypatch.setattr(enf, "economic_preflight", _boom)
+    ep = _StubSearchEP(user_id="anonymous")
+    out = await ep._memory_search_embed_or_downgrade("query text")
+    assert out == [0.1, 0.2, 0.3]
+    assert ep.embed_calls == ["query text"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_memory_wiring.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_memory_wiring.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Phase-3 wiring tests: memory reconciler -> EconomicsGuard.
+
+Exercises the economics helpers added to the memory entrypoint without standing
+up the full reconciliation pipeline (snapshot/candidates/LLM). Methods are called
+unbound against a light stub `self`.
+"""
+
+from __future__ import annotations
+
+from kdcube_ai_app.apps.chat.sdk.solutions.chatbot.entrypoint_with_memory import (
+    MemoryEntrypointMixin as M,
+)
+from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import EconomicsGuard
+
+
+class _Spec:
+    id = "task-and-memo-app@1-0"
+
+
+class _Config:
+    ai_bundle_spec = _Spec()
+
+
+class _StubMemEP:
+    """Minimal stand-in for the memory entrypoint for economics wiring tests."""
+
+    def __init__(self, *, economics: bool = True, reservation=0.25, pg_pool=None):
+        self.cp_manager = object() if economics else None
+        self.rl = object() if economics else None
+        self.budget_limiter = object() if economics else None
+        self.pg_pool = pg_pool
+        self.logger = None
+        self.comm = None
+        self.config = _Config()
+        self._reservation = reservation
+        self.stored = []
+
+    def _memory_reconciliation_config(self):
+        return {"reservation_amount_dollars": self._reservation}
+
+    async def _memory_reconciliation_store_job(self, job):
+        self.stored.append(dict(job))
+        return job
+
+    # delegate to the real mixin implementations (these call each other via self.*)
+    def _memory_economics_enabled(self):
+        return M._memory_economics_enabled(self)
+
+    def _memory_reconciliation_reservation_usd(self):
+        return M._memory_reconciliation_reservation_usd(self)
+
+    async def _memory_reconciliation_econ_subject(self, job):
+        return await M._memory_reconciliation_econ_subject(self, job)
+
+
+def _job(role="registered"):
+    return {
+        "job_id": "memrec_20260604_abc",
+        "user_type": role,
+        "timezone": "Europe/Kyiv",
+        "scope": {"tenant": "t", "project": "p", "user_id": "u1", "bundle_id": "b@1"},
+    }
+
+
+def test_economics_enabled_flag():
+    assert M._memory_economics_enabled(_StubMemEP(economics=True)) is True
+    assert M._memory_economics_enabled(_StubMemEP(economics=False)) is False
+
+
+def test_reservation_usd_from_config():
+    assert M._memory_reconciliation_reservation_usd(_StubMemEP(reservation=0.25)) == 0.25
+    # bad value -> default
+    ep = _StubMemEP(reservation="nope")
+    assert M._memory_reconciliation_reservation_usd(ep) == 0.10
+
+
+async def test_subject_preserves_privileged_carried_role():
+    ep = _StubMemEP(pg_pool=None)  # no DB -> carried role kept
+    subj = await M._memory_reconciliation_econ_subject(ep, _job(role="privileged"))
+    assert subj.user_type == "privileged"
+    assert (subj.tenant, subj.project, subj.user_id) == ("t", "p", "u1")
+    assert subj.timezone == "Europe/Kyiv"
+
+
+async def test_subject_uses_carried_role_when_no_pg():
+    ep = _StubMemEP(pg_pool=None)
+    subj = await M._memory_reconciliation_econ_subject(ep, _job(role="registered"))
+    assert subj.user_type == "registered"
+
+
+async def test_make_guard_none_when_economics_disabled():
+    ep = _StubMemEP(economics=False)
+    guard = await M._memory_reconciliation_make_guard(ep, _job(), "memrec_20260604_abc")
+    assert guard is None
+
+
+async def test_make_guard_none_when_scope_incomplete():
+    ep = _StubMemEP(economics=True)
+    bad = _job()
+    bad["scope"] = {"tenant": "", "project": "", "user_id": ""}
+    guard = await M._memory_reconciliation_make_guard(ep, bad, "memrec_x")
+    assert guard is None
+
+
+async def test_make_guard_built_when_enabled():
+    ep = _StubMemEP(economics=True)
+    guard = await M._memory_reconciliation_make_guard(ep, _job(), "memrec_20260604_abc")
+    assert isinstance(guard, EconomicsGuard)
+    assert guard.scope_id == "mem_reconcile_memrec_20260604_abc"
+    assert guard.flow == "memory.reconciler"
+    assert guard.estimate.reservation_usd == 0.25
+    assert guard.policy.enforce_concurrency is False
+    assert guard.policy.emit_user_events is False
+
+
+async def test_mark_economics_denied_sets_job_fields():
+    ep = _StubMemEP()
+    job = _job()
+
+    class _Exc(RuntimeError):
+        code = "rate_limited"
+        data = {"reason": "tokens_per_month"}
+
+    await M._memory_reconciliation_mark_economics_denied(ep, job, _Exc("limit hit"))
+    assert job["status"] == "failed"
+    assert job["economics"]["denied"] is True
+    assert job["economics"]["code"] == "rate_limited"
+    assert ep.stored and ep.stored[-1]["status"] == "failed"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_task_wiring.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_task_wiring.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Phase-2 wiring tests: task execution -> economic_preflight (verify + log).
+
+Task definition: tasks carry the user identity, verify economic feasibility of
+the pipeline, and log the economic limits. This is VERIFY-ONLY (no reserve/settle)
+— the ReAct work routes through self.run() which meters the real cost under the
+same user. `economic_preflight` is monkeypatched to drive allow/deny.
+"""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.tasks import operations as ops
+from kdcube_ai_app.apps.chat.sdk.infra.economics import enforcement as enf
+from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import EconomicsLimitException
+
+
+class _Spec:
+    id = "task-and-memo-app@1-0"
+
+
+class _Config:
+    tenant = "t"
+    project = "p"
+    ai_bundle_spec = _Spec()
+
+
+class _FakeUser:
+    def __init__(self, user_id=None, user_type=None):
+        self.user_id = user_id
+        self.user_type = user_type
+        self.timezone = None
+
+
+class _FakeCtx:
+    """Minimal comm_context with model_copy (stands in for the pydantic ctx)."""
+
+    def __init__(self, user_type="registered"):
+        self.routing = SimpleNamespace(session_id=None, conversation_id=None, turn_id=None)
+        self.user = _FakeUser(user_type=user_type)
+        self.actor = SimpleNamespace(tenant_id="t", project_id="p")
+        self.bundle_call_context = None
+
+    def model_copy(self, deep=False):
+        return copy.deepcopy(self)
+
+
+class _StubEP:
+    """Minimal stand-in for a task entrypoint for economics wiring tests."""
+
+    def __init__(self, *, economics=True, reservation=0.50, pg_pool=None, user_type=None):
+        self.cp_manager = object() if economics else None
+        self.rl = object() if economics else None
+        self.budget_limiter = object() if economics else None
+        self.pg_pool = pg_pool
+        self.config = _Config()
+        self.settings = SimpleNamespace(TENANT="t", PROJECT="p")
+        self.logger = None
+        self.comm = None
+        self._reservation = reservation
+        self.comm_context = (
+            SimpleNamespace(user=SimpleNamespace(user_type=user_type, timezone=None))
+            if user_type is not None
+            else None
+        )
+
+    def bundle_prop(self, path, default=None):
+        if path == "economics.task.reservation_amount_dollars":
+            return self._reservation
+        return default
+
+
+def test_task_economics_enabled_flag():
+    assert ops._task_economics_enabled(_StubEP(economics=True)) is True
+    assert ops._task_economics_enabled(_StubEP(economics=False)) is False
+
+
+def test_task_reservation_usd_from_config_and_default():
+    assert ops._task_reservation_usd(_StubEP(reservation=1.25)) == 1.25
+    assert ops._task_reservation_usd(_StubEP(reservation="nope")) == 0.50
+
+
+async def test_task_subject_uses_carried_role_when_no_pg():
+    ep = _StubEP(pg_pool=None)
+    subj = await ops._task_econ_subject(ep, target_user="u1", source={"user_type": "privileged"})
+    assert (subj.tenant, subj.project, subj.user_id) == ("t", "p", "u1")
+    assert subj.user_type == "privileged"  # privileged preserved without DB re-resolve
+
+
+async def test_task_subject_falls_back_to_registered():
+    ep = _StubEP(pg_pool=None)
+    subj = await ops._task_econ_subject(ep, target_user="u1", source={})
+    assert subj.user_type == "registered"
+
+
+# --------------------------------------------------------------------------
+# Verify (economic_preflight) — verify-only, no reserve/settle
+# --------------------------------------------------------------------------
+async def test_verify_economics_disabled_returns_none(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("preflight must not run when economics disabled")
+
+    monkeypatch.setattr(enf, "economic_preflight", _boom)
+    subj, dec = await ops._task_verify_economics(_StubEP(economics=False), target_user="u1", source={})
+    assert (subj, dec) == (None, None)
+
+
+async def test_verify_economics_preflight_ok(monkeypatch):
+    seen = {}
+
+    async def _pf(entrypoint, *, subject, estimate, flow, policy=None):
+        seen["flow"] = flow
+        seen["role"] = subject.user_type
+        seen["res"] = estimate.reservation_usd
+        seen["concurrency"] = policy.enforce_concurrency
+        return SimpleNamespace(lane="plan", plan_id="free", funding_source="project", est_turn_usd=0.5, admit=None)
+
+    monkeypatch.setattr(enf, "economic_preflight", _pf)
+    ep = _StubEP(economics=True, reservation=0.5)
+    subj, dec = await ops._task_verify_economics(ep, target_user="u1", source={"user_type": "paid"})
+    assert subj.user_type == "paid"
+    assert dec.funding_source == "project"
+    assert seen == {"flow": "tasks", "role": "paid", "res": 0.5, "concurrency": False}
+
+
+async def test_verify_economics_denied_raises(monkeypatch):
+    async def _pf(*a, **k):
+        raise EconomicsLimitException("rate limited", code="rate_limited")
+
+    monkeypatch.setattr(enf, "economic_preflight", _pf)
+    with pytest.raises(EconomicsLimitException):
+        await ops._task_verify_economics(_StubEP(economics=True), target_user="u1", source={})
+
+
+def test_task_economics_metadata_logs_limits():
+    admit = SimpleNamespace(snapshot={"tok_month": 100, "req_day": 5})
+    decision = SimpleNamespace(
+        lane="plan", plan_id="free", funding_source="project", est_turn_usd=0.5, admit=admit,
+    )
+    meta = ops._task_economics_metadata(decision)
+    assert meta["economics"]["verified"] is True
+    assert meta["economics"]["funding_source"] == "project"
+    assert meta["economics"]["limits"] == {"tok_month": 100, "req_day": 5}
+    assert ops._task_economics_metadata(None) == {}
+
+
+# --------------------------------------------------------------------------
+# Point (2): resolved role propagated into the scoped context for inner run()
+# --------------------------------------------------------------------------
+def test_scoped_context_propagates_resolved_role():
+    ep = _StubEP(economics=True)
+    ep.comm_context = _FakeCtx(user_type="registered")
+    ctx = ops._build_task_scoped_context(
+        ep, target_user="u1", run_conversation_id="conv", turn_id="turn_e1",
+        bundle_call_context={}, resolved_user_type="paid",
+    )
+    assert ctx.user.user_id == "u1"
+    assert ctx.user.user_type == "paid"  # inner run() now bills the correct plan
+
+
+def test_scoped_context_keeps_role_when_unresolved():
+    ep = _StubEP(economics=True)
+    ep.comm_context = _FakeCtx(user_type="registered")
+    ctx = ops._build_task_scoped_context(
+        ep, target_user="u1", run_conversation_id="conv", turn_id="turn_e1",
+        bundle_call_context={}, resolved_user_type=None,
+    )
+    assert ctx.user.user_type == "registered"  # unchanged

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Unit tests for the shared plan-lane funding reserve+settle (funding_flow).
+
+Deterministic usd_per_token; fakes record limiter calls. Verifies primary cover
+sizing, wallet overflow reservation, denial, and that the split allocation is
+wired to the correct limiter on settlement.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import QuotaPolicy, EconomicsLimitException
+from kdcube_ai_app.apps.chat.sdk.infra.economics.project_budget import BudgetInsufficientFunds
+from kdcube_ai_app.apps.chat.sdk.infra.economics import funding_flow as ff
+
+UPT = 1e-5  # usd per token (deterministic)
+
+
+class _Admit:
+    def __init__(self, reserved=2000, rid="scope-1"):
+        self.reserved_tokens = reserved
+        self.reservation_id = rid
+
+
+class _RL:
+    def __init__(self, available_tokens=10**9):
+        self.available_tokens = available_tokens
+        self.commits = []
+        self.releases = []
+
+    async def token_capacity_for_reservation(self, **kw):
+        return {"available_tokens": self.available_tokens, "own_reserved_tokens": int(kw.get("reserved_tokens") or 0)}
+
+    async def commit_with_reservation(self, **kw):
+        self.commits.append(kw)
+
+    async def release_token_reservation(self, **kw):
+        self.releases.append(("tok", kw))
+
+    async def release(self, **kw):
+        self.releases.append(("lock", kw))
+
+
+class _Budget:
+    def __init__(self, available_usd=1000.0, overdraft=None, reserve_fail=False):
+        self.available_usd = available_usd
+        self.overdraft = overdraft
+        self.reserve_fail = reserve_fail
+        self.reserved = []
+        self.committed = []
+        self.forced = []
+        self.released = []
+
+    async def get_app_budget_balance(self):
+        return {"available_usd": self.available_usd, "overdraft_limit_usd": self.overdraft}
+
+    async def reserve(self, **kw):
+        if self.reserve_fail:
+            raise BudgetInsufficientFunds("no funds")
+        self.reserved.append(kw)
+        return type("RR", (), {"reservation_id": kw["reservation_id"]})()
+
+    async def commit_reserved_spend(self, **kw):
+        self.committed.append(kw)
+
+    async def force_project_spend(self, **kw):
+        self.forced.append(kw)
+
+    async def release_reservation(self, **kw):
+        self.released.append(kw)
+
+
+class _SubBudget(_Budget):
+    async def get_subscription_budget_balance(self):
+        return {"available_usd": self.available_usd}
+
+
+class _Credits:
+    def __init__(self, balance=10**9, reserve_ok=True, consume_uncovered=0, commit_uncovered=0):
+        self.balance = balance
+        self.reserve_ok = reserve_ok
+        self.consume_uncovered = consume_uncovered
+        self.commit_uncovered = commit_uncovered
+        self.reserved = []
+        self.committed = []
+        self.consumed = []
+        self.released = []
+
+    async def get_lifetime_balance(self, **kw):
+        return self.balance
+
+    async def reserve_lifetime_tokens(self, **kw):
+        self.reserved.append(kw)
+        return self.reserve_ok
+
+    async def commit_reserved_lifetime_tokens(self, **kw):
+        self.committed.append(kw)
+        return self.commit_uncovered
+
+    async def consume_lifetime_tokens(self, **kw):
+        self.consumed.append(kw)
+        return self.consume_uncovered
+
+    async def release_lifetime_token_reservation(self, **kw):
+        self.released.append(kw)
+
+
+class _CP:
+    def __init__(self, credits):
+        self.user_credits_mgr = credits
+
+
+def _ctx(*, rl=None, budget=None, sub=None, credits=None):
+    credits = credits or _Credits()
+    return ff.FundingContext(
+        rl=rl or _RL(),
+        budget_limiter=budget or _Budget(),
+        cp_manager=_CP(credits),
+        tenant="t", project="p", user_id="u1", subject_id="t:p:u1",
+        bundle_id="b@1", rl_bundle_id="__project__", scope_id="scope-1",
+        usd_per_token=UPT, now=datetime.now(timezone.utc),
+        subscription_limiter=sub,
+    )
+
+
+# --------------------------------------------------------------------------
+# Reserve
+# --------------------------------------------------------------------------
+async def test_reserve_project_unlimited_covers_full_no_wallet():
+    ctx = _ctx(budget=_Budget(overdraft=None))
+    res = await ff.reserve_plan_funding(
+        ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=False,
+        est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
+        project_budget_snapshot={"overdraft_limit_usd": None, "available_usd": 0.0},
+        personal_can_pay_turn=False,
+    )
+    assert res.plan_project_tokens_est == 2000          # unlimited overdraft -> full cover
+    assert res.app_reservation_active is True
+    assert len(ctx.budget_limiter.reserved) == 1
+    assert ctx.cp_manager.user_credits_mgr.reserved == []  # no wallet overflow
+
+
+async def test_reserve_project_finite_overdraft_reserves_wallet_overflow():
+    # available+overdraft = $0.05 -> ~4347 tokens primary (well above the $0.01
+    # min-reserve floor); the remaining ~5653 overflow to wallet.
+    ctx = _ctx(budget=_Budget(overdraft=0.0))
+    res = await ff.reserve_plan_funding(
+        ctx, admit=_Admit(reserved=10000), funding_source="project", budget_bypass=False,
+        est_turn_tokens=10000, has_wallet=True, subscription_available_usd=0.0,
+        project_budget_snapshot={"overdraft_limit_usd": 0.0, "available_usd": 0.05},
+        personal_can_pay_turn=True,
+    )
+    assert 0 < res.plan_project_tokens_est < 10000
+    assert res.app_reservation_active is True
+    assert res.wallet_reservation_active is True
+    assert res.wallet_reserved_tokens == 10000 - res.plan_project_tokens_est
+
+
+async def test_reserve_subscription_with_wallet_overflow():
+    sub = _SubBudget(available_usd=0.05)
+    ctx = _ctx(sub=sub)
+    res = await ff.reserve_plan_funding(
+        ctx, admit=_Admit(reserved=10000), funding_source="subscription", budget_bypass=False,
+        est_turn_tokens=10000, has_wallet=True, subscription_available_usd=0.05,
+        project_budget_snapshot=None, personal_can_pay_turn=True,
+    )
+    assert 0 < res.plan_project_tokens_est < 10000
+    assert len(sub.reserved) == 1                        # primary hold on subscription
+    assert res.wallet_reservation_active is True
+
+
+async def test_reserve_denies_when_primary_fails_and_no_wallet():
+    ctx = _ctx(budget=_Budget(overdraft=0.0, reserve_fail=True))
+    with pytest.raises(EconomicsLimitException) as ei:
+        await ff.reserve_plan_funding(
+            ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=False,
+            est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
+            project_budget_snapshot={"overdraft_limit_usd": 0.0, "available_usd": 1000.0},
+            personal_can_pay_turn=False,
+        )
+    assert "reservation_failed" in ei.value.code or ei.value.code == "no_funding_source"
+
+
+async def test_reserve_bypass_takes_no_money_hold():
+    ctx = _ctx()
+    res = await ff.reserve_plan_funding(
+        ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=True,
+        est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
+        project_budget_snapshot={"overdraft_limit_usd": None, "available_usd": 0.0},
+        personal_can_pay_turn=False,
+    )
+    assert res.app_reservation_active is False
+    assert ctx.budget_limiter.reserved == []
+
+
+# --------------------------------------------------------------------------
+# Settle
+# --------------------------------------------------------------------------
+async def test_settle_project_commits_reservation_and_rl():
+    ctx = _ctx(budget=_Budget(overdraft=None, available_usd=1000.0))
+    res = await ff.reserve_plan_funding(
+        ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=False,
+        est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
+        project_budget_snapshot={"overdraft_limit_usd": None, "available_usd": 1000.0},
+        personal_can_pay_turn=False,
+    )
+    out = await ff.settle_plan_funding(
+        ctx, res, ranked_tokens=1500, total_cost_usd=0.015,
+        effective_policy=QuotaPolicy(tokens_per_month=10**9),
+        plan_has_lifetime_budget=False, user_budget_tokens=None,
+    )
+    assert len(ctx.budget_limiter.committed) == 1        # primary reservation committed
+    assert ctx.budget_limiter.committed[0]["spent_usd"] == pytest.approx(0.015, rel=1e-6)
+    assert len(ctx.rl.commits) == 1                      # RL quota committed
+    assert out.quota_commit_tokens == 1500
+    assert out.wallet_usd == 0.0
+
+
+async def test_settle_bypass_forces_project_and_commits_rl():
+    ctx = _ctx()
+    res = await ff.reserve_plan_funding(
+        ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=True,
+        est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
+        project_budget_snapshot={"overdraft_limit_usd": None, "available_usd": 0.0},
+        personal_can_pay_turn=False,
+    )
+    out = await ff.settle_plan_funding(
+        ctx, res, ranked_tokens=1000, total_cost_usd=0.02,
+        effective_policy=QuotaPolicy(tokens_per_month=10**9),
+        plan_has_lifetime_budget=False, user_budget_tokens=None,
+    )
+    assert len(ctx.budget_limiter.forced) == 1
+    assert ctx.budget_limiter.forced[0]["spent_usd"] == pytest.approx(0.02, rel=1e-6)
+    assert len(ctx.rl.commits) == 1
+    assert out.quota_commit_tokens == 1000
+
+
+async def test_settle_wallet_shortfall_absorbed_by_project():
+    # finite overdraft -> primary partial, wallet overflow; wallet consume reports
+    # uncovered tokens -> project absorbs as shortfall:wallet_plan
+    credits = _Credits(balance=10**9, commit_uncovered=0, consume_uncovered=0)
+    budget = _Budget(overdraft=0.0, available_usd=0.05)
+    ctx = _ctx(budget=budget, credits=credits)
+    res = await ff.reserve_plan_funding(
+        ctx, admit=_Admit(reserved=10000), funding_source="project", budget_bypass=False,
+        est_turn_tokens=10000, has_wallet=True, subscription_available_usd=0.0,
+        project_budget_snapshot={"overdraft_limit_usd": 0.0, "available_usd": 0.05},
+        personal_can_pay_turn=True,
+    )
+    out = await ff.settle_plan_funding(
+        ctx, res, ranked_tokens=10000, total_cost_usd=0.10,
+        effective_policy=QuotaPolicy(tokens_per_month=10**9),
+        plan_has_lifetime_budget=True, user_budget_tokens=10**9,
+    )
+    # wallet portion was committed against the reservation
+    assert len(credits.committed) == 1
+    # primary reservation committed for its covered share
+    assert len(budget.committed) == 1
+    assert out.allocation is not None
+    assert out.allocation.wallet_tokens > 0

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
@@ -23,6 +23,7 @@ from kdcube_ai_app.infra.plugin.bundle_loader import on_reactive_event
 from kdcube_ai_app.infra.service_hub.inventory import Config, _mid
 from kdcube_ai_app.apps.chat.sdk.infra.economics.events_resources import (
     msg_denied_quota_reset,
+    msg_denied_quota_insufficient_for_request,
     MSG_DENIED_LOCK_TIMEOUT,
     MSG_DENIED_CONCURRENCY,
     MSG_DENIED_TOKEN_LIMIT,
@@ -33,6 +34,7 @@ from kdcube_ai_app.apps.chat.sdk.infra.economics.events_resources import (
     MSG_WARNING_ONE_REQUEST_REMAINING,
     msg_warning_low_tokens,
     MSG_WARNING_APPROACHING,
+    msg_warning_approaching_approx,
     MSG_NO_FUNDING,
     MSG_SUBSCRIPTION_EXHAUSTED,
     MSG_PROJECT_EXHAUSTED,
@@ -387,8 +389,23 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
             date_str = reset_at.strftime("%B %-d")
             return f"on {date_str} at {time_str}"
 
-        def _build_user_message(*, reason: Optional[str], reset_text: Optional[str]) -> str:
+        def _build_user_message(
+            *,
+            reason: Optional[str],
+            reset_text: Optional[str],
+            needed_tokens: Optional[int] = None,
+            remaining_tokens: Optional[int] = None,
+        ) -> str:
             if reset_text:
+                if (
+                    needed_tokens is not None
+                    and remaining_tokens is not None
+                    and remaining_tokens > 0
+                    and remaining_tokens < needed_tokens
+                ):
+                    needed_k = max(1, needed_tokens // 1000)
+                    remaining_k = max(0, remaining_tokens // 1000)
+                    return msg_denied_quota_insufficient_for_request(needed_k, remaining_k, reset_text)
                 return msg_denied_quota_reset(reset_text)
             if reason == "quota_lock_timeout":
                 return MSG_DENIED_LOCK_TIMEOUT
@@ -467,6 +484,7 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
             reason: Optional[str],
             used_plan_override: bool = False,
             needed_tokens: Optional[int] = None,
+            remaining_tokens: Optional[int] = None,
             now: Optional[datetime] = None,
         ) -> dict:
             insight = compute_quota_insight(
@@ -502,7 +520,12 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                 )
             payload["retry_after_hours"] = retry_after_hours
             payload["reset_text"] = reset_text
-            payload["user_message"] = _build_user_message(reason=reason, reset_text=reset_text)
+            payload["user_message"] = _build_user_message(
+                reason=reason,
+                reset_text=reset_text,
+                needed_tokens=int(needed_tokens) if needed_tokens is not None else None,
+                remaining_tokens=remaining_tokens if remaining_tokens is not None else insight.total_token_remaining,
+            )
             payload["notification_type"] = "error"
             if needed_tokens is not None:
                 payload["needed_tokens"] = int(needed_tokens)
@@ -1512,7 +1535,8 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                                     snapshot=admit.snapshot,
                                     reason=admit.reason or "plan_token_overflow",
                                     used_plan_override=admit.used_plan_override,
-                                    needed_tokens=int(overflow_tokens_est),
+                                    needed_tokens=int(est_turn_tokens),
+                                    remaining_tokens=int(plan_project_tokens_est),
                                 )
                                 await _econ_fail(
                                     code="personal_reservation_failed_plan",
@@ -2268,10 +2292,11 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                         request_remaining = min(req_candidates) if req_candidates else None
                         if request_remaining is not None and request_remaining <= 1:
                             warning_user_message = MSG_WARNING_ONE_REQUEST_REMAINING
-                        elif pr_tok is not None:
-                            warning_user_message = msg_warning_low_tokens(pr_tok // 1000)
                         else:
-                            warning_user_message = MSG_WARNING_ONE_REQUEST_REMAINING
+                            # Token-limited: post-run simulation can be off by ~est_turn_tokens,
+                            # so show approximate count rather than promising an exact value.
+                            approx = pr_mr if pr_mr is not None and pr_mr >= 1 else 1
+                            warning_user_message = msg_warning_approaching_approx(approx)
                     elif pr_tok is not None:
                         warning_user_message = msg_warning_low_tokens(pr_tok // 1000)
                     else:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_memory.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_memory.py
@@ -105,6 +105,7 @@ class MemoryEntrypointMixin:
                     "retention_days": 30,
                     "storage_prefix": "memory/reconciliation/jobs",
                     "timeout_seconds": 45.0,
+                    "reservation_amount_dollars": 0.10,
                 },
                 "snapshots": {
                     "enabled": True,
@@ -3281,6 +3282,92 @@ class MemoryEntrypointMixin:
             "capabilities": self._memory_capabilities_payload(),
         }
 
+    def _memory_economics_enabled(self) -> bool:
+        return bool(
+            getattr(self, "cp_manager", None)
+            and getattr(self, "rl", None)
+            and getattr(self, "budget_limiter", None)
+        )
+
+    def _memory_reconciliation_reservation_usd(self) -> float:
+        cfg = self._memory_reconciliation_config()
+        try:
+            return float(cfg.get("reservation_amount_dollars") or 0.10)
+        except Exception:
+            return 0.10
+
+    async def _memory_reconciliation_econ_subject(self, job: Dict[str, Any]):
+        """Build an EconomicsSubject from the persisted job scope + carried role.
+
+        privileged/admin is preserved from the carried (enqueue-time) role;
+        paid/registered is re-resolved at run time from economics state.
+        """
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import (
+            EconomicsSubject,
+            RoleResolver,
+        )
+
+        scope = job.get("scope") or {}
+        tenant = str(scope.get("tenant") or "")
+        project = str(scope.get("project") or "")
+        user_id = str(scope.get("user_id") or "")
+        carried_role = str(job.get("user_type") or "registered")
+        role = carried_role
+        try:
+            pg_pool = getattr(self, "pg_pool", None)
+            if pg_pool is not None and tenant and project and user_id:
+                resolver = RoleResolver(pg_pool=pg_pool, tenant=tenant, project=project)
+                role = await resolver.resolve(user_id=user_id, carried_role=carried_role)
+        except Exception as exc:
+            logger.warning(
+                "[memory.reconciliation] role resolve failed; using carried role: job_id=%s carried=%s err=%s",
+                job.get("job_id"), carried_role, exc,
+            )
+            role = carried_role
+        return EconomicsSubject(
+            tenant=tenant, project=project, user_id=user_id,
+            user_type=role, timezone=str(job.get("timezone") or "") or None,
+        )
+
+    async def _memory_reconciliation_make_guard(self, job: Dict[str, Any], job_id: str):
+        """Return an EconomicsGuard for the reconciliation job, or None if economics
+        is not configured in this runtime (then the job runs unmetered, as before)."""
+        if not self._memory_economics_enabled():
+            return None
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import (
+            EconomicsGuard,
+            EconomicsEstimate,
+            FlowPolicy,
+        )
+
+        subject = await self._memory_reconciliation_econ_subject(job)
+        if not (subject.tenant and subject.project and subject.user_id):
+            return None
+        return EconomicsGuard(
+            self,
+            subject=subject,
+            scope_id=f"mem_reconcile_{job_id}",
+            flow="memory.reconciler",
+            estimate=EconomicsEstimate(reservation_usd=self._memory_reconciliation_reservation_usd()),
+            policy=FlowPolicy(enforce_concurrency=False, emit_user_events=False),
+        )
+
+    async def _memory_reconciliation_mark_economics_denied(self, job: Dict[str, Any], exc) -> None:
+        job_id = str(job.get("job_id") or "")
+        job["status"] = "failed"
+        job["error"] = f"economics_denied: {getattr(exc, 'code', 'rate_limited')}: {exc}"
+        job["economics"] = {
+            "denied": True,
+            "code": getattr(exc, "code", "rate_limited"),
+            "message": str(exc),
+            "data": getattr(exc, "data", {}) or {},
+        }
+        await self._memory_reconciliation_store_job(job)
+        logger.warning(
+            "[memory.reconciliation] job denied by economics: job_id=%s code=%s",
+            job_id, getattr(exc, "code", "rate_limited"),
+        )
+
     async def _memory_reconciliation_run_job(
         self,
         *,
@@ -3303,6 +3390,11 @@ class MemoryEntrypointMixin:
         )
         if job_reconciliation_context:
             job["reconciliation_context"] = job_reconciliation_context
+
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import EconomicsLimitException
+
+        guard = await self._memory_reconciliation_make_guard(job, job_id)
+        econ_decision = None
         try:
             logger.info(
                 "[memory.reconciliation] job start: job_id=%s bundle=%s scope_filter=%s limit=%s agent_type=%s",
@@ -3312,6 +3404,14 @@ class MemoryEntrypointMixin:
                 limit,
                 normalized_agent_type,
             )
+            # Verify the user's quotas/funding at the START of the flow; reserve and
+            # bind accounting under scope_id=mem_reconcile_<job_id>. Denial -> no LLM run.
+            if guard is not None:
+                try:
+                    econ_decision = await guard.__aenter__()
+                except EconomicsLimitException as exc:
+                    await self._memory_reconciliation_mark_economics_denied(job, exc)
+                    return
             job["status"] = "running"
             job = await self._memory_reconciliation_store_job(job)
 
@@ -3426,6 +3526,15 @@ class MemoryEntrypointMixin:
                 job_id,
                 normalized_scope_filter,
             )
+        finally:
+            # Settle economics (run_accounting -> charge/release) for the flow we entered.
+            if guard is not None and econ_decision is not None:
+                try:
+                    await guard.__aexit__(None, None, None)
+                except Exception:
+                    logger.exception(
+                        "[memory.reconciliation] economics settlement failed: job_id=%s", job_id
+                    )
 
     async def _memory_reconciliation_handle_background_job(
         self,
@@ -3688,6 +3797,14 @@ class MemoryEntrypointMixin:
                 ]).encode("utf-8")
             ).hexdigest()[:12]
             job_id = f"memrec_{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}_{digest}"
+            # Carry the authenticated/gateway-resolved role and timezone into the job so the
+            # detached worker can enforce economics on the correct funding lane. privileged/admin
+            # is NOT derivable from economics state, so it must be persisted here at enqueue time.
+            enqueue_user = getattr(self.comm_context, "user", None)
+            carried_user_type = self._memory_effective_user_type(
+                str(getattr(enqueue_user, "user_type", "") or "registered")
+            )
+            carried_timezone = str(getattr(enqueue_user, "timezone", "") or "")
             job: Dict[str, Any] = {
                 "job_id": job_id,
                 "status": "queued",
@@ -3698,6 +3815,8 @@ class MemoryEntrypointMixin:
                     "user_id": scope.user_id,
                     "bundle_id": scope.bundle_id,
                 },
+                "user_type": carried_user_type,
+                "timezone": carried_timezone,
                 "scope_filter": normalized_scope_filter,
                 "candidate_count": 0,
                 "proposal_count": 0,
@@ -3738,8 +3857,8 @@ class MemoryEntrypointMixin:
 
             from kdcube_ai_app.infra.jobs.stream import RedisBackgroundJobStream
 
-            user = getattr(self.comm_context, "user", None)
-            user_type = self._memory_effective_user_type(str(getattr(user, "user_type", "") or "registered"))
+            user = enqueue_user
+            user_type = carried_user_type
             routing = getattr(self.comm_context, "routing", None)
             stream = RedisBackgroundJobStream(redis, tenant=scope.tenant, project=scope.project)
             try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_memory.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_memory.py
@@ -2028,7 +2028,7 @@ class MemoryEntrypointMixin:
         labels_list = normalize_terms(labels)
         keywords_list = normalize_terms(keywords)
         normalized_query = str(query or "").strip()
-        query_embedding = await self._memory_embed_one(normalized_query) if normalized_query else None
+        query_embedding = await self._memory_search_embed_or_downgrade(normalized_query)
         search_limit = min(page_limit + 1, 101)
         try:
             min_relevance_score = float(self._memory_widget_config().get("search_min_relevance_score") or 0.58)
@@ -2121,7 +2121,7 @@ class MemoryEntrypointMixin:
         labels_list = normalize_terms(labels)
         keywords_list = normalize_terms(keywords)
         normalized_limit = max(1, min(int(limit or 5000), 5000))
-        query_embedding = await self._memory_embed_one(normalized_query) if normalized_query else None
+        query_embedding = await self._memory_search_embed_or_downgrade(normalized_query)
         store = self._memory_store()
         if _truthy(self._memory_widget_config().get("ensure_schema"), True):
             await store.ensure_schema()
@@ -3288,6 +3288,78 @@ class MemoryEntrypointMixin:
             and getattr(self, "rl", None)
             and getattr(self, "budget_limiter", None)
         )
+
+    def _memory_search_reservation_usd(self) -> float:
+        """Feasibility-gate amount for a memory semantic-search embedding call.
+
+        Cheap by design — memory search uses a verify-only economic_preflight
+        (no reservation, no settle); this only sizes the est used to decide
+        whether the user can afford the embedding before paying for it.
+        """
+        cfg = self._memory_widget_config()
+        try:
+            return float(cfg.get("search_reservation_amount_dollars") or 0.01)
+        except Exception:
+            return 0.01
+
+    def _memory_search_econ_subject(self):
+        """EconomicsSubject for synchronous widget search.
+
+        The role comes from the authenticated session (override wins), so no DB
+        re-resolution is needed (unlike detached reconciler jobs, §4.6).
+        """
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import EconomicsSubject
+
+        scope = self._memory_scope()
+        user = getattr(self.comm_context, "user", None)
+        role = self._memory_effective_user_type(
+            str(getattr(user, "user_type", None) or "registered")
+        )
+        return EconomicsSubject(
+            tenant=scope.tenant,
+            project=scope.project,
+            user_id=scope.user_id,
+            user_type=role,
+        )
+
+    async def _memory_search_embed_or_downgrade(self, query: str) -> Optional[Sequence[float]]:
+        """Embed the query for semantic ranking, gated by economics.
+
+        Runs a verify-only economic_preflight (flow="memory.search") before
+        paying for the embedding. On an economics limit (rate/funding), returns
+        None so MemoryStore.search falls back to keyword/BM25 (Postgres FTS):
+        the user still gets results, only semantic ranking is opted out. The
+        guard's nested-detection (active econ scope -> preflight nested) keeps
+        this safe if ever invoked inside an already-accountable flow.
+        """
+        normalized = str(query or "").strip()
+        if not normalized:
+            return None
+        if self._memory_economics_enabled():
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import (
+                economic_preflight,
+                EconomicsEstimate,
+                FlowPolicy,
+            )
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import EconomicsLimitException
+
+            subject = self._memory_search_econ_subject()
+            if subject.tenant and subject.project and subject.user_id and subject.user_id != "anonymous":
+                try:
+                    await economic_preflight(
+                        self,
+                        subject=subject,
+                        estimate=EconomicsEstimate(reservation_usd=self._memory_search_reservation_usd()),
+                        flow="memory.search",
+                        policy=FlowPolicy(enforce_concurrency=False, emit_user_events=False),
+                    )
+                except EconomicsLimitException as exc:
+                    logger.info(
+                        "[memory.search] economics limit; degrading to keyword/BM25: user=%s code=%s",
+                        subject.user_id, getattr(exc, "code", "rate_limited"),
+                    )
+                    return None
+        return await self._memory_embed_one(normalized)
 
     def _memory_reconciliation_reservation_usd(self) -> float:
         cfg = self._memory_reconciliation_config()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/tasks/operations.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/tasks/operations.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
 import time
 import uuid
 from contextlib import nullcontext
@@ -28,6 +29,8 @@ from kdcube_ai_app.apps.chat.sdk.integrations.telegram import (
     send_telegram_messages,
 )
 
+
+logger = logging.getLogger(__name__)
 
 BUNDLE_ID = ""
 WORK_KIND_TASK_RUN_NOW = "task.execution.manual"
@@ -100,8 +103,132 @@ def _execution_scope(entrypoint: Any, *, user_id: str) -> Dict[str, Any]:
         "tenant": tenant,
         "project": project,
         "user_id": user_id,
+        # NOTE: user_type here scopes ARTIFACT storage paths (execution_artifacts),
+        # not economics. It is intentionally left constant so artifact read/write
+        # paths stay consistent across executions regardless of the funding role.
+        # Economics uses an independently resolved role via _task_econ_subject.
         "user_type": "registered",
         "storage_root": _storage_root(entrypoint),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Economics enforcement (Option A: estimate + post-run settle, funding_flow parity)
+# ---------------------------------------------------------------------------
+def _task_economics_enabled(entrypoint: Any) -> bool:
+    return bool(
+        getattr(entrypoint, "cp_manager", None)
+        and getattr(entrypoint, "rl", None)
+        and getattr(entrypoint, "budget_limiter", None)
+    )
+
+
+def _task_reservation_usd(entrypoint: Any) -> float:
+    """Feasibility estimate for a task pipeline (bundle-configurable).
+
+    Tasks verify economic feasibility at the start (economic_preflight); this
+    only sizes the estimate the preflight admits against. The task's actual cost
+    is metered by the inner ReAct turn (self.run()), not reserved/settled here.
+    """
+    try:
+        return float(_bundle_prop(entrypoint, "economics.task.reservation_amount_dollars", 0.50) or 0.50)
+    except Exception:
+        return 0.50
+
+
+async def _task_econ_subject(entrypoint: Any, *, target_user: str, source: Dict[str, Any]):
+    """Build an EconomicsSubject for a task execution.
+
+    privileged/admin is preserved from the carried (enqueue-time) role; the
+    carried role rides in the job source (enqueue_task_job persists user_type),
+    falling back to the worker comm_context. paid/registered is re-resolved at
+    run time from economics state via RoleResolver.
+    """
+    from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import (
+        EconomicsSubject,
+        RoleResolver,
+    )
+
+    tenant, project, _bundle_id = _bundle_route_parts(entrypoint)
+    comm_context = getattr(entrypoint, "comm_context", None)
+    comm_user = getattr(comm_context, "user", None)
+    carried_role = str(
+        (source or {}).get("user_type")
+        or getattr(comm_user, "user_type", "")
+        or "registered"
+    ).strip() or "registered"
+    role = carried_role
+    try:
+        pg_pool = getattr(entrypoint, "pg_pool", None)
+        if pg_pool is not None and tenant and project and target_user:
+            resolver = RoleResolver(pg_pool=pg_pool, tenant=tenant, project=project)
+            role = await resolver.resolve(user_id=target_user, carried_role=carried_role)
+    except Exception as exc:
+        logger.warning(
+            "[tasks.economics] role resolve failed; using carried role: user=%s carried=%s err=%s",
+            target_user, carried_role, exc,
+        )
+        role = carried_role
+    timezone = str((source or {}).get("timezone") or getattr(comm_user, "timezone", "") or "") or None
+    return EconomicsSubject(
+        tenant=tenant, project=project, user_id=target_user,
+        user_type=role, timezone=timezone,
+    )
+
+
+async def _task_verify_economics(
+    entrypoint: Any,
+    *,
+    target_user: str,
+    source: Dict[str, Any],
+):
+    """Verify the task pipeline is economically feasible for the carried user.
+
+    Returns (subject, decision) on success; raises EconomicsLimitException when
+    the user's quota/funding cannot support the pipeline. Returns (None, None)
+    when economics is not configured (task runs unmetered, as before).
+
+    Verify-only (economic_preflight): NO reservation, NO settlement. The task's
+    ReAct work routes through self.run(), which already reserves+settles the real
+    cost under the task's user identity; an outer guard would only duplicate it.
+    This gates the START of the flow and surfaces the economic limits for logging.
+    """
+    if not _task_economics_enabled(entrypoint):
+        return None, None
+    from kdcube_ai_app.apps.chat.sdk.infra.economics.enforcement import (
+        economic_preflight,
+        EconomicsEstimate,
+        FlowPolicy,
+    )
+
+    subject = await _task_econ_subject(entrypoint, target_user=target_user, source=source)
+    if not (subject.tenant and subject.project and subject.user_id):
+        return None, None
+    decision = await economic_preflight(
+        entrypoint,
+        subject=subject,
+        estimate=EconomicsEstimate(reservation_usd=_task_reservation_usd(entrypoint)),
+        flow="tasks",
+        policy=FlowPolicy(enforce_concurrency=False, emit_user_events=False),
+    )
+    return subject, decision
+
+
+def _task_economics_metadata(decision) -> Dict[str, Any]:
+    """Compact economic decision + limits for the execution journal/metadata."""
+    if decision is None:
+        return {}
+    admit = getattr(decision, "admit", None)
+    limits = (getattr(admit, "snapshot", None) or {}) if admit is not None else {}
+    return {
+        "economics": {
+            "verified": True,
+            "lane": getattr(decision, "lane", None),
+            "plan_id": getattr(decision, "plan_id", None),
+            "funding_source": getattr(decision, "funding_source", None),
+            "est_turn_usd": getattr(decision, "est_turn_usd", None),
+            "limits": limits,
+        }
     }
 
 
@@ -633,6 +760,7 @@ def _build_task_scoped_context(
     run_conversation_id: str,
     turn_id: str,
     bundle_call_context: Dict[str, Any],
+    resolved_user_type: Optional[str] = None,
 ):
     comm_context = getattr(entrypoint, "comm_context", None)
     if comm_context is None or not hasattr(comm_context, "model_copy"):
@@ -643,6 +771,11 @@ def _build_task_scoped_context(
     scoped_ctx.routing.conversation_id = run_conversation_id
     scoped_ctx.routing.turn_id = turn_id
     scoped_ctx.user.user_id = target_user
+    # Carry the economics-resolved role so the inner run() applies the correct
+    # plan/limits + funding for this user (the worker comm_context may carry a
+    # stale/default role for scheduled tasks).
+    if resolved_user_type:
+        scoped_ctx.user.user_type = resolved_user_type
     scoped_ctx.bundle_call_context = bundle_call_context
     return scoped_ctx
 
@@ -673,6 +806,7 @@ async def _run_default_react_task_job(
     run_conversation_id: str,
     turn_id: str,
     bundle_call_context: Dict[str, Any],
+    resolved_user_type: Optional[str] = None,
 ) -> Dict[str, Any]:
     scoped_ctx = _build_task_scoped_context(
         entrypoint,
@@ -680,6 +814,7 @@ async def _run_default_react_task_job(
         run_conversation_id=run_conversation_id,
         turn_id=turn_id,
         bundle_call_context=bundle_call_context,
+        resolved_user_type=resolved_user_type,
     )
 
     async def _run_scoped() -> Dict[str, Any]:
@@ -730,6 +865,7 @@ async def _execute_task_job(
     run_conversation_id: str,
     turn_id: str,
     bundle_call_context: Dict[str, Any],
+    resolved_user_type: Optional[str] = None,
 ) -> Dict[str, Any]:
     executor = getattr(entrypoint, "execute_task_job", None)
     if callable(executor):
@@ -754,6 +890,7 @@ async def _execute_task_job(
                 run_conversation_id=run_conversation_id,
                 turn_id=turn_id,
                 bundle_call_context=bundle_call_context,
+                resolved_user_type=resolved_user_type,
             )
         except RuntimeError:
             return await _run_custom()
@@ -769,6 +906,7 @@ async def _execute_task_job(
         run_conversation_id=run_conversation_id,
         turn_id=turn_id,
         bundle_call_context=bundle_call_context,
+        resolved_user_type=resolved_user_type,
     )
 
 
@@ -993,6 +1131,56 @@ async def run_task_execution(
         "task_definition": json.dumps(task_definition, sort_keys=True, ensure_ascii=True),
     }
 
+    from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import EconomicsLimitException
+    econ_subject = None
+    econ_decision = None
+    try:
+        # Carry the user identity and verify the task pipeline is economically
+        # feasible BEFORE running it (verify-only). The ReAct work routes through
+        # self.run(), which reserves+settles the real cost under the same user, so
+        # we do NOT reserve/settle here. Denial -> execution cancelled, no run.
+        econ_subject, econ_decision = await _task_verify_economics(
+            entrypoint, target_user=target_user, source=source or {},
+        )
+    except EconomicsLimitException as exc:
+        code = getattr(exc, "code", "rate_limited")
+        execution = await storage.update_execution(
+            execution_id=execution["id"],
+            task_id=task_id,
+            status="cancelled",
+            conversation_id=run_conversation_id,
+            turn_id=turn_id,
+            summary=f"Task execution denied by economics ({code}).",
+            error=str(exc),
+            log_excerpt=str(exc)[:1000],
+            metadata_patch={"economics": {
+                "denied": True, "code": code, "message": str(exc),
+                "data": getattr(exc, "data", {}) or {},
+            }},
+        )
+        logger.warning(
+            "[tasks.economics] execution denied: execution_id=%s user=%s code=%s",
+            execution.get("id"), target_user, code,
+        )
+        return {
+            "ok": False,
+            "denied": True,
+            "user_id": target_user,
+            "task": await storage.get_task(task_id),
+            "execution": execution,
+            "error": {"code": "economics_denied", "message": str(exc)},
+        }
+    if econ_decision is not None:
+        logger.info(
+            "[tasks.economics] preflight ok: execution_id=%s user=%s role=%s lane=%s funding=%s plan=%s",
+            execution["id"], target_user, getattr(econ_subject, "user_type", None),
+            econ_decision.lane, econ_decision.funding_source, econ_decision.plan_id,
+        )
+    # Point (2): propagate the resolved role so the inner ReAct run() applies the
+    # correct plan/limits for this user (esp. scheduled tasks enqueued in a system
+    # context where the carried role may default to "registered").
+    resolved_user_type = getattr(econ_subject, "user_type", None)
+
     try:
         try:
             from kdcube_ai_app.apps.chat.sdk.runtime.comm_ctx import bind_current_bundle_call_context
@@ -1015,6 +1203,7 @@ async def run_task_execution(
                 run_conversation_id=run_conversation_id,
                 turn_id=turn_id,
                 bundle_call_context=bundle_call_context,
+                resolved_user_type=resolved_user_type,
             )
         answer = _result_answer(result)
         current_execution = await storage.get_execution(execution_id=execution["id"], task_id=task_id) or execution
@@ -1023,6 +1212,8 @@ async def run_task_execution(
         final_status = current_status if current_status in {"success", "failed", "cancelled"} else (requested_status or "success")
         artifacts = result.get("artifacts") if isinstance(result.get("artifacts"), list) else None
         metadata = result.get("metadata") if isinstance(result.get("metadata"), dict) else None
+        if econ_decision is not None:
+            metadata = {**(metadata or {}), **_task_economics_metadata(econ_decision)}
         execution = await storage.update_execution(
             execution_id=execution["id"],
             task_id=task_id,


### PR DESCRIPTION
  ## Economics enforcement on non-chat accountable surfaces

  Extends the economics model (roles, plans, funding lanes, reservations,
  settlement) beyond chat turns to accountable flows that run model calls on a
  user's behalf without a chat turn, via a reusable enforcement engine built
  alongside the chat entrypoint (`run()` is unchanged).

  ### Engine (reusable API)
  - `enforcement.py`: `EconomicsGuard` (verify → reserve → settle lifecycle),
    `economic_preflight` (verify-only), `EconomicsSubject` / `EconomicsEstimate` /
    `FlowPolicy` / `EconomicsDecision`, `RoleResolver` (re-derive paid/registered;
    carry privileged across the enqueue→worker boundary).
  - `funding_flow.py`: single source of truth for the plan-lane reserve+settle,
    using the same `allocate_plan_wallet_settlement` as `run()` — the reservation
    source split (project/subscription primary + wallet overflow + project
    absorption) matches chat by construction.

  ### Enforced surfaces
  - **Memory reconciliation** (background job): verify + reserve at start, settle the
    real cost to the user; denial fails the job before any model call.
  - **Memory semantic search** (widget): verify-only; on an economics limit the query
    degrades to keyword/full-text ranking instead of failing.
  - **Task execution**: carries the acting user's identity, verifies feasibility
    before running, logs the limits; denial cancels the execution. The task's actual
    cost is metered and charged by the inner `run()` under the correct user
    (project→wallet split included).

  ### Correctness
  - Nested detection via a dedicated economics-scope marker (not the raw accounting
    context), so background workers aren't mis-detected as a settling parent.
  - Verify-only where the work settles its own cost (tasks via `run()`, memory
    search) to avoid double-charging; full guard where the flow settles nothing
    itself (reconciler).

  ### Docs & tests
  - `docs/economics/economic-enforcement-engine-README.md` (engine API + examples),
    linked from the authoritative `economic-README.md`.
  - Unit tests for the engine, funding split, and each surface's wiring (79 green).
  - E2E validated on the live stack: denial / happy path / project→wallet split for
    the reconciler, search downgrade, and task execution.