### PR TITLE
Per-agent role_models override 

### DIFF
--- a/app/ai-app/docs/sdk/bundle/bundle-runtime-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-runtime-README.md
@@ -4,7 +4,7 @@ title: "Bundle Runtime"
 summary: "Runtime objects and capabilities available inside bundle entrypoints and tools: communicator, Data Bus context, integrations, props and secrets, caches, artifacts, and isolated-execution surfaces."
 tags: ["sdk", "bundle", "runtime", "tools", "integrations", "communicator", "isolation", "data-bus"]
 keywords: ["bundle runtime objects", "communicator access", "data bus context", "integrations access", "props and secrets access", "cache access", "artifact handling", "isolated execution surface", "entrypoint runtime context"]
-updated_at: 2026-05-22
+updated_at: 2026-06-09
 see_also:
   - ks:docs/sdk/bundle/bundle-developer-guide-README.md
   - ks:docs/sdk/bundle/build/how-to-assemble-bundle-with-sdk-building-blocks-README.md
@@ -160,6 +160,11 @@ What the bundle has in this path:
   - `await get_secret("b:...")` for current bundle deployment secrets
 - `await get_secret("...")` / `await get_secret("a:...")` for platform/global secrets
 - `await get_secret("u:...")` for current-user secrets
+
+Communicator behavior in this path:
+- if request routing carries an exact socket/stream target, direct peer delivery
+  is possible
+- otherwise events fan out to all clients connected to the same session room
 
 ## Portable bundle call context
 
@@ -431,10 +436,69 @@ Docker/Fargate runtimes while the context is bound. It affects SDK model calls
 through `ModelServiceBase` / `ModelRouter`, not direct provider clients that
 bypass the SDK router.
 
-Communicator behavior in this path:
-- if request routing carries an exact socket/stream target, direct peer delivery
-  is possible
-- otherwise events fan out to all clients connected to the same session room
+### Per-ReAct-agent role models (`config.react.<agent>.role_models`)
+
+A bundle can host more than one ReAct agent, and the keys in `role_models` are
+LLM call scopes (`solver.react.v2.decision.v2.strong`,
+`context.compaction.summary`, ...) shared across those agents. A flat bundle-wide
+`role_models` cannot give two agents different models for the same scope. Scope
+the override per agent instead:
+
+```yaml
+items:
+  - id: my.bundle@1-0
+    config:
+      # bundle-wide baseline (feeds Config.role_models)
+      role_models:
+        solver.react.v2.decision.v2.strong:
+          provider: anthropic
+          model: claude-sonnet-4-6
+      react:
+        default_agent:
+          role_models:
+            solver.react.v2.decision.v2.strong:
+              provider: anthropic
+              model: claude-haiku-4-5-20251001
+            context.compaction.summary:
+              provider: anthropic
+              model: claude-haiku-4-5-20251001
+        research_agent:
+          role_models:
+            solver.react.v2.decision.v2.strong:
+              provider: anthropic
+              model: claude-opus-4-8
+```
+
+The platform resolves this automatically; bundle code does not bind anything:
+
+1. the active agent id comes from the turn event (`event.agent_id`, normalized;
+   the default is `default.react.agent`)
+2. `config.react.<agent_id>.role_models` is looked up with fallback
+   `<agent_id>` -> `default_agent` -> `default`, the same resolution used by other
+   per-agent react settings
+3. the resolved map is stored on `RuntimeCtx.agent_role_models`
+4. for the lifetime of the ReAct run, the runtime overlays it onto
+   `bundle_call_context.role_models`, so `ModelRouter` picks it up per role
+
+Effective precedence for a ReAct model call becomes:
+
+1. explicit per-request `bundle_call_context.role_models` (a bundle/runtime overlay
+   bound around the call)
+2. `config.react.<agent>.role_models` for the active agent
+3. bundle-wide `role_models` (`Config.role_models`)
+4. platform defaults
+
+Notes:
+
+- this overlay does not mutate `Config.role_models`; it follows the same
+  request-scoped, non-durable rules as any other `bundle_call_context` value
+- it is bound for the duration of `react.run()`, so it covers in-run scopes such
+  as decision, compaction, and run summary; model calls made outside the ReAct
+  run fall back to the bundle-wide baseline
+- put per-agent role maps in bundle props (config), not in singleton instance
+  fields; the runtime re-resolves them on bundle props reload
+- an explicit per-request overlay still wins per role, so a bundle can force a
+  one-call model for the current turn even when the agent defines that scope
 
 ### 2) REST bundle operation path
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/base_workflow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/base_workflow.py
@@ -330,6 +330,11 @@ def _react_story_snapshots_enabled(bundle_props: Dict[str, Any], *, agent_id: An
     return bool(configured) if configured is not None else False
 
 
+def _react_role_models(bundle_props: Dict[str, Any], *, agent_id: Any = None) -> Dict[str, Any]:
+    raw, _ = _react_config_lookup(bundle_props, "role_models", agent_id=agent_id)
+    return dict(raw) if isinstance(raw, dict) else {}
+
+
 def _react_event_source_pipeline_enabled(bundle_props: Dict[str, Any], settings: Any, *, agent_id: Any = None) -> bool:
     raw, _ = _react_config_lookup(
         bundle_props,
@@ -445,6 +450,7 @@ def _effective_runtime_ctx_log_payload(runtime_ctx: Any, bundle_props: Dict[str,
         "render_thinking": bool(getattr(runtime_ctx, "render_thinking", True)),
         "line_numbers_mode": getattr(runtime_ctx, "line_numbers_mode", None),
         "story_snapshots_enabled": bool(getattr(runtime_ctx, "story_snapshots_enabled", False)),
+        "agent_role_models": dict(getattr(runtime_ctx, "agent_role_models", None) or {}),
         "event_source_pipeline_enabled": bool(getattr(runtime_ctx, "event_source_pipeline_enabled", False)),
         "event_source_pipeline_config": _react_event_source_pipeline_config_report(
             bundle_props,
@@ -788,6 +794,7 @@ class BaseWorkflow():
             )
             runtime_ctx.debug_timeline_root = _react_debug_timeline_root(settings)
             runtime_ctx.debug_timeline_keep_files = _react_debug_timeline_keep_files(settings)
+            runtime_ctx.agent_role_models = _react_role_models(self.bundle_props, agent_id=agent_id)
         except Exception:
             pass
         memory_cfg = self.get_prop_path(self.bundle_props or {}, "memory", default={}) or {}

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/tests/test_base_workflow_runtime_ctx.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/tests/test_base_workflow_runtime_ctx.py
@@ -1079,3 +1079,90 @@ async def test_event_lane_prompt_is_not_indexed_twice_by_legacy_persist_call():
     assert [m["role"] for m in saved_messages] == ["user"]
     assert saved_messages[0]["text"] == "Original prompt"
     assert "ar:turn-1.user.prompt.evt_1" in scratchpad.persisted_turn_entry_paths
+
+
+# ---------------------------------------------------------------------------
+# Per-agent role_models overlay (config.react.<agent>.role_models)
+# ---------------------------------------------------------------------------
+
+def test_react_role_models_resolves_per_agent_with_fallback():
+    bundle_props = {
+        "config": {
+            "react": {
+                "default_agent": {
+                    "role_models": {
+                        "solver.react.v2.decision.v2.strong": {
+                            "provider": "anthropic",
+                            "model": "claude-sonnet-4-6",
+                        }
+                    }
+                },
+                "research_agent": {
+                    "role_models": {
+                        "solver.react.v2.decision.v2.strong": {
+                            "provider": "anthropic",
+                            "model": "claude-opus-4-8",
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    # Exact agent id wins.
+    research = workflow_mod._react_role_models(bundle_props, agent_id="research_agent")
+    assert research["solver.react.v2.decision.v2.strong"]["model"] == "claude-opus-4-8"
+
+    # Unknown agent id falls back to default_agent.
+    fallback = workflow_mod._react_role_models(bundle_props, agent_id="unknown_agent")
+    assert fallback["solver.react.v2.decision.v2.strong"]["model"] == "claude-sonnet-4-6"
+
+    # No react config at all -> empty (static Config.role_models base applies).
+    assert workflow_mod._react_role_models({}, agent_id="research_agent") == {}
+
+
+def test_bind_runtime_role_models_overlays_and_existing_wins():
+    from kdcube_ai_app.apps.chat.sdk.solutions.react.v2.runtime import ReactSolverV2
+    from kdcube_ai_app.apps.chat.sdk.runtime.comm_ctx import (
+        bind_current_bundle_call_context_patch,
+        get_current_bundle_call_context,
+    )
+
+    solver = ReactSolverV2.__new__(ReactSolverV2)
+    solver.ctx_browser = SimpleNamespace(
+        runtime_ctx=RuntimeCtx(
+            agent_id="research_agent",
+            agent_role_models={
+                "solver.react.v2.decision.v2.strong": {"provider": "anthropic", "model": "agent-model"},
+                "context.compaction.summary": {"provider": "anthropic", "model": "agent-summary"},
+            },
+        )
+    )
+
+    # No pre-existing overlay: agent map is applied verbatim.
+    with solver._bind_runtime_role_models():
+        rm = get_current_bundle_call_context().get("role_models")
+        assert rm["solver.react.v2.decision.v2.strong"]["model"] == "agent-model"
+        assert rm["context.compaction.summary"]["model"] == "agent-summary"
+    # Restored after the block.
+    assert "role_models" not in get_current_bundle_call_context()
+
+    # Explicit per-request overlay already bound wins per role; agent fills the rest.
+    with bind_current_bundle_call_context_patch(
+        {"role_models": {"solver.react.v2.decision.v2.strong": {"provider": "anthropic", "model": "request-model"}}}
+    ):
+        with solver._bind_runtime_role_models():
+            rm = get_current_bundle_call_context().get("role_models")
+            assert rm["solver.react.v2.decision.v2.strong"]["model"] == "request-model"  # explicit wins
+            assert rm["context.compaction.summary"]["model"] == "agent-summary"           # agent fills gap
+
+
+def test_bind_runtime_role_models_noop_without_agent_overlay():
+    from kdcube_ai_app.apps.chat.sdk.solutions.react.v2.runtime import ReactSolverV2
+    from kdcube_ai_app.apps.chat.sdk.runtime.comm_ctx import get_current_bundle_call_context
+
+    solver = ReactSolverV2.__new__(ReactSolverV2)
+    solver.ctx_browser = SimpleNamespace(runtime_ctx=RuntimeCtx(agent_id="a", agent_role_models={}))
+
+    with solver._bind_runtime_role_models():
+        assert "role_models" not in get_current_bundle_call_context()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/proto.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/proto.py
@@ -99,6 +99,7 @@ class RuntimeCtx:
     turn_id: Optional[str] = None
     bundle_id: Optional[str] = None
     agent_id: str = DEFAULT_REACT_AGENT_ID
+    agent_role_models: Dict[str, Any] = field(default_factory=dict)
     timezone: Optional[str] = None
     max_tokens: Optional[int] = None
     max_iterations: Optional[int] = None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v2/runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v2/runtime.py
@@ -13,6 +13,7 @@ import traceback
 
 import time
 import uuid
+from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Callable, Awaitable, Type
 
 from langgraph.graph import StateGraph, END
@@ -23,6 +24,10 @@ from kdcube_ai_app.apps.chat.sdk.protocol import ExternalEventPayload
 from kdcube_ai_app.apps.chat.sdk.solutions.react.browser import ContextBrowser
 from kdcube_ai_app.apps.chat.sdk.solutions.infra import emit_event
 from kdcube_ai_app.apps.chat.sdk.runtime.execution import execute_tool, _safe_label
+from kdcube_ai_app.apps.chat.sdk.runtime.comm_ctx import (
+    bind_current_bundle_call_context_patch,
+    get_current_bundle_call_context,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v2.agents.decision import react_decision_stream_v2
 from kdcube_ai_app.apps.chat.sdk.solutions.react.live_events import (
     compute_reactive_iteration_credit_cap,
@@ -1547,7 +1552,27 @@ class ReactSolverV2:
             max_decision_retries=2,
         )
 
+    @contextmanager
+    def _bind_runtime_role_models(self):
+        runtime_ctx = getattr(self.ctx_browser, "runtime_ctx", None) if self.ctx_browser else None
+        agent_role_models = getattr(runtime_ctx, "agent_role_models", None)
+        if not isinstance(agent_role_models, dict) or not agent_role_models:
+            yield
+            return
+        existing = get_current_bundle_call_context().get("role_models") or {}
+        merged: Dict[str, Any] = {**agent_role_models, **existing}
+        with bind_current_bundle_call_context_patch({"role_models": merged}):
+            yield
+
     async def run(
+        self,
+        *,
+        allowed_plugins: List[str],
+    ):
+        with self._bind_runtime_role_models():
+            return await self._run_impl(allowed_plugins=allowed_plugins)
+
+    async def _run_impl(
         self,
         *,
         allowed_plugins: List[str],

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/runtime.py
@@ -14,6 +14,7 @@ import traceback
 
 import time
 import uuid
+from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Callable, Awaitable, Type, Set
 
 from langgraph.graph import StateGraph, END
@@ -24,6 +25,10 @@ from kdcube_ai_app.apps.chat.sdk.protocol import ExternalEventPayload
 from kdcube_ai_app.apps.chat.sdk.solutions.react.browser import ContextBrowser
 from kdcube_ai_app.apps.chat.sdk.solutions.infra import emit_event
 from kdcube_ai_app.apps.chat.sdk.runtime.execution import execute_tool, _safe_label
+from kdcube_ai_app.apps.chat.sdk.runtime.comm_ctx import (
+    bind_current_bundle_call_context_patch,
+    get_current_bundle_call_context,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v3.agents.decision import (
     parse_single_react_decision_from_channel_text,
     react_decision_stream_v2,
@@ -2133,7 +2138,27 @@ class ReactSolverV2:
             max_decision_retries=2,
         )
 
+    @contextmanager
+    def _bind_runtime_role_models(self):
+        runtime_ctx = getattr(self.ctx_browser, "runtime_ctx", None) if self.ctx_browser else None
+        agent_role_models = getattr(runtime_ctx, "agent_role_models", None)
+        if not isinstance(agent_role_models, dict) or not agent_role_models:
+            yield
+            return
+        existing = get_current_bundle_call_context().get("role_models") or {}
+        merged: Dict[str, Any] = {**agent_role_models, **existing}
+        with bind_current_bundle_call_context_patch({"role_models": merged}):
+            yield
+
     async def run(
+        self,
+        *,
+        allowed_plugins: List[str],
+    ):
+        with self._bind_runtime_role_models():
+            return await self._run_impl(allowed_plugins=allowed_plugins)
+
+    async def _run_impl(
         self,
         *,
         allowed_plugins: List[str],


### PR DESCRIPTION
  A bundle can host several ReAct agents that share the same LLM call scopes
  (solver.react.v2.decision.v2.strong, context.compaction.summary, ...). A flat
  bundle-wide role_models map cannot route the same scope to different models per
  agent. Scope the override per agent instead and apply it for the ReAct run only,
  without mutating the shared Config.role_models.

  Ownership split:
  - bundle props: config.react.<agent_id>.role_models (fallback default_agent/default)
  - BaseWorkflow resolves it onto RuntimeCtx.agent_role_models per turn
  - ReactSolver.run() binds it into bundle_call_context.role_models for the run lifetime, so ModelRouter resolves it per role on top of the static base
  - Config.role_models stays the global/static baseline; build_react() stays construction-only

  Effective precedence for a ReAct model call:
    explicit per-request overlay > config.react.<agent>.role_models
    > bundle-wide role_models (Config) > platform defaults
  (an explicit per-request overlay still wins per role)

  Changes:
  - proto.py: add RuntimeCtx.agent_role_models
  - base_workflow.py: add _react_role_models() resolver; populate runtime_ctx.agent_role_models in _sync_runtime_ctx_bundle_props(); surface it in the [react.runtime_ctx.effective] log
  - react/v2 + v3 runtime: add _bind_runtime_role_models() and split run() into a thin wrapper + _run_impl() so the overlay scopes the whole run (decision, compaction, summary). Patched both versions since both expose ReactSolverV2.run
  - tests: per-agent resolution with fallback, bind precedence (explicit overlay wins, agent fills gaps, restored after block), no-op without overlay
  - docs(bundle-runtime): document config.react.<agent>.role_models and precedence; move the orphaned chat-turn communicator note back into its section