### PR TITLE
Economics fixes and refactor

### DIFF
--- a/app/ai-app/docs/economics/economic-enforcement-engine-README.md
+++ b/app/ai-app/docs/economics/economic-enforcement-engine-README.md
@@ -163,16 +163,18 @@ Carries the resolved `lane` (`plan` / `paid` / `bypass`), `plan_id`,
   emitted when `emit_user_events` is on.
 - **Paid‑lane switch.** With `allow_paid_lane_fallback` on, a plan‑lane request that
   cannot be served from the plan — the plan admit is rate‑limited, or plan funding is
-  exhausted and cannot be reserved — switches to a **wallet‑only paid lane** instead
-  of denying, provided the user has a wallet: the plan reservation is released, admit
-  is retried against the pay‑as‑you‑go policy, and the wallet becomes the primary
-  funding. Off by default, so a flow denies rather than charging the wallet unless it
-  opts in.
+  exhausted and cannot be reserved — switches to the **paid lane** instead of denying,
+  provided the user can pay: the plan reservation is released and admit is retried
+  against the pay‑as‑you‑go policy. In the paid lane an active subscription pays first
+  from its budget (the wallet stays untouched); otherwise the wallet is the primary
+  funding. Off by default, so a flow denies rather than escalating to paid funding
+  unless it opts in.
 - **Settlement (guard only).** On exit, actual spend is charged across the same lanes
   as chat — plan/subscription/project first, wallet for the overflow, with project
-  budget absorbing any shortfall. A paid‑lane flow settles from the wallet (project
-  absorbs any uncovered remainder). A flow whose actual cost is zero releases its
-  holds rather than charging. Subscriptions and wallets never go negative.
+  budget absorbing any shortfall. A paid‑lane flow settles from the subscription
+  budget or the wallet (whichever is the paid primary). A flow whose actual cost is
+  zero releases its holds rather than charging. Subscriptions and wallets never go
+  negative.
 - **Quota lock.** With `enforce_quota_lock` on (and Redis available on the
   entrypoint), the admit→reserve planning window is serialized per user with a
   distributed lock, closing the read‑remaining‑quota → reserve race between concurrent

--- a/app/ai-app/docs/economics/economic-enforcement-engine-README.md
+++ b/app/ai-app/docs/economics/economic-enforcement-engine-README.md
@@ -3,7 +3,7 @@ id: repo:kdcube-ai-app/app/ai-app/docs/economics/economic-enforcement-engine-REA
 title: "Economics Enforcement Engine"
 summary: "Reusable API for enforcing the economics model (quota, funding, settlement) on accountable flows outside the chat entrypoint."
 tags: ["economics", "enforcement", "engine", "api", "integration"]
-keywords: ["EconomicsGuard", "economic_preflight", "EconomicsSubject", "RoleResolver", "FlowPolicy", "reservation", "settlement", "scope_id"]
+keywords: ["EconomicsGuard", "economic_preflight", "EconomicsSubject", "RoleResolver", "FlowPolicy", "reservation", "settlement", "scope_id", "quota lock", "paid lane", "lane switch", "allow_paid_lane_fallback", "enforce_quota_lock"]
 see_also:
   - repo:kdcube-ai-app/app/ai-app/docs/economics/economic-README.md
   - repo:kdcube-ai-app/app/ai-app/docs/economics/economics-events-README.md
@@ -141,6 +141,10 @@ except EconomicsLimitException:
 | `reservation_ttl_sec` | `900` | reservation hold lifetime |
 | `lock_ttl_sec` | `180` | admit lock lifetime |
 | `emit_user_events` | `False` | emit `rate_limit.*` SSE events on denial (needs a `comm` channel); background flows log only |
+| `allow_paid_lane_fallback` | `False` | when the plan lane cannot cover but the user can pay, switch to a wallet‑only paid lane instead of denying (see *Paid‑lane switch* below) |
+| `enforce_quota_lock` | `False` | serialize the admit→reserve window per user with a distributed lock (reserving flows only; see *Quota lock* below) |
+| `quota_lock_ttl_sec` | `60` | quota‑lock key lifetime (safety net if the holder dies) |
+| `quota_lock_wait_sec` | `5.0` | how long to wait for the lock before denying as `quota_lock_timeout` |
 
 ### `EconomicsDecision` — outcome (returned by both APIs)
 
@@ -152,13 +156,31 @@ Carries the resolved `lane` (`plan` / `paid` / `bypass`), `plan_id`,
 ## Behavior notes
 
 - **Denial.** When the flow is not feasible the API raises `EconomicsLimitException`
-  before any work runs. `exc.code` is `rate_limited` (quota) or `no_funding_source`
-  (no eligible funding); `exc.data` carries the snapshot. See
+  before any work runs. `exc.code` is `rate_limited` (quota), `no_funding_source`
+  (no eligible funding), or `quota_lock_timeout` (lock contended — see *Quota lock*);
+  `exc.data` carries the snapshot. See
   [economics-events-README.md](./economics-events-README.md) for the event payloads
   emitted when `emit_user_events` is on.
+- **Paid‑lane switch.** With `allow_paid_lane_fallback` on, a plan‑lane request that
+  cannot be served from the plan — the plan admit is rate‑limited, or plan funding is
+  exhausted and cannot be reserved — switches to a **wallet‑only paid lane** instead
+  of denying, provided the user has a wallet: the plan reservation is released, admit
+  is retried against the pay‑as‑you‑go policy, and the wallet becomes the primary
+  funding. Off by default, so a flow denies rather than charging the wallet unless it
+  opts in.
 - **Settlement (guard only).** On exit, actual spend is charged across the same lanes
   as chat — plan/subscription/project first, wallet for the overflow, with project
-  budget absorbing any shortfall. Subscriptions and wallets never go negative.
+  budget absorbing any shortfall. A paid‑lane flow settles from the wallet (project
+  absorbs any uncovered remainder). A flow whose actual cost is zero releases its
+  holds rather than charging. Subscriptions and wallets never go negative.
+- **Quota lock.** With `enforce_quota_lock` on (and Redis available on the
+  entrypoint), the admit→reserve planning window is serialized per user with a
+  distributed lock, closing the read‑remaining‑quota → reserve race between concurrent
+  requests of the same user. The lock is held only across planning and released before
+  the work runs; if it cannot be acquired within `quota_lock_wait_sec` the flow is
+  denied with `quota_lock_timeout`. It is skipped for `privileged`/`admin` (which
+  bypass funding) and is only meaningful for reserving flows — `economic_preflight`
+  takes no reservation and ignores it. Without Redis it degrades to no lock.
 - **Nested safety.** If a guard is entered while an economics scope is already active
   on the same logical task, it automatically degrades to verify-only (the outer scope
   settles) so the same work is never charged twice.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/UserBillingDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/UserBillingDashboard.tsx
@@ -107,6 +107,8 @@ interface QuotaBreakdown {
         period_end?: string | null;
         available_usd: number;
         available_tokens?: number;
+        reserved_usd?: number;
+        reserved_tokens?: number;
         spent_usd?: number;
     } | null;
 }
@@ -864,11 +866,17 @@ const UserBillingDashboard: React.FC = () => {
                             {breakdown.subscription_balance?.has_subscription && (
                                 <Card className="p-4">
                                     <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500">Subscription Balance</h3>
-                                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
                                         <div className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
                                             <div className="text-xs font-semibold uppercase tracking-wider text-gray-400">Available</div>
                                             <div className="mt-1 text-sm font-medium text-gray-900">
                                                 {formatUsd(breakdown.subscription_balance.available_usd)}
+                                            </div>
+                                        </div>
+                                        <div className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+                                            <div className="text-xs font-semibold uppercase tracking-wider text-gray-400">Reserved</div>
+                                            <div className="mt-1 text-sm font-medium text-gray-900">
+                                                {formatUsd(breakdown.subscription_balance.reserved_usd || 0)}
                                             </div>
                                         </div>
                                         <div className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/comm/sink/telemetry.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/comm/sink/telemetry.py
@@ -107,6 +107,7 @@ class StatsTelemetryTarget:
 
     endpoint_url: str
     token: str = ""
+    token_header: str = "Authorization"
     headers: Mapping[str, str] = field(default_factory=dict)
     timeout_seconds: float = 10.0
 
@@ -117,10 +118,18 @@ class StatsTelemetryTarget:
     def request_headers(self) -> Dict[str, str]:
         headers = {"Content-Type": "application/json"}
         headers.update({str(k): str(v) for k, v in dict(self.headers or {}).items()})
-        has_authorization = any(str(key).lower() == "authorization" for key in headers)
-        if self.token:
-            headers.setdefault("Authorization", f"Bearer {self.token}")
-        elif not has_authorization:
+        token_header = str(self.token_header or "Authorization").strip() or "Authorization"
+        has_token_header = any(str(key).lower() == token_header.lower() for key in headers)
+        if self.token and not has_token_header:
+            # The platform gateway only JWT-parses `Authorization: Bearer ...`. When the
+            # telemetry secret is carried under a non-Authorization header it never trips
+            # the gateway's JWT parser (no "Not enough segments" warning). Send the raw
+            # secret there; the receiver strips an optional "Bearer " prefix either way.
+            if token_header.lower() == "authorization":
+                headers[token_header] = f"Bearer {self.token}"
+            else:
+                headers[token_header] = self.token
+        elif not self.token and not has_token_header:
             raise ValueError("StatsTelemetryTarget requires a bearer token or Authorization header")
         return headers
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/config/bundles.secrets.template.yaml
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/config/bundles.secrets.template.yaml
@@ -11,7 +11,8 @@ bundles:
         telemetry_sink:
           auth:
             # Required when telemetry_sink.endpoint_url is configured.
-            # The SDK sink sends this as Authorization: Bearer <token>.
+            # Sent under telemetry_sink.auth_header: default `Authorization: Bearer <token>`,
+            # or the raw value when a non-Authorization header is configured.
             token: "<RANDOM_TELEMETRY_SINK_BEARER_TOKEN>"
         integrations:
           telegram:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/config/bundles.template.yaml
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/config/bundles.template.yaml
@@ -52,6 +52,7 @@ bundles:
           # bundle URLs here; paste the receiver URL exactly as it should be
           # called.
           endpoint_url: ""
+          auth_header: ""
         integrations:
           telegram:
             enabled: false

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/doc-reader-README.md
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/doc-reader-README.md
@@ -309,6 +309,7 @@ Config:
 ```yaml
 telemetry_sink:
   endpoint_url: "https://stats.example.internal/telemetry/events"
+  auth_header: "X-Telemetry-Token"
 ```
 
 Secret:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/docs/README.md
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/docs/README.md
@@ -51,6 +51,10 @@ Bundle config:
 ```yaml
 telemetry_sink:
   endpoint_url: "https://stats.example.internal/telemetry/events"
+  # Optional. Header carrying the ingest secret. Empty -> Authorization: Bearer.
+  # Use a non-Authorization header (e.g. X-Telemetry-Token) when the receiver is
+  # behind the platform gateway, so the gateway does not JWT-parse the secret.
+  auth_header: "X-Telemetry-Token"
 ```
 
 Bundle secret:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube.copilot@2026-04-03-19-05/entrypoint.py
@@ -542,10 +542,12 @@ class ReactWorkflow(BaseEntrypointWithEconomicsAndMemory):
             except Exception:
                 pass
             return None
+        auth_header = str(self.bundle_prop("telemetry_sink.auth_header", "Authorization") or "").strip() or "Authorization"
         return StatsTelemetrySink(
             StatsTelemetryTarget(
                 endpoint_url=endpoint_url,
                 token=token,
+                token_header=auth_header,
             ),
             source_bundle=self._bundle_id(),
         )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/config/bundles.secrets.template.yaml
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/config/bundles.secrets.template.yaml
@@ -6,7 +6,8 @@ bundles:
         telemetry_sink:
           auth:
             # Required when telemetry_sink.endpoint_url is configured.
-            # The SDK sink sends this as Authorization: Bearer <token>.
+            # Sent under telemetry_sink.auth_header: default `Authorization: Bearer <token>`,
+            # or the raw value when a non-Authorization header is configured.
             token: "<RANDOM_TELEMETRY_SINK_BEARER_TOKEN>"
         integrations:
           telegram:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/config/bundles.template.yaml
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/config/bundles.template.yaml
@@ -37,6 +37,12 @@ bundles:
           # called. When configured, the bundle records selected comm events
           # during chat turns and posts them as one bounded batch after the turn.
           endpoint_url: ""
+          # Header that carries the static ingest secret. Empty -> legacy
+          # `Authorization: Bearer <token>`. Set to a non-Authorization header
+          # (e.g. X-Telemetry-Token) so the platform gateway does not try to
+          # JWT-parse it. Must match the receiver's ingest.public.header_name.
+          auth_header: ""
+          auth_header: ""
         integrations:
           telegram:
             enabled: false

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
@@ -633,10 +633,12 @@ class VersatileEntrypoint(BaseEntrypointWithEconomicsAndMemory):
             except Exception:
                 pass
             return None
+        auth_header = str(self.bundle_prop("telemetry_sink.auth_header", "Authorization") or "").strip() or "Authorization"
         return StatsTelemetrySink(
             StatsTelemetryTarget(
                 endpoint_url=endpoint_url,
                 token=token,
+                token_header=auth_header,
             ),
             source_bundle=self._bundle_id(),
         )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
@@ -21,10 +21,8 @@ Design: docs/economics/economic-enforcement-non-chat-v2-README.md
 
 from __future__ import annotations
 
-import asyncio
 import dataclasses
 import math
-import secrets
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -42,6 +40,7 @@ from kdcube_ai_app.apps.chat.sdk.infra.economics.limiter import (
     GLOBAL_BUNDLE_ID,
 )
 from kdcube_ai_app.apps.chat.sdk.infra.economics.project_budget import BudgetInsufficientFunds
+from kdcube_ai_app.apps.chat.sdk.infra.economics.quota_lock import QuotaLock, quota_lock_key
 from kdcube_ai_app.apps.chat.sdk.infra.economics.events_resources import (
     MSG_NO_FUNDING,
     MSG_SUBSCRIPTION_EXHAUSTED,
@@ -252,9 +251,7 @@ class EconomicsGuard:
         self._funding_ctx_obj = None       # funding_flow.FundingContext (all lanes)
         self._funding_res = None           # funding_flow.PlanFundingReservation (all lanes)
         # quota-lock state (distributed admit->reserve serialization)
-        self._quota_lock_key: Optional[str] = None
-        self._quota_lock_token: Optional[str] = None
-        self._quota_lock_acquired: bool = False
+        self._quota_lock = QuotaLock(self.redis)
 
     # -- logging / events -----------------------------------------------------
     def _log(self, stage: str, msg: str, level: str = "INFO", **kv):
@@ -296,53 +293,8 @@ class EconomicsGuard:
         raise EconomicsLimitException(message, code=code, data=payload)
 
     # -- quota lock (distributed admit->reserve serialization) ----------------
-    async def _quota_lock_try_acquire(self, key: str, token: str, ttl_sec: int) -> bool:
-        r = self.redis
-        if r is None:
-            return False
-        try:
-            return bool(await r.set(key, token, nx=True, ex=ttl_sec))
-        except TypeError:
-            pass
-        except Exception:
-            return False
-        try:
-            return bool(await r.set(key, token, nx=True, px=int(ttl_sec * 1000)))
-        except Exception:
-            return False
-
-    async def _quota_lock_release_key(self, key: str, token: str) -> None:
-        r = self.redis
-        if r is None:
-            return
-        # compare-and-del: only release the lock if WE still hold it (token match),
-        # so a release after our TTL expired can't drop a successor's lock.
-        lua = (
-            "if redis.call('get', KEYS[1]) == ARGV[1] then "
-            "return redis.call('del', KEYS[1]) else return 0 end"
-        )
-        try:
-            await r.eval(lua, 1, key, token)
-            return
-        except TypeError:
-            try:
-                await r.eval(lua, keys=[key], args=[token])
-                return
-            except Exception:
-                pass
-        except Exception:
-            pass
-        try:
-            cur = await r.get(key)
-            if cur is None:
-                return
-            if isinstance(cur, (bytes, bytearray)):
-                cur = cur.decode("utf-8", errors="ignore")
-            if str(cur) == str(token):
-                await r.delete(key)
-        except Exception:
-            pass
-
+    # Redis mechanics + spin-wait live in the shared funding_flow QuotaLock; the
+    # guard owns the policy gating and the denial payload it raises on timeout.
     async def _acquire_quota_lock_or_deny(self, *, scope: str, budget_bypass: bool) -> None:
         # Only reserving surfaces opt in; admin bypass has no shared-pool reserve
         # window to serialize; without redis we degrade to no lock (log a warning).
@@ -352,37 +304,26 @@ class EconomicsGuard:
             self._log("quota_lock", "redis unavailable; quota_lock disabled", "WARN")
             return
         s = self.subject
-        self._quota_lock_key = f"quota_lock:{s.tenant}:{s.project}:{s.user_id}:{scope}:{GLOBAL_BUNDLE_ID}"
-        self._quota_lock_token = secrets.token_hex(16)
         ttl_sec = int(self.policy.quota_lock_ttl_sec)
-        wait_total = float(self.policy.quota_lock_wait_sec)
-        t0 = asyncio.get_event_loop().time()
-        sleep = 0.05
-        while True:
-            if await self._quota_lock_try_acquire(self._quota_lock_key, self._quota_lock_token, ttl_sec=ttl_sec):
-                self._quota_lock_acquired = True
-                self._log("quota_lock", "acquired", key=self._quota_lock_key, scope=scope, ttl_sec=ttl_sec)
-                return
-            if (asyncio.get_event_loop().time() - t0) >= wait_total:
-                self._log("quota_lock", "failed to acquire within wait window", "WARN",
-                          key=self._quota_lock_key, scope=scope)
-                await self._deny(
-                    code="quota_lock_timeout",
-                    title="System busy",
-                    message=f"{self.flow}: quota_lock contended; concurrent planning in progress",
-                    user_message="Too many concurrent requests are planning quotas right now. Please retry.",
-                    data={"reason": "quota_lock_timeout", "lane": "deny", "scope": scope},
-                )
-            await asyncio.sleep(sleep)
-            sleep = min(sleep * 1.5, 0.25)
+        key = quota_lock_key(s.tenant, s.project, s.user_id, scope, GLOBAL_BUNDLE_ID)
+        if await self._quota_lock.acquire_blocking(
+            key, ttl_sec=ttl_sec, wait_total_sec=float(self.policy.quota_lock_wait_sec),
+        ):
+            self._log("quota_lock", "acquired", key=key, scope=scope, ttl_sec=ttl_sec)
+            return
+        self._log("quota_lock", "failed to acquire within wait window", "WARN", key=key, scope=scope)
+        await self._deny(
+            code="quota_lock_timeout",
+            title="System busy",
+            message=f"{self.flow}: quota_lock contended; concurrent planning in progress",
+            user_message="Too many concurrent requests are planning quotas right now. Please retry.",
+            data={"reason": "quota_lock_timeout", "lane": "deny", "scope": scope},
+        )
 
     async def _release_quota_lock_if_held(self) -> None:
-        if self._quota_lock_acquired and self._quota_lock_key and self._quota_lock_token:
-            await self._quota_lock_release_key(self._quota_lock_key, self._quota_lock_token)
-            self._log("quota_lock", "released", key=self._quota_lock_key)
-        self._quota_lock_key = None
-        self._quota_lock_token = None
-        self._quota_lock_acquired = False
+        key = self._quota_lock.key
+        if await self._quota_lock.release_if_held():
+            self._log("quota_lock", "released", key=key)
 
     # -- pre-run --------------------------------------------------------------
     async def __aenter__(self) -> EconomicsDecision:
@@ -748,45 +689,51 @@ class EconomicsGuard:
         if isinstance(decision.extra, dict):
             decision.extra["effective_policy"] = paid_policy
         self._log("lane_switch", "switched plan -> paid", reason=reason)
-        # paid-lane funding (mirrors run()): an active subscription pays first from
-        # its budget (wallet stays untouched); otherwise the wallet is the primary.
-        if r.get("has_active_subscription") and await self._reserve_paid_subscription(decision, r):
+        # paid-lane funding: an active subscription pays first from its budget (wallet
+        # stays untouched); otherwise the wallet is the primary. The money flow is owned
+        # by the shared funding_flow.reserve_paid_funding (single reservation owner).
+        # wallet_can_pay_turn=True mirrors the guard's previous always-fall-to-wallet
+        # behavior (no early subscription-failure deny; the wallet reserve decides).
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import (
+            reserve_paid_funding, ReserveStatus,
+        )
+        sub_limiter = (
+            await self._get_subscription_limiter(r["subscription"])
+            if r.get("has_active_subscription") else None
+        )
+        ctx = self._funding_ctx(sub_limiter)
+        outcome = await reserve_paid_funding(
+            ctx, admit=decision.admit, est_turn_tokens=int(decision.est_turn_tokens),
+            has_active_subscription=bool(r.get("has_active_subscription")),
+            has_wallet=bool(r["has_wallet"]), wallet_can_pay_turn=True,
+            ttl_sec=int(self.policy.reservation_ttl_sec),
+        )
+        if outcome.status is ReserveStatus.OK:
+            res = outcome.reservation
+            self._funding_res = res
+            self._funding_ctx_obj = ctx
+            decision.funding_source = res.funding_source
+            decision.lane = "paid"
+            decision.app_reservation_source = res.funding_source
+            decision.app_reservation_active = res.app_reservation_active
+            if res.funding_source == "wallet":
+                decision.wallet_reservation_id = res.wallet_reservation_id
+                decision.wallet_reserved_tokens = int(res.wallet_reserved_tokens)
             return
-        await self._reserve_wallet_or_deny(
-            decision, r, reserve_usd=float(decision.est_turn_usd), exhausted=None,
-        )
-
-    async def _reserve_paid_subscription(self, decision: EconomicsDecision, r: dict) -> bool:
-        """Reserve the subscription budget as the paid-lane primary. Returns True if
-        the hold was taken (sets lane=paid, funding_source=subscription); False to fall
-        back to the wallet (no subscription limiter, sub-cent hold, or insufficient
-        subscription balance)."""
-        sub_limiter = await self._get_subscription_limiter(r["subscription"])
-        if sub_limiter is None:
-            return False
-        app_reserved_usd = float(decision.est_turn_tokens) * self.usd_per_token * SAFETY_MARGIN
-        if app_reserved_usd < _MIN_RESERVE_USD:
-            return False
-        reservation_id = uuid4()
-        try:
-            await sub_limiter.reserve(
-                bundle_id=self.bundle_id, amount_usd=float(app_reserved_usd),
-                provider=None, request_id=self.scope_id, reservation_id=reservation_id,
-                ttl_sec=int(self.policy.reservation_ttl_sec), now=self.now,
-                notes=f"{self.flow} paid reserve (subscription): est_turn={decision.est_turn_tokens}",
+        # DENIED -> guard denial vocabulary (preserve pre-change codes)
+        if outcome.deny_code == "paid_wallet_reservation_failed":
+            await self._deny(
+                code="personal_reservation_failed", title="Insufficient personal credits",
+                message=f"{self.flow}: wallet reservation failed",
+                user_message=MSG_NO_FUNDING,
+                data={"reason": "personal_reservation_failed", "funding_source": "wallet"},
             )
-        except (BudgetInsufficientFunds, ValueError) as e:
-            self._log("reserve.subscription", "paid subscription reserve declined; falling back to wallet",
-                      "WARN", error=str(e))
-            return False
-        decision.funding_source = "subscription"
-        decision.lane = "paid"
-        self._store_paid_funding(
-            decision, funding_source="subscription",
-            app_reservation_id=reservation_id, app_reserved_usd=app_reserved_usd,
-            subscription_limiter=sub_limiter,
+        await self._deny(
+            code="no_funding_source", title="No funding source",
+            message=f"{self.flow}: no funding source",
+            user_message=MSG_NO_FUNDING,
+            data={"reason": "no_funding_source", "funding_source": "none"},
         )
-        return True
 
     async def _on_funding_denied(self, exc: Exception) -> None:
         """Log + optionally emit a denial, then release the RL token reservation

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
@@ -99,6 +99,10 @@ class FlowPolicy:
     reservation_ttl_sec: int = 900      # configurable per flow
     lock_ttl_sec: int = 180             # configurable per flow
     emit_user_events: bool = False      # background flows log only, no UI delivery
+    # When the plan lane can't cover but the user can pay, switch to a wallet-only
+    # paid lane (re-admit paid policy + reserve wallet) instead of denying.
+    # Off by default (non-chat denies); chat / run()-on-engine sets it True.
+    allow_paid_lane_fallback: bool = False
 
 
 @dataclass
@@ -498,9 +502,21 @@ class EconomicsGuard:
             )
 
         # 2) reserve funding via the shared plan-lane flow (primary + wallet overflow)
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import ReserveStatus
         try:
             if funding_source in ("project", "subscription") or budget_bypass:
-                await self._reserve_plan_lane(decision, r, admit=admit, funding_source=funding_source)
+                outcome = await self._reserve_plan_lane(decision, r, admit=admit, funding_source=funding_source)
+                if outcome.status is ReserveStatus.DENIED:
+                    await self._deny(
+                        code=outcome.deny_code or "no_funding_source",
+                        title="Insufficient funds",
+                        message=outcome.deny_message or f"{self.flow}: cannot fund request",
+                        user_message=MSG_NO_FUNDING,
+                        data=outcome.deny_data or {"reason": "no_funding_source"},
+                    )
+                elif outcome.status is ReserveStatus.SWITCH_TO_PAID:
+                    await self._switch_to_paid(decision, r, reason=outcome.switch_reason or "plan_tokens_exhausted_for_turn")
+                # OK -> _reserve_plan_lane stored _funding_res
             elif funding_source == "wallet":
                 # wallet-primary edge (anonymous + wallet) — not a plan lane
                 await self._reserve_wallet_or_deny(decision, r, reserve_usd=est_turn_usd, exhausted=None)
@@ -518,8 +534,8 @@ class EconomicsGuard:
         )
         return decision
 
-    async def _reserve_plan_lane(self, decision: EconomicsDecision, r: dict, *, admit: AdmitResult, funding_source: str) -> None:
-        from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import reserve_plan_funding
+    async def _reserve_plan_lane(self, decision: EconomicsDecision, r: dict, *, admit: AdmitResult, funding_source: str):
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import reserve_plan_funding, ReserveStatus
 
         est_turn_tokens = int(decision.est_turn_tokens)
         budget_bypass = decision.budget_bypass
@@ -552,18 +568,65 @@ class EconomicsGuard:
         personal_can_pay = bool(wallet_can_pay or sub_can_pay)
 
         ctx = self._funding_ctx(sub_limiter)
-        res = await reserve_plan_funding(
+        outcome = await reserve_plan_funding(
             ctx, admit=admit,
             funding_source=("project" if budget_bypass else funding_source),
             budget_bypass=budget_bypass, est_turn_tokens=est_turn_tokens,
             has_wallet=bool(r["has_wallet"]), subscription_available_usd=sub_available,
             project_budget_snapshot=project_snapshot, personal_can_pay_turn=personal_can_pay,
+            allow_paid_lane_fallback=bool(self.policy.allow_paid_lane_fallback),
             ttl_sec=int(self.policy.reservation_ttl_sec),
         )
-        self._funding_ctx_obj = ctx
-        self._funding_res = res
-        decision.app_reservation_source = res.funding_source
-        decision.app_reservation_active = res.app_reservation_active
+        if outcome.status is ReserveStatus.OK:
+            res = outcome.reservation
+            self._funding_ctx_obj = ctx
+            self._funding_res = res
+            decision.app_reservation_source = res.funding_source
+            decision.app_reservation_active = res.app_reservation_active
+        return outcome
+
+    def _paid_policy(self, r: dict) -> QuotaPolicy:
+        """Policy for the paid (wallet-only) lane — payasyougo service limits."""
+        pols = getattr(self.ep, "app_quota_policies", None) or {}
+        return pols.get("payasyougo") or r.get("base_policy")
+
+    async def _switch_to_paid(self, decision: EconomicsDecision, r: dict, *, reason: str) -> None:
+        """Release the plan RL token reservation, re-admit against the paid policy,
+        and reserve wallet as the primary funding (wallet-only paid lane).
+        Mirrors run()'s _switch_plan_to_paid_or_die (minus the SSE lane_switch event,
+        which is emitted only when policy.emit_user_events)."""
+        # release the plan-lane RL token reservation + lock taken by the plan admit
+        try:
+            await self.rl.release_token_reservation(
+                bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj,
+                reservation_id=self.scope_id, now=self.now,
+            )
+            await self.rl.release(bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, lock_id=self.scope_id)
+        except Exception:
+            pass
+        # the plan-lane money flow took no hold before signalling a switch
+        self._funding_res = None
+        self._funding_ctx_obj = None
+
+        paid_policy = self._paid_policy(r)
+        paid_admit = await self._admit(paid_policy, reserve_tokens=int(decision.est_turn_tokens))
+        if not paid_admit.allowed:
+            await self._deny(
+                code="paid_admit_denied_after_switch",
+                title="Rate limit exceeded",
+                message=f"{self.flow}: paid lane admit denied after switch: {paid_admit.reason or 'unknown'}",
+                user_message=MSG_DENIED_GENERIC,
+                data={"reason": paid_admit.reason, "snapshot": paid_admit.snapshot,
+                      "lane": "deny", "switch_reason": reason},
+            )
+        decision.admit = paid_admit
+        if isinstance(decision.extra, dict):
+            decision.extra["effective_policy"] = paid_policy
+        self._log("lane_switch", "switched plan -> paid", reason=reason)
+        # reserve wallet as primary (existing wallet-primary path; sets lane=paid)
+        await self._reserve_wallet_or_deny(
+            decision, r, reserve_usd=float(decision.est_turn_usd), exhausted=None,
+        )
 
     async def _on_funding_denied(self, exc: Exception) -> None:
         """Log + optionally emit a denial, then release the RL token reservation

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
@@ -21,13 +21,15 @@ Design: docs/economics/economic-enforcement-non-chat-v2-README.md
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import math
+import secrets
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional, Tuple
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from kdcube_ai_app.infra import accounting as acct
 from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import (
@@ -103,6 +105,14 @@ class FlowPolicy:
     # paid lane (re-admit paid policy + reserve wallet) instead of denying.
     # Off by default (non-chat denies); chat / run()-on-engine sets it True.
     allow_paid_lane_fallback: bool = False
+    # Serialize the admit->reserve planning window per user with a distributed
+    # Redis lock (mirrors run()'s quota_lock). Only meaningful for RESERVING
+    # surfaces (full guard) — closes the read-remaining-quota -> reserve TOCTOU
+    # between concurrent turns of the same user. Off by default; needs redis on
+    # the entrypoint. preflight-only flows have no reserve window and ignore it.
+    enforce_quota_lock: bool = False
+    quota_lock_ttl_sec: int = 60        # lock key expiry (safety net if holder dies)
+    quota_lock_wait_sec: float = 5.0    # max spin-wait before denying as "system busy"
 
 
 @dataclass
@@ -118,9 +128,11 @@ class EconomicsDecision:
     nested: bool = False                # degraded to preflight inside a parent ctx
     scope_id: Optional[str] = None
     admit: Optional[AdmitResult] = None
-    # reservation handles for settlement
-    app_reservation_id: Optional[UUID] = None       # subscription/project hold
+    # plan-lane reservation metadata (the actual hold lives in funding_flow's
+    # PlanFundingReservation, kept on the guard as _funding_res; these are the
+    # decision-level mirror used for tracing/assertions).
     app_reservation_source: Optional[str] = None     # which limiter holds it
+    app_reservation_active: bool = False             # primary money hold was taken
     wallet_reservation_id: Optional[str] = None       # lifetime-token hold
     wallet_reserved_tokens: int = 0
     extra: dict = field(default_factory=dict)
@@ -226,6 +238,7 @@ class EconomicsGuard:
         self.cp = getattr(entrypoint, "cp_manager", None)
         self.rl = getattr(entrypoint, "rl", None)
         self.budget_limiter = getattr(entrypoint, "budget_limiter", None)
+        self.redis = getattr(entrypoint, "redis", None)
         self.bundle_id = str(getattr(getattr(getattr(entrypoint, "config", None), "ai_bundle_spec", None), "id", "") or "")
 
         self.subj = subject_id_of(subject.tenant, subject.project, subject.user_id)
@@ -238,6 +251,10 @@ class EconomicsGuard:
         self._subscription_limiter = None  # SubscriptionBudgetLimiter when applicable
         self._funding_ctx_obj = None       # funding_flow.FundingContext (plan lane)
         self._funding_res = None           # funding_flow.PlanFundingReservation (plan lane)
+        # quota-lock state (distributed admit->reserve serialization)
+        self._quota_lock_key: Optional[str] = None
+        self._quota_lock_token: Optional[str] = None
+        self._quota_lock_acquired: bool = False
 
     # -- logging / events -----------------------------------------------------
     def _log(self, stage: str, msg: str, level: str = "INFO", **kv):
@@ -277,6 +294,95 @@ class EconomicsGuard:
         self._log("deny", message, "WARN", code=code)
         await self._emit_denial(code=code, title=title, data=payload)
         raise EconomicsLimitException(message, code=code, data=payload)
+
+    # -- quota lock (distributed admit->reserve serialization) ----------------
+    async def _quota_lock_try_acquire(self, key: str, token: str, ttl_sec: int) -> bool:
+        r = self.redis
+        if r is None:
+            return False
+        try:
+            return bool(await r.set(key, token, nx=True, ex=ttl_sec))
+        except TypeError:
+            pass
+        except Exception:
+            return False
+        try:
+            return bool(await r.set(key, token, nx=True, px=int(ttl_sec * 1000)))
+        except Exception:
+            return False
+
+    async def _quota_lock_release_key(self, key: str, token: str) -> None:
+        r = self.redis
+        if r is None:
+            return
+        # compare-and-del: only release the lock if WE still hold it (token match),
+        # so a release after our TTL expired can't drop a successor's lock.
+        lua = (
+            "if redis.call('get', KEYS[1]) == ARGV[1] then "
+            "return redis.call('del', KEYS[1]) else return 0 end"
+        )
+        try:
+            await r.eval(lua, 1, key, token)
+            return
+        except TypeError:
+            try:
+                await r.eval(lua, keys=[key], args=[token])
+                return
+            except Exception:
+                pass
+        except Exception:
+            pass
+        try:
+            cur = await r.get(key)
+            if cur is None:
+                return
+            if isinstance(cur, (bytes, bytearray)):
+                cur = cur.decode("utf-8", errors="ignore")
+            if str(cur) == str(token):
+                await r.delete(key)
+        except Exception:
+            pass
+
+    async def _acquire_quota_lock_or_deny(self, *, scope: str, budget_bypass: bool) -> None:
+        # Only reserving surfaces opt in; admin bypass has no shared-pool reserve
+        # window to serialize; without redis we degrade to no lock (log a warning).
+        if not self.policy.enforce_quota_lock or budget_bypass:
+            return
+        if self.redis is None:
+            self._log("quota_lock", "redis unavailable; quota_lock disabled", "WARN")
+            return
+        s = self.subject
+        self._quota_lock_key = f"quota_lock:{s.tenant}:{s.project}:{s.user_id}:{scope}:{GLOBAL_BUNDLE_ID}"
+        self._quota_lock_token = secrets.token_hex(16)
+        ttl_sec = int(self.policy.quota_lock_ttl_sec)
+        wait_total = float(self.policy.quota_lock_wait_sec)
+        t0 = asyncio.get_event_loop().time()
+        sleep = 0.05
+        while True:
+            if await self._quota_lock_try_acquire(self._quota_lock_key, self._quota_lock_token, ttl_sec=ttl_sec):
+                self._quota_lock_acquired = True
+                self._log("quota_lock", "acquired", key=self._quota_lock_key, scope=scope, ttl_sec=ttl_sec)
+                return
+            if (asyncio.get_event_loop().time() - t0) >= wait_total:
+                self._log("quota_lock", "failed to acquire within wait window", "WARN",
+                          key=self._quota_lock_key, scope=scope)
+                await self._deny(
+                    code="quota_lock_timeout",
+                    title="System busy",
+                    message=f"{self.flow}: quota_lock contended; concurrent planning in progress",
+                    user_message="Too many concurrent requests are planning quotas right now. Please retry.",
+                    data={"reason": "quota_lock_timeout", "lane": "deny", "scope": scope},
+                )
+            await asyncio.sleep(sleep)
+            sleep = min(sleep * 1.5, 0.25)
+
+    async def _release_quota_lock_if_held(self) -> None:
+        if self._quota_lock_acquired and self._quota_lock_key and self._quota_lock_token:
+            await self._quota_lock_release_key(self._quota_lock_key, self._quota_lock_token)
+            self._log("quota_lock", "released", key=self._quota_lock_key)
+        self._quota_lock_key = None
+        self._quota_lock_token = None
+        self._quota_lock_acquired = False
 
     # -- pre-run --------------------------------------------------------------
     async def __aenter__(self) -> EconomicsDecision:
@@ -462,67 +568,84 @@ class EconomicsGuard:
         budget_bypass = r["budget_bypass"]
         funding_source, available_usd = self._funding_summary(r)
 
-        # 1) verify quota AND reserve RL plan tokens at the start (full run() parity)
-        admit = await self._admit(r["base_policy"], reserve_tokens=est_turn_tokens)
-        if not admit.allowed and not budget_bypass:
-            await self._deny(
-                code="rate_limited",
-                title="Rate limit exceeded",
-                message=f"{self.flow}: rate limited: {admit.reason or 'unknown'}",
-                user_message=MSG_DENIED_GENERIC,
-                data={"reason": admit.reason, "snapshot": admit.snapshot, "lane": "deny"},
-            )
-
-        est_turn_usd = float(r["est_turn_usd"])
-        decision = EconomicsDecision(
-            lane="bypass" if budget_bypass else ("paid" if funding_source == "wallet" else "plan"),
-            plan_id=r["plan_id"],
-            funding_source=funding_source,
-            funding_available_usd=available_usd,
-            est_turn_tokens=est_turn_tokens,
-            est_turn_usd=est_turn_usd,
-            budget_bypass=budget_bypass,
-            nested=False,
-            scope_id=self.scope_id,
-            admit=admit,
-            extra={
-                "effective_policy": r["base_policy"],
-                "plan_balance": r["plan_balance"],
-                "wallet_tokens": int(r["wallet_tokens"]),
-            },
-        )
-
-        if funding_source == "none" and not budget_bypass:
-            await self._deny(
-                code="no_funding_source",
-                title="No funding source",
-                message=f"{self.flow}: no funding source for user",
-                user_message=MSG_NO_FUNDING,
-                data={"reason": "no_funding_source", "funding_source": "none"},
-            )
-
-        # 2) reserve funding via the shared plan-lane flow (primary + wallet overflow)
-        from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import ReserveStatus
+        # Serialize the admit->reserve planning window per user (reserving surfaces
+        # only; no-op unless policy.enforce_quota_lock + redis). Acquired BEFORE
+        # admit (which reserves RL tokens) and released as soon as all holds are
+        # taken (or on any deny) — never held across the LLM work. Mirrors run().
+        _, quota_scope = r["base_policy"].effective_allowed_tokens()
+        await self._acquire_quota_lock_or_deny(scope=str(quota_scope or "month"), budget_bypass=budget_bypass)
         try:
-            if funding_source in ("project", "subscription") or budget_bypass:
-                outcome = await self._reserve_plan_lane(decision, r, admit=admit, funding_source=funding_source)
-                if outcome.status is ReserveStatus.DENIED:
+            # 1) verify quota AND reserve RL plan tokens at the start (full run() parity)
+            admit = await self._admit(r["base_policy"], reserve_tokens=est_turn_tokens)
+
+            est_turn_usd = float(r["est_turn_usd"])
+            decision = EconomicsDecision(
+                lane="bypass" if budget_bypass else ("paid" if funding_source == "wallet" else "plan"),
+                plan_id=r["plan_id"],
+                funding_source=funding_source,
+                funding_available_usd=available_usd,
+                est_turn_tokens=est_turn_tokens,
+                est_turn_usd=est_turn_usd,
+                budget_bypass=budget_bypass,
+                nested=False,
+                scope_id=self.scope_id,
+                admit=admit,
+                extra={
+                    "effective_policy": r["base_policy"],
+                    "plan_balance": r["plan_balance"],
+                    "wallet_tokens": int(r["wallet_tokens"]),
+                },
+            )
+
+            if not admit.allowed and not budget_bypass:
+                # Plan policy rate-limited. If the flow allows a paid-lane fallback
+                # and the user has a wallet to back it, switch to the paid lane
+                # instead of denying (run() parity: admit-denied -> paid for payers).
+                # Otherwise deny. _switch_to_paid raises on its own failures.
+                if self.policy.allow_paid_lane_fallback and r["has_wallet"]:
+                    await self._switch_to_paid(decision, r, reason="plan_admit_rate_limited")
+                else:
                     await self._deny(
-                        code=outcome.deny_code or "no_funding_source",
-                        title="Insufficient funds",
-                        message=outcome.deny_message or f"{self.flow}: cannot fund request",
-                        user_message=MSG_NO_FUNDING,
-                        data=outcome.deny_data or {"reason": "no_funding_source"},
+                        code="rate_limited",
+                        title="Rate limit exceeded",
+                        message=f"{self.flow}: rate limited: {admit.reason or 'unknown'}",
+                        user_message=MSG_DENIED_GENERIC,
+                        data={"reason": admit.reason, "snapshot": admit.snapshot, "lane": "deny"},
                     )
-                elif outcome.status is ReserveStatus.SWITCH_TO_PAID:
-                    await self._switch_to_paid(decision, r, reason=outcome.switch_reason or "plan_tokens_exhausted_for_turn")
-                # OK -> _reserve_plan_lane stored _funding_res
-            elif funding_source == "wallet":
-                # wallet-primary edge (anonymous + wallet) — not a plan lane
-                await self._reserve_wallet_or_deny(decision, r, reserve_usd=est_turn_usd, exhausted=None)
-        except EconomicsLimitException as exc:
-            await self._on_funding_denied(exc)
-            raise
+            else:
+                if funding_source == "none" and not budget_bypass:
+                    await self._deny(
+                        code="no_funding_source",
+                        title="No funding source",
+                        message=f"{self.flow}: no funding source for user",
+                        user_message=MSG_NO_FUNDING,
+                        data={"reason": "no_funding_source", "funding_source": "none"},
+                    )
+
+                # 2) reserve funding via the shared plan-lane flow (primary + wallet overflow)
+                from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import ReserveStatus
+                try:
+                    if funding_source in ("project", "subscription") or budget_bypass:
+                        outcome = await self._reserve_plan_lane(decision, r, admit=admit, funding_source=funding_source)
+                        if outcome.status is ReserveStatus.DENIED:
+                            await self._deny(
+                                code=outcome.deny_code or "no_funding_source",
+                                title="Insufficient funds",
+                                message=outcome.deny_message or f"{self.flow}: cannot fund request",
+                                user_message=MSG_NO_FUNDING,
+                                data=outcome.deny_data or {"reason": "no_funding_source"},
+                            )
+                        elif outcome.status is ReserveStatus.SWITCH_TO_PAID:
+                            await self._switch_to_paid(decision, r, reason=outcome.switch_reason or "plan_tokens_exhausted_for_turn")
+                        # OK -> _reserve_plan_lane stored _funding_res
+                    elif funding_source == "wallet":
+                        # wallet-primary edge (anonymous + wallet) — not a plan lane
+                        await self._reserve_wallet_or_deny(decision, r, reserve_usd=est_turn_usd, exhausted=None)
+                except EconomicsLimitException as exc:
+                    await self._on_funding_denied(exc)
+                    raise
+        finally:
+            await self._release_quota_lock_if_held()
 
         # 3) bind accounting (Variant A) + mark active economics scope
         self._bind_accounting()
@@ -592,9 +715,11 @@ class EconomicsGuard:
 
     async def _switch_to_paid(self, decision: EconomicsDecision, r: dict, *, reason: str) -> None:
         """Release the plan RL token reservation, re-admit against the paid policy,
-        and reserve wallet as the primary funding (wallet-only paid lane).
-        Mirrors run()'s _switch_plan_to_paid_or_die (minus the SSE lane_switch event,
-        which is emitted only when policy.emit_user_events)."""
+        and reserve wallet as the primary funding (wallet-only paid lane). Triggered
+        either by plan-admit rate-limit or by plan-funding exhaustion (ReserveStatus
+        .SWITCH_TO_PAID). Mirrors run()'s _switch_plan_to_paid_or_die money flow; the
+        switch is logged only (no rate_limit.lane_switch SSE event is emitted here —
+        UX events stay in run())."""
         # release the plan-lane RL token reservation + lock taken by the plan admit
         try:
             await self.rl.release_token_reservation(
@@ -840,6 +965,15 @@ class EconomicsGuard:
         except Exception as e:
             self._log("rl.commit", "failed to commit rl usage", "WARN", error=str(e))
         if d.wallet_reservation_id:
+            if int(ranked_tokens) <= 0:
+                # Nothing consumed (e.g. free-tier provider): commit_reserved_lifetime_tokens
+                # no-ops on tokens<=0 and would leave the hold 'reserved' until TTL —
+                # release it so the wallet balance frees immediately.
+                await self.cp.user_credits_mgr.release_lifetime_token_reservation(
+                    tenant=s.tenant, project=s.project, user_id=s.user_id,
+                    reservation_id=d.wallet_reservation_id, reason=f"{self.flow}: zero actual cost",
+                )
+                return
             uncovered = await self.cp.user_credits_mgr.commit_reserved_lifetime_tokens(
                 tenant=s.tenant, project=s.project, user_id=s.user_id,
                 reservation_id=d.wallet_reservation_id, tokens=int(ranked_tokens),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
@@ -251,6 +251,8 @@ class EconomicsGuard:
         self._subscription_limiter = None  # SubscriptionBudgetLimiter when applicable
         self._funding_ctx_obj = None       # funding_flow.FundingContext (plan lane)
         self._funding_res = None           # funding_flow.PlanFundingReservation (plan lane)
+        self._paid_sub_limiter = None      # SubscriptionBudgetLimiter holding the paid-lane primary
+        self._paid_sub_reservation_id = None  # subscription app-reservation id (paid lane)
         # quota-lock state (distributed admit->reserve serialization)
         self._quota_lock_key: Optional[str] = None
         self._quota_lock_token: Optional[str] = None
@@ -748,10 +750,44 @@ class EconomicsGuard:
         if isinstance(decision.extra, dict):
             decision.extra["effective_policy"] = paid_policy
         self._log("lane_switch", "switched plan -> paid", reason=reason)
-        # reserve wallet as primary (existing wallet-primary path; sets lane=paid)
+        # paid-lane funding (mirrors run()): an active subscription pays first from
+        # its budget (wallet stays untouched); otherwise the wallet is the primary.
+        if r.get("has_active_subscription") and await self._reserve_paid_subscription(decision, r):
+            return
         await self._reserve_wallet_or_deny(
             decision, r, reserve_usd=float(decision.est_turn_usd), exhausted=None,
         )
+
+    async def _reserve_paid_subscription(self, decision: EconomicsDecision, r: dict) -> bool:
+        """Reserve the subscription budget as the paid-lane primary. Returns True if
+        the hold was taken (sets lane=paid, funding_source=subscription); False to fall
+        back to the wallet (no subscription limiter, sub-cent hold, or insufficient
+        subscription balance)."""
+        sub_limiter = await self._get_subscription_limiter(r["subscription"])
+        if sub_limiter is None:
+            return False
+        app_reserved_usd = float(decision.est_turn_tokens) * self.usd_per_token * SAFETY_MARGIN
+        if app_reserved_usd < _MIN_RESERVE_USD:
+            return False
+        reservation_id = uuid4()
+        try:
+            await sub_limiter.reserve(
+                bundle_id=self.bundle_id, amount_usd=float(app_reserved_usd),
+                provider=None, request_id=self.scope_id, reservation_id=reservation_id,
+                ttl_sec=int(self.policy.reservation_ttl_sec), now=self.now,
+                notes=f"{self.flow} paid reserve (subscription): est_turn={decision.est_turn_tokens}",
+            )
+        except (BudgetInsufficientFunds, ValueError) as e:
+            self._log("reserve.subscription", "paid subscription reserve declined; falling back to wallet",
+                      "WARN", error=str(e))
+            return False
+        self._paid_sub_limiter = sub_limiter
+        self._paid_sub_reservation_id = reservation_id
+        decision.funding_source = "subscription"
+        decision.lane = "paid"
+        decision.app_reservation_source = "subscription"
+        decision.app_reservation_active = True
+        return True
 
     async def _on_funding_denied(self, exc: Exception) -> None:
         """Log + optionally emit a denial, then release the RL token reservation
@@ -951,6 +987,10 @@ class EconomicsGuard:
                 user_budget_tokens=(wallet_tokens or None),
             )
             return
+        # paid lane, subscription-primary (after a switch): subscription budget pays
+        if self._paid_sub_reservation_id is not None and self._paid_sub_limiter is not None:
+            await self._settle_paid_subscription(d, ranked_tokens=ranked_tokens, total_cost=total_cost)
+            return
         # wallet-primary edge (no plan-lane reservation taken)
         await self._settle_wallet(d, ranked_tokens=ranked_tokens, total_cost=total_cost)
 
@@ -988,10 +1028,53 @@ class EconomicsGuard:
                         request_id=self.scope_id, user_id=s.user_id, note=f"{self.flow}: shortfall:wallet_paid",
                     )
 
+    async def _settle_paid_subscription(self, d: EconomicsDecision, *, ranked_tokens: int, total_cost: float) -> None:
+        # Paid lane: payasyougo quotas applied, so RL usage commits reservation-free
+        # (no plan-quota consumption). The subscription budget pays the actual cost;
+        # the wallet stays untouched.
+        try:
+            await self.rl.commit_with_reservation(
+                bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj,
+                tokens=int(ranked_tokens), lock_id=self.scope_id,
+                reservation_id=self.scope_id, now=self.now, inc_request=1,
+            )
+        except Exception as e:
+            self._log("rl.commit", "failed to commit rl usage", "WARN", error=str(e))
+        try:
+            if float(total_cost) > 0:
+                await self._paid_sub_limiter.commit_reserved_spend(
+                    reservation_id=self._paid_sub_reservation_id, spent_usd=float(total_cost),
+                    now=self.now, project_budget=self.budget_limiter,
+                )
+            else:
+                # nothing spent -> release the subscription hold
+                await self._paid_sub_limiter.release_reservation(
+                    reservation_id=self._paid_sub_reservation_id,
+                    note=f"{self.flow}: zero actual cost", now=self.now,
+                )
+        except Exception as e:
+            self._log("settle.subscription", "failed to commit subscription spend", "WARN", error=str(e))
+
     async def _cleanup_release(self, d: EconomicsDecision) -> None:
         if self._funding_res is not None and self._funding_ctx_obj is not None:
             from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import release_plan_funding
             await release_plan_funding(self._funding_ctx_obj, self._funding_res)
+            return
+        if self._paid_sub_reservation_id is not None and self._paid_sub_limiter is not None:
+            try:
+                await self._paid_sub_limiter.release_reservation(
+                    reservation_id=self._paid_sub_reservation_id,
+                    note=f"{self.flow}: cleanup", now=self.now,
+                )
+            except Exception as e:
+                self._log("cleanup", "failed to release subscription reservation", "WARN", error=str(e))
+            try:
+                await self.rl.release_token_reservation(
+                    bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, reservation_id=self.scope_id, now=self.now,
+                )
+                await self.rl.release(bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, lock_id=self.scope_id)
+            except Exception:
+                pass
             return
         s = self.subject
         try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
@@ -249,10 +249,8 @@ class EconomicsGuard:
         self._acct_cm = None
         self._econ_token = None  # ContextVar token for the economics-scope marker
         self._subscription_limiter = None  # SubscriptionBudgetLimiter when applicable
-        self._funding_ctx_obj = None       # funding_flow.FundingContext (plan lane)
-        self._funding_res = None           # funding_flow.PlanFundingReservation (plan lane)
-        self._paid_sub_limiter = None      # SubscriptionBudgetLimiter holding the paid-lane primary
-        self._paid_sub_reservation_id = None  # subscription app-reservation id (paid lane)
+        self._funding_ctx_obj = None       # funding_flow.FundingContext (all lanes)
+        self._funding_res = None           # funding_flow.PlanFundingReservation (all lanes)
         # quota-lock state (distributed admit->reserve serialization)
         self._quota_lock_key: Optional[str] = None
         self._quota_lock_token: Optional[str] = None
@@ -781,12 +779,13 @@ class EconomicsGuard:
             self._log("reserve.subscription", "paid subscription reserve declined; falling back to wallet",
                       "WARN", error=str(e))
             return False
-        self._paid_sub_limiter = sub_limiter
-        self._paid_sub_reservation_id = reservation_id
         decision.funding_source = "subscription"
         decision.lane = "paid"
-        decision.app_reservation_source = "subscription"
-        decision.app_reservation_active = True
+        self._store_paid_funding(
+            decision, funding_source="subscription",
+            app_reservation_id=reservation_id, app_reserved_usd=app_reserved_usd,
+            subscription_limiter=sub_limiter,
+        )
         return True
 
     async def _on_funding_denied(self, exc: Exception) -> None:
@@ -811,6 +810,34 @@ class EconomicsGuard:
                 await self.rl.release(bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, lock_id=self.scope_id)
         except Exception:
             pass
+
+    def _store_paid_funding(
+        self, decision: EconomicsDecision, *, funding_source: str,
+        wallet_reservation_id: Optional[str] = None, wallet_reserved_tokens: int = 0,
+        app_reservation_id=None, app_reserved_usd: float = 0.0, subscription_limiter=None,
+    ) -> None:
+        """Build the PlanFundingReservation for a paid-lane hold and store it as the
+        settlement handle, so paid settle/cleanup run through the shared funding_flow
+        (single settlement owner — no per-lane settle methods on the guard)."""
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import PlanFundingReservation
+        admit = decision.admit
+        plan_reserved = int(getattr(admit, "reserved_tokens", 0) or 0)
+        plan_resv_id = getattr(admit, "reservation_id", None)
+        self._funding_res = PlanFundingReservation(
+            funding_source=funding_source, budget_bypass=False,
+            est_turn_tokens=int(decision.est_turn_tokens),
+            plan_reservation_id=plan_resv_id, plan_reserved_tokens=plan_reserved,
+            plan_reservation_active=bool(plan_resv_id and plan_reserved > 0),
+            app_reservation_id=app_reservation_id, app_reserved_usd=float(app_reserved_usd),
+            app_reservation_active=bool(app_reservation_id),
+            wallet_reservation_id=wallet_reservation_id,
+            wallet_reserved_tokens=int(wallet_reserved_tokens),
+            wallet_reservation_active=bool(wallet_reservation_id),
+            has_wallet=bool(decision.extra.get("wallet_tokens")), paid_lane=True,
+        )
+        self._funding_ctx_obj = self._funding_ctx(subscription_limiter)
+        decision.app_reservation_source = funding_source
+        decision.app_reservation_active = True
 
     async def _reserve_wallet_or_deny(self, decision: EconomicsDecision, r: dict, *, reserve_usd: float, exhausted: Optional[str]) -> None:
         s = self.subject
@@ -858,6 +885,10 @@ class EconomicsGuard:
         decision.lane = "paid"
         decision.wallet_reservation_id = self.scope_id
         decision.wallet_reserved_tokens = tokens
+        self._store_paid_funding(
+            decision, funding_source="wallet",
+            wallet_reservation_id=self.scope_id, wallet_reserved_tokens=tokens,
+        )
 
     async def _get_subscription_limiter(self, subscription: Any):
         if self._subscription_limiter is not None:
@@ -973,8 +1004,9 @@ class EconomicsGuard:
         return int(ranked or 0), (result or {})
 
     async def _settle(self, d: EconomicsDecision, *, ranked_tokens: int, total_cost: float) -> None:
-        # Plan lane (project/subscription/bypass) -> shared funding_flow settlement
-        # (primary + wallet overflow + project absorption, via allocate_plan_wallet_settlement).
+        # All lanes (plan/subscription/project/bypass + paid wallet/subscription)
+        # settle through the shared funding_flow — single settlement owner. The paid
+        # reserve builds the same PlanFundingReservation handle as the plan lane.
         if self._funding_res is not None and self._funding_ctx_obj is not None:
             from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import settle_plan_funding
             plan_balance = d.extra.get("plan_balance")
@@ -987,104 +1019,16 @@ class EconomicsGuard:
                 user_budget_tokens=(wallet_tokens or None),
             )
             return
-        # paid lane, subscription-primary (after a switch): subscription budget pays
-        if self._paid_sub_reservation_id is not None and self._paid_sub_limiter is not None:
-            await self._settle_paid_subscription(d, ranked_tokens=ranked_tokens, total_cost=total_cost)
-            return
-        # wallet-primary edge (no plan-lane reservation taken)
-        await self._settle_wallet(d, ranked_tokens=ranked_tokens, total_cost=total_cost)
-
-    async def _settle_wallet(self, d: EconomicsDecision, *, ranked_tokens: int, total_cost: float) -> None:
-        s = self.subject
-        try:
-            await self.rl.commit_with_reservation(
-                bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj,
-                tokens=int(ranked_tokens), lock_id=self.scope_id,
-                reservation_id=self.scope_id, now=self.now, inc_request=1,
-            )
-        except Exception as e:
-            self._log("rl.commit", "failed to commit rl usage", "WARN", error=str(e))
-        if d.wallet_reservation_id:
-            if int(ranked_tokens) <= 0:
-                # Nothing consumed (e.g. free-tier provider): commit_reserved_lifetime_tokens
-                # no-ops on tokens<=0 and would leave the hold 'reserved' until TTL —
-                # release it so the wallet balance frees immediately.
-                await self.cp.user_credits_mgr.release_lifetime_token_reservation(
-                    tenant=s.tenant, project=s.project, user_id=s.user_id,
-                    reservation_id=d.wallet_reservation_id, reason=f"{self.flow}: zero actual cost",
-                )
-                return
-            uncovered = await self.cp.user_credits_mgr.commit_reserved_lifetime_tokens(
-                tenant=s.tenant, project=s.project, user_id=s.user_id,
-                reservation_id=d.wallet_reservation_id, tokens=int(ranked_tokens),
-            )
-            uncovered = int(uncovered or 0)
-            if uncovered > 0 and total_cost > 0 and ranked_tokens > 0:
-                from kdcube_ai_app.apps.chat.sdk.util import safe_frac
-                shortfall = float(total_cost) * safe_frac(float(uncovered), float(ranked_tokens))
-                if shortfall > 0:
-                    await self.budget_limiter.force_project_spend(
-                        spent_usd=shortfall, bundle_id=self.bundle_id, provider=None,
-                        request_id=self.scope_id, user_id=s.user_id, note=f"{self.flow}: shortfall:wallet_paid",
-                    )
-
-    async def _settle_paid_subscription(self, d: EconomicsDecision, *, ranked_tokens: int, total_cost: float) -> None:
-        # Paid lane: payasyougo quotas applied, so RL usage commits reservation-free
-        # (no plan-quota consumption). The subscription budget pays the actual cost;
-        # the wallet stays untouched.
-        try:
-            await self.rl.commit_with_reservation(
-                bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj,
-                tokens=int(ranked_tokens), lock_id=self.scope_id,
-                reservation_id=self.scope_id, now=self.now, inc_request=1,
-            )
-        except Exception as e:
-            self._log("rl.commit", "failed to commit rl usage", "WARN", error=str(e))
-        try:
-            if float(total_cost) > 0:
-                await self._paid_sub_limiter.commit_reserved_spend(
-                    reservation_id=self._paid_sub_reservation_id, spent_usd=float(total_cost),
-                    now=self.now, project_budget=self.budget_limiter,
-                )
-            else:
-                # nothing spent -> release the subscription hold
-                await self._paid_sub_limiter.release_reservation(
-                    reservation_id=self._paid_sub_reservation_id,
-                    note=f"{self.flow}: zero actual cost", now=self.now,
-                )
-        except Exception as e:
-            self._log("settle.subscription", "failed to commit subscription spend", "WARN", error=str(e))
+        self._log("settle", "no funding reservation to settle", "WARN")
 
     async def _cleanup_release(self, d: EconomicsDecision) -> None:
+        # All lanes hold a PlanFundingReservation -> release everything (app/wallet/RL
+        # holds + lock) through the shared funding_flow cleanup.
         if self._funding_res is not None and self._funding_ctx_obj is not None:
             from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import release_plan_funding
             await release_plan_funding(self._funding_ctx_obj, self._funding_res)
             return
-        if self._paid_sub_reservation_id is not None and self._paid_sub_limiter is not None:
-            try:
-                await self._paid_sub_limiter.release_reservation(
-                    reservation_id=self._paid_sub_reservation_id,
-                    note=f"{self.flow}: cleanup", now=self.now,
-                )
-            except Exception as e:
-                self._log("cleanup", "failed to release subscription reservation", "WARN", error=str(e))
-            try:
-                await self.rl.release_token_reservation(
-                    bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, reservation_id=self.scope_id, now=self.now,
-                )
-                await self.rl.release(bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, lock_id=self.scope_id)
-            except Exception:
-                pass
-            return
-        s = self.subject
-        try:
-            if d.wallet_reservation_id:
-                await self.cp.user_credits_mgr.release_lifetime_token_reservation(
-                    tenant=s.tenant, project=s.project, user_id=s.user_id,
-                    reservation_id=d.wallet_reservation_id, reason=f"{self.flow}: cleanup",
-                )
-        except Exception as e:
-            self._log("cleanup", "failed to release wallet reservation", "WARN", error=str(e))
+        # defensive: nothing reserved -> drop any RL lock/reservation tied to scope
         try:
             await self.rl.release_token_reservation(
                 bundle_id=GLOBAL_BUNDLE_ID, subject_id=self.subj, reservation_id=self.scope_id, now=self.now,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
@@ -95,6 +95,9 @@ class PlanFundingReservation:
     wallet_reservation_active: bool = False
 
     has_wallet: bool = False
+    # paid lane (post-switch): payasyougo quotas, primary is the wallet or the
+    # subscription budget; RL usage commits reservation-free (no plan-quota consume).
+    paid_lane: bool = False
 
 
 @dataclass
@@ -107,6 +110,11 @@ class SettlementResult:
     quota_commit_tokens: int = 0
     allocation: Optional[PlanWalletSettlementAllocation] = None
     extra_project_items: list = field(default_factory=list)
+    # wallet settlement intermediates (consumed by the caller's observability:
+    # the user_underfunded_absorbed event). wallet_consumed = wallet target - uncovered.
+    wallet_consumed_tokens: int = 0
+    user_uncovered_tokens: int = 0
+    user_uncovered_usd: float = 0.0
 
 
 class ReserveStatus(Enum):
@@ -365,6 +373,27 @@ async def settle_plan_funding(
         out.quota_commit_tokens = ranked_tokens
         return out
 
+    if funding_source == "subscription" and res.paid_lane:
+        # paid lane, subscription-primary: payasyougo quotas (RL committed
+        # reservation-free, no plan-quota consume); the subscription budget pays the
+        # actual cost; the wallet stays untouched.
+        await _commit_rl(ctx, res, tokens=ranked_tokens)
+        if res.app_reservation_active and res.app_reservation_id:
+            if total_cost > 0:
+                await ctx.subscription_limiter.commit_reserved_spend(
+                    reservation_id=res.app_reservation_id, spent_usd=float(total_cost),
+                    project_budget=ctx.budget_limiter,
+                )
+            else:
+                # nothing spent -> release the subscription hold
+                await ctx.subscription_limiter.release_reservation(
+                    reservation_id=res.app_reservation_id, note="settle: zero actual cost",
+                )
+            res.app_reservation_active = False
+        out.primary_funding_usd = float(total_cost)
+        out.quota_commit_tokens = ranked_tokens
+        return out
+
     if funding_source == "wallet":
         # paid lane: wallet is the primary funding; project absorbs any uncovered
         # shortfall (shortfall:wallet_paid). Wallet-paid tokens do NOT consume plan
@@ -405,6 +434,9 @@ async def settle_plan_funding(
         out.wallet_usd = max(float(total_cost) - float(user_uncovered_usd), 0.0)
         out.project_absorption_usd = float(user_uncovered_usd)
         out.quota_commit_tokens = ranked_tokens
+        out.wallet_consumed_tokens = max(int(ranked_tokens) - int(user_uncovered), 0)
+        out.user_uncovered_tokens = int(user_uncovered)
+        out.user_uncovered_usd = float(user_uncovered_usd)
         return out
 
     if funding_source == "none":
@@ -571,6 +603,9 @@ async def settle_plan_funding(
     out.project_absorption_usd = float(project_absorption_usd)
     out.quota_commit_tokens = int(plan_quota_commit_tokens)
     out.extra_project_items = extra_project_items
+    out.wallet_consumed_tokens = max(int(user_target_tokens) - int(user_uncovered_tokens), 0)
+    out.user_uncovered_tokens = int(user_uncovered_tokens)
+    out.user_uncovered_usd = float(user_uncovered_usd)
     return out
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
@@ -374,10 +374,11 @@ async def settle_plan_funding(
         return out
 
     if funding_source == "subscription" and res.paid_lane:
-        # paid lane, subscription-primary: payasyougo quotas (RL committed
-        # reservation-free, no plan-quota consume); the subscription budget pays the
-        # actual cost; the wallet stays untouched.
-        await _commit_rl(ctx, res, tokens=ranked_tokens)
+        # paid lane, subscription-primary: payasyougo quotas; the subscription
+        # budget pays the actual cost and the wallet stays untouched. Paid-lane
+        # usage does NOT consume plan token quota (only the request counts), so the
+        # RL commit records 0 tokens reservation-free.
+        await _commit_rl(ctx, res, tokens=0)
         if res.app_reservation_active and res.app_reservation_id:
             if total_cost > 0:
                 await ctx.subscription_limiter.commit_reserved_spend(
@@ -391,13 +392,14 @@ async def settle_plan_funding(
                 )
             res.app_reservation_active = False
         out.primary_funding_usd = float(total_cost)
-        out.quota_commit_tokens = ranked_tokens
+        out.quota_commit_tokens = 0
         return out
 
     if funding_source == "wallet":
         # paid lane: wallet is the primary funding; project absorbs any uncovered
         # shortfall (shortfall:wallet_paid). Wallet-paid tokens do NOT consume plan
-        # quota, but we record the request + tokens against RL (reservation-free).
+        # token quota (only the request counts), so the RL commit records 0 tokens
+        # reservation-free.
         user_uncovered = 0
         remaining = int(ranked_tokens)
         if res.wallet_reservation_active and res.wallet_reservation_id and res.wallet_reserved_tokens > 0:
@@ -430,10 +432,10 @@ async def settle_plan_funding(
                 spent_usd=float(user_uncovered_usd), bundle_id=ctx.bundle_id, provider=None,
                 request_id=ctx.scope_id, user_id=ctx.user_id, note="shortfall:wallet_paid",
             )
-        await _commit_rl(ctx, res, tokens=ranked_tokens)
+        await _commit_rl(ctx, res, tokens=0)
         out.wallet_usd = max(float(total_cost) - float(user_uncovered_usd), 0.0)
         out.project_absorption_usd = float(user_uncovered_usd)
-        out.quota_commit_tokens = ranked_tokens
+        out.quota_commit_tokens = 0
         out.wallet_consumed_tokens = max(int(ranked_tokens) - int(user_uncovered), 0)
         out.user_uncovered_tokens = int(user_uncovered)
         out.user_uncovered_usd = float(user_uncovered_usd)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
@@ -6,17 +6,20 @@
 Shared plan-lane funding reserve + settlement, extracted so a single
 implementation backs BOTH the chat run() path and the reusable EconomicsGuard.
 
-It mirrors BaseEntrypointWithEconomics.run()'s plan-lane money flow:
-  reserve:  size the primary (project|subscription) cover + reserve it, then
-            reserve wallet overflow for the remainder.
+It mirrors BaseEntrypointWithEconomics.run()'s money flow:
+  reserve_plan_funding:  plan lane — size the primary (project|subscription)
+            cover + reserve it, then reserve wallet overflow for the remainder.
+  reserve_paid_funding:  paid lane — reserve the subscription budget as primary
+            (active subscription), otherwise the wallet, with wallet fallback
+            when the subscription hold is declined.
   settle:   read fresh capacities, split the actual usage with
             allocate_plan_wallet_settlement (primary + wallet + project
             absorption), commit each source, and commit RL token quota.
 
 It deliberately contains NO event emission and NO UI insight — those are
-run()-specific concerns. reserve_plan_funding does NOT itself switch lanes: it
-returns a ReserveOutcome (OK / SWITCH_TO_PAID / DENIED) and the caller owns the
-paid-lane switch (release RL + re-admit paid + reserve wallet primary).
+run()-specific concerns. The reserve helpers do NOT switch lanes or emit denials:
+they return a ReserveOutcome (OK / SWITCH_TO_PAID / DENIED) and the caller owns
+the paid-lane switch and the denial it raises.
 
 Design: docs/economics/economic-enforcement-non-chat-v2-README.md (§4.1, §6)
 """
@@ -336,6 +339,107 @@ async def reserve_plan_funding(
                 est_turn_tokens=est_turn_tokens,
             )
 
+    return _ok(res)
+
+
+# ---------------------------------------------------------------------------
+# Paid-lane reservation (post-switch or direct paid lane)
+# ---------------------------------------------------------------------------
+async def reserve_paid_funding(
+    ctx: FundingContext,
+    *,
+    admit: Any,
+    est_turn_tokens: int,
+    has_active_subscription: bool,
+    has_wallet: bool,
+    wallet_can_pay_turn: bool,
+    ttl_sec: int = 900,
+) -> ReserveOutcome:
+    """
+    Paid-lane reservation: the subscription budget pays first (if the user has an
+    active subscription and a chargeable hold can be placed), otherwise the wallet
+    is the primary funding. Mirrors run()'s paid-lane reserve and the guard's
+    _reserve_paid_subscription + _reserve_wallet_or_deny(paid).
+
+    Non-raising: returns a ReserveOutcome (never SWITCH_TO_PAID — this IS the paid
+    lane).
+      - OK: reservation placed (paid_lane=True; use outcome.reservation).
+      - DENIED: cannot reserve subscription nor wallet. deny_code is canonical:
+          paid_no_personal_budget          -> no wallet to back the paid lane
+          paid_subscription_reservation_failed -> subscription hold declined and the
+                                               wallet cannot cover the turn either
+          paid_wallet_reservation_failed   -> wallet present but the hold was declined
+        Each caller remaps the kind onto its own denial vocabulary.
+    """
+    usd_per_token = ctx.usd_per_token
+
+    plan_reserved_tokens = int(getattr(admit, "reserved_tokens", 0) or 0)
+    plan_reservation_id = getattr(admit, "reservation_id", None)
+    plan_reservation_active = plan_reserved_tokens > 0 and plan_reservation_id is not None
+
+    res = PlanFundingReservation(
+        funding_source="wallet",
+        budget_bypass=False,
+        est_turn_tokens=int(est_turn_tokens),
+        plan_reservation_id=plan_reservation_id,
+        plan_reserved_tokens=plan_reserved_tokens,
+        plan_reservation_active=plan_reservation_active,
+        has_wallet=has_wallet,
+        paid_lane=True,
+    )
+
+    def _denied_paid(*, code: str) -> ReserveOutcome:
+        return ReserveOutcome(
+            status=ReserveStatus.DENIED, deny_code=code,
+            deny_message="Paid lane cannot reserve funds for this request.",
+            deny_data={
+                "reason": code, "funding_source": res.funding_source,
+                "min_tokens_required": int(est_turn_tokens), "lane": "paid",
+            },
+        )
+
+    # --- subscription primary --------------------------------------------
+    if has_active_subscription and ctx.subscription_limiter is not None:
+        app_reserved_usd = float(est_turn_tokens) * usd_per_token * SAFETY_MARGIN
+        if app_reserved_usd >= _MIN_RESERVE_USD:
+            app_reservation_id = uuid4()
+            try:
+                await ctx.subscription_limiter.reserve(
+                    bundle_id=ctx.bundle_id, amount_usd=float(app_reserved_usd),
+                    provider=None, request_id=ctx.scope_id, reservation_id=app_reservation_id,
+                    ttl_sec=int(ttl_sec), now=ctx.now,
+                    notes=f"paid reserve (subscription): scope={ctx.scope_id}, est_turn={est_turn_tokens}",
+                )
+                res.funding_source = "subscription"
+                res.app_reservation_id = app_reservation_id
+                res.app_reserved_usd = float(app_reserved_usd)
+                res.app_reservation_active = True
+                return _ok(res)
+            except (BudgetInsufficientFunds, ValueError) as e:
+                ctx.log("reserve.subscription", "paid subscription reserve declined; falling back to wallet",
+                        "WARN", error=str(e))
+                if not wallet_can_pay_turn:
+                    res.funding_source = "subscription"
+                    return _denied_paid(code="paid_subscription_reservation_failed")
+                # else: the wallet can cover the turn -> fall through to wallet primary
+
+    # --- wallet primary --------------------------------------------------
+    if not has_wallet:
+        return _denied_paid(code="paid_no_personal_budget")
+
+    ok = await ctx.cp_manager.user_credits_mgr.reserve_lifetime_tokens(
+        tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+        reservation_id=ctx.scope_id, tokens=int(est_turn_tokens),
+        ttl_sec=int(ttl_sec), bundle_id=ctx.bundle_id,
+        notes=f"paid reserve (wallet): scope={ctx.scope_id}, est_turn={est_turn_tokens}",
+    )
+    if not ok:
+        return _denied_paid(code="paid_wallet_reservation_failed")
+
+    res.funding_source = "wallet"
+    res.wallet_reservation_id = ctx.scope_id
+    res.wallet_reserved_tokens = int(est_turn_tokens)
+    res.wallet_reservation_active = True
     return _ok(res)
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
@@ -371,17 +371,25 @@ async def settle_plan_funding(
         # quota, but we record the request + tokens against RL (reservation-free).
         user_uncovered = 0
         remaining = int(ranked_tokens)
-        if remaining > 0 and res.wallet_reservation_active and res.wallet_reservation_id and res.wallet_reserved_tokens > 0:
-            reserved_target = min(remaining, int(res.wallet_reserved_tokens))
+        if res.wallet_reservation_active and res.wallet_reservation_id and res.wallet_reserved_tokens > 0:
+            reserved_target = min(int(remaining), int(res.wallet_reserved_tokens))
             try:
-                reserved_uncovered = await ctx.cp_manager.user_credits_mgr.commit_reserved_lifetime_tokens(
-                    tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
-                    reservation_id=str(res.wallet_reservation_id), tokens=int(reserved_target),
-                )
+                if reserved_target > 0:
+                    reserved_uncovered = await ctx.cp_manager.user_credits_mgr.commit_reserved_lifetime_tokens(
+                        tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+                        reservation_id=str(res.wallet_reservation_id), tokens=int(reserved_target),
+                    )
+                    reserved_consumed = max(int(reserved_target) - int(reserved_uncovered or 0), 0)
+                    remaining = max(remaining - reserved_consumed, 0)
+                else:
+                    # nothing consumed: commit_reserved_lifetime_tokens no-ops on tokens<=0
+                    # and would leave the hold 'reserved' until TTL -> release it explicitly.
+                    await ctx.cp_manager.user_credits_mgr.release_lifetime_token_reservation(
+                        tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+                        reservation_id=str(res.wallet_reservation_id), reason="zero actual cost",
+                    )
             finally:
                 res.wallet_reservation_active = False
-            reserved_consumed = max(int(reserved_target) - int(reserved_uncovered or 0), 0)
-            remaining = max(remaining - reserved_consumed, 0)
         if remaining > 0:
             user_uncovered = await ctx.cp_manager.user_credits_mgr.consume_lifetime_tokens(
                 tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id, tokens=int(remaining),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
@@ -13,9 +13,10 @@ It mirrors BaseEntrypointWithEconomics.run()'s plan-lane money flow:
             allocate_plan_wallet_settlement (primary + wallet + project
             absorption), commit each source, and commit RL token quota.
 
-It deliberately contains NO event emission, NO UI insight, and NO paid-lane
-switch — those are run()-specific concerns. Denials raise EconomicsLimitException
-(neutral) so both callers can translate them.
+It deliberately contains NO event emission and NO UI insight — those are
+run()-specific concerns. reserve_plan_funding does NOT itself switch lanes: it
+returns a ReserveOutcome (OK / SWITCH_TO_PAID / DENIED) and the caller owns the
+paid-lane switch (release RL + re-admit paid + reserve wallet primary).
 
 Design: docs/economics/economic-enforcement-non-chat-v2-README.md (§4.1, §6)
 """
@@ -24,6 +25,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Any, Callable, Optional
 from uuid import UUID, uuid4
 
@@ -107,6 +109,43 @@ class SettlementResult:
     extra_project_items: list = field(default_factory=list)
 
 
+class ReserveStatus(Enum):
+    OK = "ok"                          # reservation placed (plan lane); use .reservation
+    SWITCH_TO_PAID = "switch_to_paid"  # primary can't cover; caller re-plans as paid lane
+    DENIED = "denied"                  # cannot fund and cannot pay; caller denies
+
+
+@dataclass
+class ReserveOutcome:
+    """Non-raising result of reserve_plan_funding. The caller decides what to do:
+    OK -> proceed; SWITCH_TO_PAID -> release RL + re-admit paid + reserve wallet
+    primary; DENIED -> raise/emit the denial."""
+    status: ReserveStatus
+    reservation: Optional[PlanFundingReservation] = None
+    switch_reason: Optional[str] = None
+    deny_code: Optional[str] = None
+    deny_message: str = ""
+    deny_data: dict = field(default_factory=dict)
+
+
+def _ok(res: PlanFundingReservation) -> ReserveOutcome:
+    return ReserveOutcome(status=ReserveStatus.OK, reservation=res)
+
+
+def _switch(reason: str) -> ReserveOutcome:
+    return ReserveOutcome(status=ReserveStatus.SWITCH_TO_PAID, switch_reason=reason)
+
+
+def _denied(*, code: str, message: str, funding_source: str, est_turn_tokens: int) -> ReserveOutcome:
+    return ReserveOutcome(
+        status=ReserveStatus.DENIED, deny_code=code, deny_message=message,
+        deny_data={
+            "reason": code, "funding_source": funding_source,
+            "min_tokens_required": int(est_turn_tokens), "lane": "deny",
+        },
+    )
+
+
 def _cost_for_tokens(*, tokens: int, ranked_tokens: int, total_cost: float) -> float:
     if tokens <= 0 or ranked_tokens <= 0 or total_cost <= 0:
         return 0.0
@@ -134,12 +173,23 @@ async def reserve_plan_funding(
     subscription_available_usd: float,
     project_budget_snapshot: Optional[dict],
     personal_can_pay_turn: bool,
+    allow_paid_lane_fallback: bool = False,
     ttl_sec: int = 900,
-) -> PlanFundingReservation:
+) -> ReserveOutcome:
     """
     Plan-lane reservation: size the primary cover, reserve it, then reserve
-    wallet overflow. Mirrors run() (plan lane). Raises EconomicsLimitException
-    when the user cannot fund the request.
+    wallet overflow. Mirrors run() (plan lane).
+
+    Non-raising: returns a ReserveOutcome.
+      - OK: reservation placed (use outcome.reservation).
+      - SWITCH_TO_PAID: primary cannot cover and allow_paid_lane_fallback is set;
+        the caller releases RL + re-admits the paid policy + reserves wallet as
+        primary. Any partial primary money hold is released before returning.
+      - DENIED: the user cannot fund and cannot pay personally.
+
+    With allow_paid_lane_fallback=False (default, non-chat) the behavior matches
+    the previous version: a primary-exhausted user with a wallet covers the whole
+    request via wallet overflow WITHIN the plan lane (no lane switch).
     """
     usd_per_token = ctx.usd_per_token
     funding_limiter = ctx.subscription_limiter if funding_source == "subscription" else ctx.budget_limiter
@@ -184,13 +234,19 @@ async def reserve_plan_funding(
         if budget_bypass:
             pass  # admin: no money hold
         elif not personal_can_pay_turn:
-            _deny(
+            return _denied(
                 code="plan_exhausted_no_personal",
                 message="Plan funding exhausted and user cannot pay from personal credits.",
                 funding_source=funding_source,
                 est_turn_tokens=est_turn_tokens,
             )
-        # else: wallet covers the whole request via overflow below
+        elif allow_paid_lane_fallback:
+            # primary can't cover, but the user can pay -> caller switches to paid lane
+            return _switch(
+                "subscription_budget_zero_for_turn" if funding_source == "subscription"
+                else "plan_tokens_exhausted_for_turn"
+            )
+        # else: wallet covers the whole request via overflow below (plan lane)
     elif not budget_bypass:
         app_reserved_usd = float(plan_project_tokens_est) * usd_per_token * SAFETY_MARGIN
         app_reservation_id = uuid4()
@@ -213,13 +269,19 @@ async def reserve_plan_funding(
         except BudgetInsufficientFunds as e:
             ctx.log("reserve.app", "primary reservation denied", "WARN", error=str(e))
             if not personal_can_pay_turn:
-                _deny(
+                return _denied(
                     code=f"{funding_source}_budget_reservation_failed_no_personal",
                     message=f"{funding_source} funding cannot reserve and user cannot pay.",
                     funding_source=funding_source,
                     est_turn_tokens=est_turn_tokens,
                 )
-            # fall back to wallet-only for this request
+            if allow_paid_lane_fallback:
+                # primary reserve failed but the user can pay -> caller switches to paid lane
+                return _switch(
+                    "subscription_reservation_failed" if funding_source == "subscription"
+                    else "app_budget_reservation_failed"
+                )
+            # fall back to wallet-only for this request (plan lane, primary=0)
             plan_project_tokens_est = 0
 
     res.plan_project_tokens_est = int(plan_project_tokens_est)
@@ -248,7 +310,7 @@ async def reserve_plan_funding(
                     except Exception:
                         pass
                     res.app_reservation_active = False
-                _deny(
+                return _denied(
                     code="personal_reservation_failed_plan",
                     message="Insufficient personal credits to cover overflow.",
                     funding_source=funding_source,
@@ -259,27 +321,14 @@ async def reserve_plan_funding(
             res.wallet_reservation_active = True
         elif overflow_tokens_est > 0 and not has_wallet and plan_project_tokens_est <= 0 and not budget_bypass:
             # no primary cover and no wallet -> nothing can pay
-            _deny(
+            return _denied(
                 code="no_funding_source",
                 message="No plan, subscription, project, or wallet funding can cover this request.",
                 funding_source=funding_source,
                 est_turn_tokens=est_turn_tokens,
             )
 
-    return res
-
-
-def _deny(*, code: str, message: str, funding_source: str, est_turn_tokens: int) -> None:
-    raise EconomicsLimitException(
-        message,
-        code=code,
-        data={
-            "reason": code,
-            "funding_source": funding_source,
-            "min_tokens_required": int(est_turn_tokens),
-            "lane": "deny",
-        },
-    )
+    return _ok(res)
 
 
 # ---------------------------------------------------------------------------
@@ -310,6 +359,52 @@ async def settle_plan_funding(
             await ctx.budget_limiter.force_project_spend(
                 spent_usd=float(total_cost), bundle_id=ctx.bundle_id, provider=None,
                 request_id=ctx.scope_id, user_id=ctx.user_id, note="settle: admin bypass",
+            )
+        await _commit_rl(ctx, res, tokens=ranked_tokens)
+        out.primary_funding_usd = float(total_cost)
+        out.quota_commit_tokens = ranked_tokens
+        return out
+
+    if funding_source == "wallet":
+        # paid lane: wallet is the primary funding; project absorbs any uncovered
+        # shortfall (shortfall:wallet_paid). Wallet-paid tokens do NOT consume plan
+        # quota, but we record the request + tokens against RL (reservation-free).
+        user_uncovered = 0
+        remaining = int(ranked_tokens)
+        if remaining > 0 and res.wallet_reservation_active and res.wallet_reservation_id and res.wallet_reserved_tokens > 0:
+            reserved_target = min(remaining, int(res.wallet_reserved_tokens))
+            try:
+                reserved_uncovered = await ctx.cp_manager.user_credits_mgr.commit_reserved_lifetime_tokens(
+                    tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+                    reservation_id=str(res.wallet_reservation_id), tokens=int(reserved_target),
+                )
+            finally:
+                res.wallet_reservation_active = False
+            reserved_consumed = max(int(reserved_target) - int(reserved_uncovered or 0), 0)
+            remaining = max(remaining - reserved_consumed, 0)
+        if remaining > 0:
+            user_uncovered = await ctx.cp_manager.user_credits_mgr.consume_lifetime_tokens(
+                tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id, tokens=int(remaining),
+            )
+        user_uncovered = int(user_uncovered or 0)
+        user_uncovered_usd = _cost_for_tokens(tokens=user_uncovered, ranked_tokens=ranked_tokens, total_cost=total_cost)
+        if user_uncovered_usd > 0:
+            await ctx.budget_limiter.force_project_spend(
+                spent_usd=float(user_uncovered_usd), bundle_id=ctx.bundle_id, provider=None,
+                request_id=ctx.scope_id, user_id=ctx.user_id, note="shortfall:wallet_paid",
+            )
+        await _commit_rl(ctx, res, tokens=ranked_tokens)
+        out.wallet_usd = max(float(total_cost) - float(user_uncovered_usd), 0.0)
+        out.project_absorption_usd = float(user_uncovered_usd)
+        out.quota_commit_tokens = ranked_tokens
+        return out
+
+    if funding_source == "none":
+        # no funding source resolved -> charge the project as a last resort (audit)
+        if total_cost > 0:
+            await ctx.budget_limiter.force_project_spend(
+                spent_usd=float(total_cost), bundle_id=ctx.bundle_id, provider=None,
+                request_id=ctx.scope_id, user_id=ctx.user_id, note="settle: no_funding_source",
             )
         await _commit_rl(ctx, res, tokens=ranked_tokens)
         out.primary_funding_usd = float(total_cost)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/quota_lock.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/quota_lock.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# chat/sdk/infra/economics/quota_lock.py
+"""
+Distributed quota lock: serializes the admit->reserve window for a single subject
+so concurrent requests don't double-count a shared-pool reservation.
+
+Extracted so ONE implementation backs BOTH the chat run() path and the reusable
+EconomicsGuard. The redis mechanics (SET NX acquire with a px fallback, and the
+compare-and-del Lua release with a python fallback) plus the bounded spin-wait
+live here. Callers own the policy gating (enforce flag / admin bypass /
+redis-absent), the denial they raise on timeout, and their own log lines — those
+differ per surface and stay in the caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from typing import Any, Optional
+
+
+def quota_lock_key(tenant: str, project: str, user_id: str, scope: str, bundle_id: str) -> str:
+    """Per-subject, per-scope lock key (bundle_id is the global RL subject bundle)."""
+    return f"quota_lock:{tenant}:{project}:{user_id}:{scope}:{bundle_id}"
+
+
+class QuotaLock:
+    """A single-hold distributed lock. One instance per request/turn: it remembers
+    the key+token it took so release() only drops a lock WE still own (a release
+    after our TTL expired can't evict a successor)."""
+
+    def __init__(self, redis: Any):
+        self.redis = redis
+        self.key: Optional[str] = None
+        self.token: Optional[str] = None
+        self.acquired: bool = False
+
+    async def acquire_blocking(self, key: str, *, ttl_sec: int, wait_total_sec: float) -> bool:
+        """Spin-wait up to wait_total_sec to take `key`. Returns True if acquired,
+        False on timeout. Precondition: redis is present (callers gate on
+        redis-absent / policy / bypass and skip calling this)."""
+        self.key = key
+        self.token = secrets.token_hex(16)
+        t0 = asyncio.get_event_loop().time()
+        sleep = 0.05
+        while True:
+            if await self._try_acquire(self.key, self.token, ttl_sec):
+                self.acquired = True
+                return True
+            if (asyncio.get_event_loop().time() - t0) >= wait_total_sec:
+                return False
+            await asyncio.sleep(sleep)
+            sleep = min(sleep * 1.5, 0.25)
+
+    async def release_if_held(self) -> bool:
+        """Release the lock if we still hold it. Returns True if a release was
+        issued (so the caller can log it), False otherwise. Always clears state."""
+        held = bool(self.acquired and self.key and self.token)
+        if held:
+            await self._release(self.key, self.token)
+        self.key = None
+        self.token = None
+        self.acquired = False
+        return held
+
+    # -- redis mechanics ------------------------------------------------------
+    async def _try_acquire(self, key: str, token: str, ttl_sec: int) -> bool:
+        r = self.redis
+        if r is None:
+            return False
+        try:
+            return bool(await r.set(key, token, nx=True, ex=ttl_sec))
+        except TypeError:
+            pass
+        except Exception:
+            return False
+        try:
+            return bool(await r.set(key, token, nx=True, px=int(ttl_sec * 1000)))
+        except Exception:
+            return False
+
+    async def _release(self, key: str, token: str) -> None:
+        r = self.redis
+        if r is None:
+            return
+        # compare-and-del: only release if WE still hold it (token match).
+        lua = (
+            "if redis.call('get', KEYS[1]) == ARGV[1] then "
+            "return redis.call('del', KEYS[1]) else return 0 end"
+        )
+        try:
+            await r.eval(lua, 1, key, token)
+            return
+        except TypeError:
+            try:
+                await r.eval(lua, keys=[key], args=[token])
+                return
+            except Exception:
+                pass
+        except Exception:
+            pass
+        try:
+            cur = await r.get(key)
+            if cur is None:
+                return
+            if isinstance(cur, (bytes, bytearray)):
+                cur = cur.decode("utf-8", errors="ignore")
+            if str(cur) == str(token):
+                await r.delete(key)
+        except Exception:
+            pass

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
@@ -494,6 +494,8 @@ async def test_paid_lane_switch_when_primary_exhausted_and_fallback_allowed():
     await g.__aexit__(None, None, None)
     assert len(ep.cp_manager.user_credits_mgr.committed) == 1  # wallet committed at settle
     assert len(ep.rl.commits) == 1
+    # paid lane consumes 0 plan token quota (wallet pays at payasyougo)
+    assert int(ep.rl.commits[-1].get("tokens") or 0) == 0
 
 
 async def test_paid_lane_wallet_zero_cost_releases_reservation():
@@ -600,6 +602,8 @@ async def test_paid_lane_switch_subscription_primary():
     assert len(sub_limiter.committed) == 1                      # subscription spend committed
     assert sub_limiter.committed[0]["spent_usd"] == 0.02
     assert ep.cp_manager.user_credits_mgr.committed == []       # wallet never charged
+    # paid lane consumes 0 plan token quota (subscription pays at payasyougo)
+    assert int(ep.rl.commits[-1].get("tokens") or 0) == 0
 
 
 async def test_paid_lane_subscription_zero_cost_releases_hold():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
@@ -410,6 +410,54 @@ async def test_top_level_project_lifecycle_reserves_and_settles():
     assert enf.active_econ_scope() is None
 
 
+async def test_paid_lane_switch_when_primary_exhausted_and_fallback_allowed():
+    # registered + wallet, project exhausted (overdraft 0 / available 0):
+    # allow_paid_lane_fallback -> switch plan->paid, reserve wallet, settle wallet.
+    class _ZeroBudget(_Budget):
+        async def get_app_budget_balance(self):
+            return {"available_usd": 0.0, "overdraft_limit_usd": 0.0}
+
+    cp = _CP(wallet=1_000_000, plan_balance=_PlanBalance(wallet=True))
+    ep = _EP(cp=cp, rl=_RL(), budget=_ZeroBudget(), accounting_result=(1000, {"cost_total_usd": 0.02}))
+    g = EconomicsGuard(
+        ep, subject=_subject("registered"), scope_id="sw1", flow="f",
+        estimate=EconomicsEstimate(reservation_usd=0.05),
+        policy=FlowPolicy(allow_paid_lane_fallback=True),
+    )
+    decision = await g.__aenter__()
+    assert decision.lane == "paid"
+    assert decision.funding_source == "wallet"
+    assert decision.wallet_reservation_id == "sw1"
+    assert len(ep.cp_manager.user_credits_mgr.reserved) == 1   # wallet reserved as primary
+    assert ep.budget_limiter.reserved == []                    # no project hold taken
+    assert any(kind == "tok" for kind, _ in ep.rl.releases)    # plan RL reservation released
+    assert len(ep.rl.admit_calls) == 2                         # plan admit + paid re-admit
+
+    await g.__aexit__(None, None, None)
+    assert len(ep.cp_manager.user_credits_mgr.committed) == 1  # wallet committed at settle
+    assert len(ep.rl.commits) == 1
+
+
+async def test_no_paid_switch_when_fallback_disabled_denies():
+    # same setup, but allow_paid_lane_fallback=False (default non-chat) -> deny.
+    class _ZeroBudget(_Budget):
+        async def get_app_budget_balance(self):
+            return {"available_usd": 0.0, "overdraft_limit_usd": 0.0}
+
+    cp = _CP(wallet=1_000_000, plan_balance=_PlanBalance(wallet=True))
+    ep = _EP(cp=cp, rl=_RL(), budget=_ZeroBudget())
+    g = EconomicsGuard(
+        ep, subject=_subject("registered"), scope_id="sw2", flow="f",
+        estimate=EconomicsEstimate(reservation_usd=0.05),
+        policy=FlowPolicy(allow_paid_lane_fallback=False),
+    )
+    # primary exhausted but wallet can pay -> stays plan lane, wallet covers overflow (no switch, no deny)
+    decision = await g.__aenter__()
+    assert decision.lane == "plan"
+    assert len(ep.rl.admit_calls) == 1                         # no paid re-admit
+    await g.__aexit__(None, None, None)
+
+
 async def test_top_level_releases_reservation_on_accounting_failure():
     class _BadEP(_EP):
         async def run_accounting(self, **kw):

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
@@ -676,7 +676,7 @@ async def test_quota_lock_acquired_then_released_on_success():
     assert any(c["nx"] for c in ep.redis.set_calls)
     # ...and released as soon as holds were reserved (not held across the body)
     assert ep.redis.store == {}
-    assert g._quota_lock_acquired is False
+    assert g._quota_lock.acquired is False
     await g.__aexit__(None, None, None)
     assert ep.redis.store == {}
 
@@ -710,7 +710,7 @@ async def test_quota_lock_released_on_deny():
     with pytest.raises(EconomicsLimitException):
         await g.__aenter__()
     assert ep.redis.store == {}
-    assert g._quota_lock_acquired is False
+    assert g._quota_lock.acquired is False
 
 
 async def test_quota_lock_skipped_for_bypass():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
@@ -89,6 +89,33 @@ class _SubMgr:
         return self.sub
 
 
+class _SubLimiter:
+    """Fake SubscriptionBudgetLimiter (paid-lane primary). Inject via
+    guard._subscription_limiter before __aenter__."""
+    def __init__(self, reserve_ok: bool = True, available_usd: float = 100.0):
+        self.reserve_ok = reserve_ok
+        self.available_usd = available_usd
+        self.reserved = []
+        self.committed = []
+        self.released = []
+
+    async def reserve(self, **kw):
+        self.reserved.append(kw)
+        if not self.reserve_ok:
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.project_budget import BudgetInsufficientFunds
+            raise BudgetInsufficientFunds("subscription budget exhausted")
+        return type("RR", (), {"reservation_id": kw.get("reservation_id")})()
+
+    async def commit_reserved_spend(self, **kw):
+        self.committed.append(kw)
+
+    async def release_reservation(self, **kw):
+        self.released.append(kw)
+
+    async def get_subscription_budget_balance(self):
+        return {"available_usd": self.available_usd}
+
+
 class _CP:
     def __init__(self, *, plan_balance=None, sub=None, wallet=0, policy=None):
         self._plan_balance = plan_balance or _PlanBalance(wallet=bool(wallet))
@@ -547,6 +574,72 @@ async def test_admit_rate_limit_denies_without_wallet_even_if_fallback_allowed()
         await g.__aenter__()
     assert ei.value.code == "rate_limited"
     assert len(ep.rl.admit_calls) == 1                         # no paid re-admit
+
+
+async def test_paid_lane_switch_subscription_primary():
+    # active-subscription user (with a wallet so the admit-denied switch is allowed),
+    # plan admit rate-limited -> switch to paid; the SUBSCRIPTION pays, wallet untouched.
+    cp = _CP(sub=_Sub(active=True), wallet=1_000_000, plan_balance=_PlanBalance(wallet=True))
+    ep = _EP(cp=cp, rl=_RL(deny_first=True), budget=_Budget(),
+             accounting_result=(1000, {"cost_total_usd": 0.02}))
+    sub_limiter = _SubLimiter()
+    g = EconomicsGuard(
+        ep, subject=_subject("paid"), scope_id="ps1", flow="f",
+        estimate=EconomicsEstimate(reservation_usd=0.05),
+        policy=FlowPolicy(allow_paid_lane_fallback=True),
+    )
+    g._subscription_limiter = sub_limiter                       # inject the fake paid-lane limiter
+    decision = await g.__aenter__()
+    assert decision.lane == "paid"
+    assert decision.funding_source == "subscription"
+    assert len(sub_limiter.reserved) == 1                       # subscription reserved as primary
+    assert ep.cp_manager.user_credits_mgr.reserved == []        # wallet untouched
+    assert len(ep.rl.admit_calls) == 2                          # plan deny + paid re-admit
+
+    await g.__aexit__(None, None, None)
+    assert len(sub_limiter.committed) == 1                      # subscription spend committed
+    assert sub_limiter.committed[0]["spent_usd"] == 0.02
+    assert ep.cp_manager.user_credits_mgr.committed == []       # wallet never charged
+
+
+async def test_paid_lane_subscription_zero_cost_releases_hold():
+    # paid subscription lane, zero actual cost -> release the subscription hold.
+    cp = _CP(sub=_Sub(active=True), wallet=1_000_000, plan_balance=_PlanBalance(wallet=True))
+    ep = _EP(cp=cp, rl=_RL(deny_first=True), budget=_Budget(),
+             accounting_result=(0, {"cost_total_usd": 0.0}))
+    sub_limiter = _SubLimiter()
+    g = EconomicsGuard(
+        ep, subject=_subject("paid"), scope_id="ps2", flow="f",
+        estimate=EconomicsEstimate(reservation_usd=0.05),
+        policy=FlowPolicy(allow_paid_lane_fallback=True),
+    )
+    g._subscription_limiter = sub_limiter
+    await g.__aenter__()
+    await g.__aexit__(None, None, None)
+    assert sub_limiter.committed == []
+    assert len(sub_limiter.released) == 1                       # zero-cost hold released
+
+
+async def test_paid_lane_subscription_falls_back_to_wallet():
+    # active subscription but its budget cannot reserve -> fall back to wallet-primary.
+    cp = _CP(sub=_Sub(active=True), wallet=1_000_000, plan_balance=_PlanBalance(wallet=True))
+    ep = _EP(cp=cp, rl=_RL(deny_first=True), budget=_Budget(),
+             accounting_result=(1000, {"cost_total_usd": 0.02}))
+    sub_limiter = _SubLimiter(reserve_ok=False)                 # subscription reserve declines
+    g = EconomicsGuard(
+        ep, subject=_subject("paid"), scope_id="ps3", flow="f",
+        estimate=EconomicsEstimate(reservation_usd=0.05),
+        policy=FlowPolicy(allow_paid_lane_fallback=True),
+    )
+    g._subscription_limiter = sub_limiter
+    decision = await g.__aenter__()
+    assert decision.lane == "paid"
+    assert decision.funding_source == "wallet"                 # fell back to wallet
+    assert len(sub_limiter.reserved) == 1                      # tried subscription first
+    assert sub_limiter.committed == []
+    assert len(ep.cp_manager.user_credits_mgr.reserved) == 1   # wallet reserved as primary
+    await g.__aexit__(None, None, None)
+    assert len(ep.cp_manager.user_credits_mgr.committed) == 1
 
 
 async def test_top_level_releases_reservation_on_accounting_failure():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
@@ -104,23 +104,26 @@ class _CP:
 
 
 class _RL:
-    def __init__(self, allowed: bool = True, reason=None):
+    def __init__(self, allowed: bool = True, reason=None, deny_first: bool = False):
         self.allowed = allowed
         self.reason = reason
+        self.deny_first = deny_first   # deny the 1st admit, allow the rest (plan-admit rate-limit -> switch)
         self.admit_calls = []
         self.commits = []
         self.releases = []
 
     async def admit(self, **kw):
+        first = not self.admit_calls
         self.admit_calls.append(kw)
+        allowed = self.allowed and not (self.deny_first and first)
         reserve = int(kw.get("reserve_tokens") or 0)
         return AdmitResult(
-            allowed=self.allowed,
-            reason=None if self.allowed else (self.reason or "tokens_per_month"),
-            lock_id=kw.get("lock_id") if self.allowed else None,
+            allowed=allowed,
+            reason=None if allowed else (self.reason or "tokens_per_month"),
+            lock_id=kw.get("lock_id") if allowed else None,
             snapshot={"tok_month": 0, "req_day": 0},
-            reserved_tokens=reserve if self.allowed else 0,
-            reservation_id=(kw.get("reservation_id") if (self.allowed and reserve > 0) else None),
+            reserved_tokens=reserve if allowed else 0,
+            reservation_id=(kw.get("reservation_id") if (allowed and reserve > 0) else None),
         )
 
     async def commit_with_reservation(self, **kw):
@@ -160,6 +163,34 @@ class _Budget:
 
     async def force_project_spend(self, **kw):
         self.forced.append(kw)
+
+
+class _FakeRedis:
+    """Minimal async Redis supporting SET NX EX, GET, DELETE, and the Lua
+    compare-and-del used by the quota lock."""
+    def __init__(self):
+        self.store = {}
+        self.set_calls = []
+
+    async def set(self, key, val, nx=False, ex=None, px=None):
+        self.set_calls.append({"key": key, "nx": nx, "ex": ex, "px": px})
+        if nx and key in self.store:
+            return None
+        self.store[key] = val
+        return True
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def delete(self, key):
+        self.store.pop(key, None)
+        return 1
+
+    async def eval(self, lua, numkeys, key, token):
+        if self.store.get(key) == token:
+            self.store.pop(key, None)
+            return 1
+        return 0
 
 
 class _Spec:
@@ -438,6 +469,29 @@ async def test_paid_lane_switch_when_primary_exhausted_and_fallback_allowed():
     assert len(ep.rl.commits) == 1
 
 
+async def test_paid_lane_wallet_zero_cost_releases_reservation():
+    # paid lane (switch), but the actual cost settles to 0 (e.g. free-tier provider).
+    # commit_reserved_lifetime_tokens no-ops on tokens<=0, so the hold must be
+    # RELEASED explicitly — otherwise the wallet stays debited until TTL.
+    class _ZeroBudget(_Budget):
+        async def get_app_budget_balance(self):
+            return {"available_usd": 0.0, "overdraft_limit_usd": 0.0}
+
+    cp = _CP(wallet=1_000_000, plan_balance=_PlanBalance(wallet=True))
+    ep = _EP(cp=cp, rl=_RL(), budget=_ZeroBudget(), accounting_result=(0, {"cost_total_usd": 0.0}))
+    g = EconomicsGuard(
+        ep, subject=_subject("registered"), scope_id="z1", flow="f",
+        estimate=EconomicsEstimate(reservation_usd=0.05),
+        policy=FlowPolicy(allow_paid_lane_fallback=True),
+    )
+    await g.__aenter__()
+    assert len(ep.cp_manager.user_credits_mgr.reserved) == 1
+    await g.__aexit__(None, None, None)
+    # zero actual cost -> reservation released, NOT committed
+    assert len(ep.cp_manager.user_credits_mgr.released) == 1
+    assert ep.cp_manager.user_credits_mgr.committed == []
+
+
 async def test_no_paid_switch_when_fallback_disabled_denies():
     # same setup, but allow_paid_lane_fallback=False (default non-chat) -> deny.
     class _ZeroBudget(_Budget):
@@ -458,6 +512,43 @@ async def test_no_paid_switch_when_fallback_disabled_denies():
     await g.__aexit__(None, None, None)
 
 
+async def test_paid_lane_switch_on_admit_rate_limit_when_fallback_allowed():
+    # plan admit is rate-limited, but the user has a wallet + fallback is allowed:
+    # switch to the paid lane (re-admit paid policy + reserve wallet), DO NOT deny.
+    cp = _CP(wallet=1_000_000, plan_balance=_PlanBalance(wallet=True))
+    ep = _EP(cp=cp, rl=_RL(deny_first=True), budget=_Budget(),
+             accounting_result=(1000, {"cost_total_usd": 0.02}))
+    g = EconomicsGuard(
+        ep, subject=_subject("registered"), scope_id="sw3", flow="f",
+        estimate=EconomicsEstimate(reservation_usd=0.05),
+        policy=FlowPolicy(allow_paid_lane_fallback=True),
+    )
+    decision = await g.__aenter__()
+    assert decision.lane == "paid"
+    assert decision.funding_source == "wallet"
+    assert decision.wallet_reservation_id == "sw3"
+    assert len(ep.cp_manager.user_credits_mgr.reserved) == 1   # wallet reserved as primary
+    assert ep.budget_limiter.reserved == []                    # plan funding never reserved
+    assert len(ep.rl.admit_calls) == 2                         # denied plan admit + paid re-admit
+    await g.__aexit__(None, None, None)
+    assert len(ep.cp_manager.user_credits_mgr.committed) == 1  # wallet committed at settle
+
+
+async def test_admit_rate_limit_denies_without_wallet_even_if_fallback_allowed():
+    # plan admit rate-limited, fallback allowed, but NO wallet -> deny (nothing to switch to).
+    cp = _CP(plan_balance=_PlanBalance(False))
+    ep = _EP(cp=cp, rl=_RL(deny_first=True), budget=_Budget())
+    g = EconomicsGuard(
+        ep, subject=_subject("registered"), scope_id="sw4", flow="f",
+        estimate=EconomicsEstimate(reservation_usd=0.05),
+        policy=FlowPolicy(allow_paid_lane_fallback=True),
+    )
+    with pytest.raises(EconomicsLimitException) as ei:
+        await g.__aenter__()
+    assert ei.value.code == "rate_limited"
+    assert len(ep.rl.admit_calls) == 1                         # no paid re-admit
+
+
 async def test_top_level_releases_reservation_on_accounting_failure():
     class _BadEP(_EP):
         async def run_accounting(self, **kw):
@@ -472,3 +563,78 @@ async def test_top_level_releases_reservation_on_accounting_failure():
     # settlement failed -> reservation released, accounting unbound
     assert len(ep.budget_limiter.released) == 1
     assert enf.active_econ_scope() is None
+
+
+# --------------------------------------------------------------------------
+# Quota lock (distributed admit->reserve serialization)
+# --------------------------------------------------------------------------
+async def test_quota_lock_acquired_then_released_on_success():
+    ep = _ep(accounting=(1000, {"cost_total_usd": 0.03}))
+    ep.redis = _FakeRedis()
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="ql1", flow="memory.reconciler",
+                       estimate=EconomicsEstimate(reservation_usd=0.05),
+                       policy=FlowPolicy(enforce_quota_lock=True))
+    await g.__aenter__()
+    # lock was taken with SET NX during the planning window...
+    assert any(c["nx"] for c in ep.redis.set_calls)
+    # ...and released as soon as holds were reserved (not held across the body)
+    assert ep.redis.store == {}
+    assert g._quota_lock_acquired is False
+    await g.__aexit__(None, None, None)
+    assert ep.redis.store == {}
+
+
+async def test_quota_lock_timeout_denies_when_contended():
+    ep = _ep()
+    ep.redis = _FakeRedis()
+    s = _subject("registered")
+    # another holder already owns the lock key for this user/scope/bundle
+    from kdcube_ai_app.apps.chat.sdk.infra.economics.limiter import GLOBAL_BUNDLE_ID
+    key = f"quota_lock:{s.tenant}:{s.project}:{s.user_id}:month:{GLOBAL_BUNDLE_ID}"
+    ep.redis.store[key] = "someone-else"
+    g = EconomicsGuard(ep, subject=s, scope_id="ql2", flow="memory.reconciler",
+                       estimate=EconomicsEstimate(reservation_usd=0.05),
+                       policy=FlowPolicy(enforce_quota_lock=True, quota_lock_wait_sec=0.2))
+    with pytest.raises(EconomicsLimitException) as ei:
+        await g.__aenter__()
+    assert ei.value.code == "quota_lock_timeout"
+    # contended -> we never admitted/reserved, and the other holder's key is intact
+    assert ep.rl.admit_calls == []
+    assert ep.redis.store.get(key) == "someone-else"
+
+
+async def test_quota_lock_released_on_deny():
+    # rate-limited deny inside the lock window must still release the lock.
+    ep = _ep(allowed=False, reason="tokens_per_month")
+    ep.redis = _FakeRedis()
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="ql3", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05),
+                       policy=FlowPolicy(enforce_quota_lock=True))
+    with pytest.raises(EconomicsLimitException):
+        await g.__aenter__()
+    assert ep.redis.store == {}
+    assert g._quota_lock_acquired is False
+
+
+async def test_quota_lock_skipped_for_bypass():
+    # admin/privileged bypass has no shared-pool reserve window -> no lock attempt.
+    ep = _ep()
+    ep.redis = _FakeRedis()
+    g = EconomicsGuard(ep, subject=_subject("privileged"), scope_id="ql4", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05),
+                       policy=FlowPolicy(enforce_quota_lock=True))
+    await g.__aenter__()
+    assert ep.redis.set_calls == []
+    await g.__aexit__(None, None, None)
+
+
+async def test_quota_lock_noop_without_redis():
+    # enforce_quota_lock=True but no redis on the entrypoint -> degrade to no lock.
+    ep = _ep(accounting=(1000, {"cost_total_usd": 0.03}))
+    assert getattr(ep, "redis", None) is None
+    g = EconomicsGuard(ep, subject=_subject("registered"), scope_id="ql5", flow="f",
+                       estimate=EconomicsEstimate(reservation_usd=0.05),
+                       policy=FlowPolicy(enforce_quota_lock=True))
+    decision = await g.__aenter__()
+    assert decision.funding_source == "project"
+    await g.__aexit__(None, None, None)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
@@ -226,6 +226,9 @@ async def test_settle_wallet_primary_paid_lane():
     assert credits.committed[0]["tokens"] == 1500
     assert ctx.budget_limiter.forced == []             # no shortfall (fully covered)
     assert len(ctx.rl.commits) == 1                    # RL recorded (reservation-free)
+    # paid lane consumes 0 plan token quota (wallet pays) -> RL commits 0 tokens
+    assert int(ctx.rl.commits[0].get("tokens") or 0) == 0
+    assert out.quota_commit_tokens == 0
     assert out.wallet_usd == pytest.approx(0.015, rel=1e-6)
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
@@ -115,6 +115,13 @@ class _CP:
         self.user_credits_mgr = credits
 
 
+async def _resv(*a, **k):
+    """reserve and unwrap the PlanFundingReservation (asserts an OK outcome)."""
+    out = await ff.reserve_plan_funding(*a, **k)
+    assert out.status is ff.ReserveStatus.OK, f"expected OK, got {out.status}"
+    return out.reservation
+
+
 def _ctx(*, rl=None, budget=None, sub=None, credits=None):
     credits = credits or _Credits()
     return ff.FundingContext(
@@ -133,7 +140,7 @@ def _ctx(*, rl=None, budget=None, sub=None, credits=None):
 # --------------------------------------------------------------------------
 async def test_reserve_project_unlimited_covers_full_no_wallet():
     ctx = _ctx(budget=_Budget(overdraft=None))
-    res = await ff.reserve_plan_funding(
+    res = await _resv(
         ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=False,
         est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
         project_budget_snapshot={"overdraft_limit_usd": None, "available_usd": 0.0},
@@ -149,7 +156,7 @@ async def test_reserve_project_finite_overdraft_reserves_wallet_overflow():
     # available+overdraft = $0.05 -> ~4347 tokens primary (well above the $0.01
     # min-reserve floor); the remaining ~5653 overflow to wallet.
     ctx = _ctx(budget=_Budget(overdraft=0.0))
-    res = await ff.reserve_plan_funding(
+    res = await _resv(
         ctx, admit=_Admit(reserved=10000), funding_source="project", budget_bypass=False,
         est_turn_tokens=10000, has_wallet=True, subscription_available_usd=0.0,
         project_budget_snapshot={"overdraft_limit_usd": 0.0, "available_usd": 0.05},
@@ -164,7 +171,7 @@ async def test_reserve_project_finite_overdraft_reserves_wallet_overflow():
 async def test_reserve_subscription_with_wallet_overflow():
     sub = _SubBudget(available_usd=0.05)
     ctx = _ctx(sub=sub)
-    res = await ff.reserve_plan_funding(
+    res = await _resv(
         ctx, admit=_Admit(reserved=10000), funding_source="subscription", budget_bypass=False,
         est_turn_tokens=10000, has_wallet=True, subscription_available_usd=0.05,
         project_budget_snapshot=None, personal_can_pay_turn=True,
@@ -176,19 +183,69 @@ async def test_reserve_subscription_with_wallet_overflow():
 
 async def test_reserve_denies_when_primary_fails_and_no_wallet():
     ctx = _ctx(budget=_Budget(overdraft=0.0, reserve_fail=True))
-    with pytest.raises(EconomicsLimitException) as ei:
-        await ff.reserve_plan_funding(
-            ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=False,
-            est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
-            project_budget_snapshot={"overdraft_limit_usd": 0.0, "available_usd": 1000.0},
-            personal_can_pay_turn=False,
-        )
-    assert "reservation_failed" in ei.value.code or ei.value.code == "no_funding_source"
+    out = await ff.reserve_plan_funding(
+        ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=False,
+        est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
+        project_budget_snapshot={"overdraft_limit_usd": 0.0, "available_usd": 1000.0},
+        personal_can_pay_turn=False,
+    )
+    assert out.status is ff.ReserveStatus.DENIED
+    assert "reservation_failed" in out.deny_code or out.deny_code == "no_funding_source"
+
+
+async def test_reserve_switches_to_paid_when_primary_fails_and_fallback_allowed():
+    # primary reserve fails, user can pay, allow_paid_lane_fallback -> SWITCH_TO_PAID
+    ctx = _ctx(budget=_Budget(overdraft=0.0, reserve_fail=True))
+    out = await ff.reserve_plan_funding(
+        ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=False,
+        est_turn_tokens=2000, has_wallet=True, subscription_available_usd=0.0,
+        project_budget_snapshot={"overdraft_limit_usd": 0.0, "available_usd": 1000.0},
+        personal_can_pay_turn=True, allow_paid_lane_fallback=True,
+    )
+    assert out.status is ff.ReserveStatus.SWITCH_TO_PAID
+    assert out.switch_reason == "app_budget_reservation_failed"
+    assert ctx.budget_limiter.reserved == []   # no primary hold left
+    assert ctx.cp_manager.user_credits_mgr.reserved == []  # no wallet hold (caller does it)
+
+
+async def test_settle_wallet_primary_paid_lane():
+    # funding_source="wallet" -> wallet pays everything; project absorbs uncovered.
+    credits = _Credits(consume_uncovered=0)
+    ctx = _ctx(credits=credits)
+    res = ff.PlanFundingReservation(
+        funding_source="wallet", budget_bypass=False, est_turn_tokens=2000,
+        wallet_reservation_id="scope-1", wallet_reserved_tokens=2000, wallet_reservation_active=True,
+        has_wallet=True,
+    )
+    out = await ff.settle_plan_funding(
+        ctx, res, ranked_tokens=1500, total_cost_usd=0.015,
+        effective_policy=QuotaPolicy(tokens_per_month=10**9),
+        plan_has_lifetime_budget=True, user_budget_tokens=10**9,
+    )
+    assert len(credits.committed) == 1                 # wallet reservation committed
+    assert credits.committed[0]["tokens"] == 1500
+    assert ctx.budget_limiter.forced == []             # no shortfall (fully covered)
+    assert len(ctx.rl.commits) == 1                    # RL recorded (reservation-free)
+    assert out.wallet_usd == pytest.approx(0.015, rel=1e-6)
+
+
+async def test_settle_none_charges_project_last_resort():
+    ctx = _ctx()
+    res = ff.PlanFundingReservation(funding_source="none", budget_bypass=False, est_turn_tokens=2000)
+    out = await ff.settle_plan_funding(
+        ctx, res, ranked_tokens=1000, total_cost_usd=0.02,
+        effective_policy=QuotaPolicy(tokens_per_month=10**9),
+        plan_has_lifetime_budget=False, user_budget_tokens=None,
+    )
+    assert len(ctx.budget_limiter.forced) == 1
+    assert ctx.budget_limiter.forced[0]["spent_usd"] == pytest.approx(0.02, rel=1e-6)
+    assert "no_funding_source" in ctx.budget_limiter.forced[0]["note"]
+    assert out.quota_commit_tokens == 1000
 
 
 async def test_reserve_bypass_takes_no_money_hold():
     ctx = _ctx()
-    res = await ff.reserve_plan_funding(
+    res = await _resv(
         ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=True,
         est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
         project_budget_snapshot={"overdraft_limit_usd": None, "available_usd": 0.0},
@@ -203,7 +260,7 @@ async def test_reserve_bypass_takes_no_money_hold():
 # --------------------------------------------------------------------------
 async def test_settle_project_commits_reservation_and_rl():
     ctx = _ctx(budget=_Budget(overdraft=None, available_usd=1000.0))
-    res = await ff.reserve_plan_funding(
+    res = await _resv(
         ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=False,
         est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
         project_budget_snapshot={"overdraft_limit_usd": None, "available_usd": 1000.0},
@@ -223,7 +280,7 @@ async def test_settle_project_commits_reservation_and_rl():
 
 async def test_settle_bypass_forces_project_and_commits_rl():
     ctx = _ctx()
-    res = await ff.reserve_plan_funding(
+    res = await _resv(
         ctx, admit=_Admit(reserved=2000), funding_source="project", budget_bypass=True,
         est_turn_tokens=2000, has_wallet=False, subscription_available_usd=0.0,
         project_budget_snapshot={"overdraft_limit_usd": None, "available_usd": 0.0},
@@ -246,7 +303,7 @@ async def test_settle_wallet_shortfall_absorbed_by_project():
     credits = _Credits(balance=10**9, commit_uncovered=0, consume_uncovered=0)
     budget = _Budget(overdraft=0.0, available_usd=0.05)
     ctx = _ctx(budget=budget, credits=credits)
-    res = await ff.reserve_plan_funding(
+    res = await _resv(
         ctx, admit=_Admit(reserved=10000), funding_source="project", budget_bypass=False,
         est_turn_tokens=10000, has_wallet=True, subscription_available_usd=0.0,
         project_budget_snapshot={"overdraft_limit_usd": 0.0, "available_usd": 0.05},

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
@@ -341,3 +341,34 @@ async def test_settle_wallet_shortfall_absorbed_by_project():
     assert len(budget.committed) == 1
     assert out.allocation is not None
     assert out.allocation.wallet_tokens > 0
+    # wallet fully covered its target -> nothing uncovered; consumed == target
+    assert out.user_uncovered_tokens == 0
+    assert out.user_uncovered_usd == 0.0
+    assert out.wallet_consumed_tokens == int(out.allocation.wallet_tokens)
+
+
+async def test_settle_exposes_wallet_uncovered_intermediates():
+    # wallet can't fully cover its target -> the result exposes wallet_consumed /
+    # user_uncovered (tokens + usd) for the caller's underfunded event. commit_uncovered
+    # leaves a reservation-free remainder that consume_lifetime_tokens reports uncovered.
+    credits = _Credits(balance=10**9, commit_uncovered=2000, consume_uncovered=2000)
+    budget = _Budget(overdraft=0.0, available_usd=0.05)
+    ctx = _ctx(budget=budget, credits=credits)
+    res = await _resv(
+        ctx, admit=_Admit(reserved=10000), funding_source="project", budget_bypass=False,
+        est_turn_tokens=10000, has_wallet=True, subscription_available_usd=0.0,
+        project_budget_snapshot={"overdraft_limit_usd": 0.0, "available_usd": 0.05},
+        personal_can_pay_turn=True,
+    )
+    out = await ff.settle_plan_funding(
+        ctx, res, ranked_tokens=10000, total_cost_usd=0.10,
+        effective_policy=QuotaPolicy(tokens_per_month=10**9),
+        plan_has_lifetime_budget=True, user_budget_tokens=10**9,
+    )
+    target = int(out.allocation.wallet_tokens)
+    assert target >= 2000
+    assert out.user_uncovered_tokens == 2000
+    assert out.wallet_consumed_tokens == target - 2000
+    # invariant: consumed + uncovered == wallet target
+    assert out.wallet_consumed_tokens + out.user_uncovered_tokens == target
+    assert out.user_uncovered_usd == pytest.approx(out.total_cost_usd * 2000 / out.ranked_tokens, rel=1e-6)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
@@ -208,6 +208,106 @@ async def test_reserve_switches_to_paid_when_primary_fails_and_fallback_allowed(
     assert ctx.cp_manager.user_credits_mgr.reserved == []  # no wallet hold (caller does it)
 
 
+# --------------------------------------------------------------------------
+# Paid-lane reserve
+# --------------------------------------------------------------------------
+async def test_reserve_paid_subscription_primary():
+    # active subscription -> subscription budget is the paid-lane primary; wallet untouched.
+    sub = _SubBudget(available_usd=100.0)
+    ctx = _ctx(sub=sub)
+    out = await ff.reserve_paid_funding(
+        ctx, admit=_Admit(reserved=2000), est_turn_tokens=2000,
+        has_active_subscription=True, has_wallet=True, wallet_can_pay_turn=True,
+    )
+    assert out.status is ff.ReserveStatus.OK
+    res = out.reservation
+    assert res.funding_source == "subscription"
+    assert res.paid_lane is True
+    assert res.app_reservation_active is True
+    assert len(sub.reserved) == 1
+    assert ctx.cp_manager.user_credits_mgr.reserved == []   # wallet untouched
+
+
+async def test_reserve_paid_subscription_falls_back_to_wallet():
+    # subscription hold declined but the wallet can pay -> wallet becomes the primary.
+    sub = _SubBudget(reserve_fail=True)
+    credits = _Credits(reserve_ok=True)
+    ctx = _ctx(sub=sub, credits=credits)
+    out = await ff.reserve_paid_funding(
+        ctx, admit=_Admit(reserved=2000), est_turn_tokens=2000,
+        has_active_subscription=True, has_wallet=True, wallet_can_pay_turn=True,
+    )
+    assert out.status is ff.ReserveStatus.OK
+    res = out.reservation
+    assert res.funding_source == "wallet"
+    assert res.wallet_reservation_active is True
+    assert res.wallet_reserved_tokens == 2000
+    assert len(credits.reserved) == 1
+
+
+async def test_reserve_paid_subcent_subscription_skips_to_wallet():
+    # est below the cent floor -> no subscription hold attempted; wallet is primary.
+    sub = _SubBudget(available_usd=100.0)
+    credits = _Credits(reserve_ok=True)
+    ctx = _ctx(sub=sub, credits=credits)
+    out = await ff.reserve_paid_funding(
+        ctx, admit=_Admit(reserved=200), est_turn_tokens=200,
+        has_active_subscription=True, has_wallet=True, wallet_can_pay_turn=True,
+    )
+    assert out.status is ff.ReserveStatus.OK
+    assert out.reservation.funding_source == "wallet"
+    assert sub.reserved == []
+    assert len(credits.reserved) == 1
+
+
+async def test_reserve_paid_subscription_failed_no_wallet_denies():
+    sub = _SubBudget(reserve_fail=True)
+    ctx = _ctx(sub=sub)
+    out = await ff.reserve_paid_funding(
+        ctx, admit=_Admit(reserved=2000), est_turn_tokens=2000,
+        has_active_subscription=True, has_wallet=False, wallet_can_pay_turn=False,
+    )
+    assert out.status is ff.ReserveStatus.DENIED
+    assert out.deny_code == "paid_subscription_reservation_failed"
+
+
+async def test_reserve_paid_wallet_primary():
+    # no subscription -> wallet is the paid-lane primary.
+    credits = _Credits(reserve_ok=True)
+    ctx = _ctx(credits=credits)
+    out = await ff.reserve_paid_funding(
+        ctx, admit=_Admit(reserved=2000), est_turn_tokens=2000,
+        has_active_subscription=False, has_wallet=True, wallet_can_pay_turn=True,
+    )
+    assert out.status is ff.ReserveStatus.OK
+    res = out.reservation
+    assert res.funding_source == "wallet"
+    assert res.wallet_reservation_active is True
+    assert res.wallet_reserved_tokens == 2000
+    assert len(credits.reserved) == 1
+
+
+async def test_reserve_paid_no_wallet_denies():
+    ctx = _ctx()
+    out = await ff.reserve_paid_funding(
+        ctx, admit=_Admit(reserved=2000), est_turn_tokens=2000,
+        has_active_subscription=False, has_wallet=False, wallet_can_pay_turn=False,
+    )
+    assert out.status is ff.ReserveStatus.DENIED
+    assert out.deny_code == "paid_no_personal_budget"
+
+
+async def test_reserve_paid_wallet_reservation_failed_denies():
+    credits = _Credits(reserve_ok=False)
+    ctx = _ctx(credits=credits)
+    out = await ff.reserve_paid_funding(
+        ctx, admit=_Admit(reserved=2000), est_turn_tokens=2000,
+        has_active_subscription=False, has_wallet=True, wallet_can_pay_turn=True,
+    )
+    assert out.status is ff.ReserveStatus.DENIED
+    assert out.deny_code == "paid_wallet_reservation_failed"
+
+
 async def test_settle_wallet_primary_paid_lane():
     # funding_source="wallet" -> wallet pays everything; project absorbs uncovered.
     credits = _Credits(consume_uncovered=0)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
@@ -229,6 +229,27 @@ async def test_settle_wallet_primary_paid_lane():
     assert out.wallet_usd == pytest.approx(0.015, rel=1e-6)
 
 
+async def test_settle_wallet_zero_cost_releases_reservation():
+    # paid lane with zero actual cost (ranked_tokens=0): commit_reserved no-ops on
+    # tokens<=0, so the wallet hold must be RELEASED, not left 'reserved' until TTL.
+    credits = _Credits()
+    ctx = _ctx(credits=credits)
+    res = ff.PlanFundingReservation(
+        funding_source="wallet", budget_bypass=False, est_turn_tokens=2000,
+        wallet_reservation_id="scope-1", wallet_reserved_tokens=2000, wallet_reservation_active=True,
+        has_wallet=True,
+    )
+    out = await ff.settle_plan_funding(
+        ctx, res, ranked_tokens=0, total_cost_usd=0.0,
+        effective_policy=QuotaPolicy(tokens_per_month=10**9),
+        plan_has_lifetime_budget=True, user_budget_tokens=10**9,
+    )
+    assert credits.committed == []                     # nothing committed
+    assert len(credits.released) == 1                  # hold released
+    assert credits.released[0]["reservation_id"] == "scope-1"
+    assert res.wallet_reservation_active is False
+
+
 async def test_settle_none_charges_project_last_resort():
     ctx = _ctx()
     res = ff.PlanFundingReservation(funding_source="none", budget_bypass=False, est_turn_tokens=2000)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_quota_lock.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_quota_lock.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Unit tests for the shared distributed quota lock (funding_flow QuotaLock).
+
+A minimal in-memory redis fake exercises SET NX acquire, the bounded spin-wait
+timeout, and the compare-and-del release (own-token only)."""
+
+from __future__ import annotations
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.infra.economics.quota_lock import QuotaLock, quota_lock_key
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.store: dict = {}
+
+    async def set(self, key, val, nx=False, ex=None, px=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = val
+        return True
+
+    async def eval(self, lua, numkeys, key, token):
+        # compare-and-del
+        if self.store.get(key) == token:
+            del self.store[key]
+            return 1
+        return 0
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def delete(self, key):
+        self.store.pop(key, None)
+
+
+def test_quota_lock_key_format():
+    assert quota_lock_key("t", "p", "u1", "month", "__project__") == \
+        "quota_lock:t:p:u1:month:__project__"
+
+
+async def test_acquire_then_release_roundtrip():
+    r = _FakeRedis()
+    ql = QuotaLock(r)
+    key = quota_lock_key("t", "p", "u1", "month", "__project__")
+    assert await ql.acquire_blocking(key, ttl_sec=60, wait_total_sec=1.0) is True
+    assert ql.acquired is True
+    assert r.store.get(key) == ql.token       # we hold it
+    assert await ql.release_if_held() is True  # released
+    assert r.store == {}
+    assert ql.acquired is False
+
+
+async def test_acquire_times_out_when_contended():
+    r = _FakeRedis()
+    key = quota_lock_key("t", "p", "u1", "month", "__project__")
+    r.store[key] = "someone-else"             # another holder owns it
+    ql = QuotaLock(r)
+    assert await ql.acquire_blocking(key, ttl_sec=60, wait_total_sec=0.2) is False
+    assert ql.acquired is False
+    assert r.store[key] == "someone-else"      # untouched (we never overwrote)
+
+
+async def test_release_if_held_noop_when_not_acquired():
+    ql = QuotaLock(_FakeRedis())
+    assert await ql.release_if_held() is False
+
+
+async def test_release_only_drops_own_token():
+    r = _FakeRedis()
+    key = quota_lock_key("t", "p", "u1", "month", "__project__")
+    ql = QuotaLock(r)
+    await ql.acquire_blocking(key, ttl_sec=60, wait_total_sec=1.0)
+    # a successor overwrites the key (e.g. after our TTL) with a different token
+    r.store[key] = "successor-token"
+    assert await ql.release_if_held() is True   # we issued a release...
+    assert r.store[key] == "successor-token"    # ...but compare-and-del kept theirs

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
@@ -557,102 +557,43 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
             except Exception as e:
                 _log("analytics", "Provider analytics write failed (best-effort)", "WARN", error=str(e))
 
-        async def _quota_lock_try_acquire(key: str, token: str, ttl_sec: int) -> bool:
-            r = self.redis
-            if r is None:
-                return False
-            try:
-                ok = await r.set(key, token, nx=True, ex=ttl_sec)
-                return bool(ok)
-            except TypeError:
-                pass
-            except Exception:
-                return False
-            try:
-                ok = await r.set(key, token, nx=True, px=int(ttl_sec * 1000))
-                return bool(ok)
-            except Exception:
-                return False
-
-        async def _quota_lock_release(key: str, token: str) -> None:
-            r = self.redis
-            if r is None:
-                return
-            lua = (
-                "if redis.call('get', KEYS[1]) == ARGV[1] then "
-                "return redis.call('del', KEYS[1]) else return 0 end"
-            )
-            try:
-                await r.eval(lua, 1, key, token)
-                return
-            except TypeError:
-                try:
-                    await r.eval(lua, keys=[key], args=[token])
-                    return
-                except Exception:
-                    pass
-            except Exception:
-                pass
-            try:
-                cur = await r.get(key)
-                if cur is None:
-                    return
-                if isinstance(cur, (bytes, bytearray)):
-                    cur = cur.decode("utf-8", errors="ignore")
-                if str(cur) == str(token):
-                    await r.delete(key)
-            except Exception:
-                pass
-
-        quota_lock_key = None
-        quota_lock_token = None
-        quota_lock_acquired = False
+        # Redis mechanics + spin-wait live in the shared funding_flow QuotaLock; run()
+        # owns the redis-absent gate, the denial it raises on timeout, and its logs.
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.quota_lock import (
+            QuotaLock, quota_lock_key,
+        )
+        _quota_lock = QuotaLock(self.redis)
 
         async def _acquire_quota_lock_or_deny(*, scope: str) -> None:
-            nonlocal quota_lock_key, quota_lock_token, quota_lock_acquired
             if self.redis is None:
                 _log("quota_lock", "Redis unavailable; quota_lock disabled", "WARN")
                 return
-            quota_lock_key = f"quota_lock:{tenant}:{project}:{user_id}:{scope}:{rl_bundle_id}"
-            quota_lock_token = secrets.token_hex(16)
+            key = quota_lock_key(tenant, project, user_id, scope, rl_bundle_id)
             ttl_sec = 60
-            wait_total_sec = 5.0
-            t0 = asyncio.get_event_loop().time()
-            sleep = 0.05
-            while True:
-                ok = await _quota_lock_try_acquire(quota_lock_key, quota_lock_token, ttl_sec=ttl_sec)
-                if ok:
-                    quota_lock_acquired = True
-                    _log("quota_lock", "Acquired quota_lock", key=quota_lock_key, scope=scope, ttl_sec=ttl_sec)
-                    return
-                if (asyncio.get_event_loop().time() - t0) >= wait_total_sec:
-                    _log("quota_lock", "Failed to acquire quota_lock within wait window", "WARN", key=quota_lock_key, scope=scope)
-                    await _econ_fail(
-                        code="quota_lock_timeout",
-                        title="System busy",
-                        message="Too many concurrent requests are planning quotas right now. Please retry.",
-                        event_type="rate_limit.denied",
-                        data={
-                            "reason": "quota_lock_timeout",
-                            "user_message": _build_user_message(reason="quota_lock_timeout", reset_text=None),
-                            "bundle_id": bundle_id,
-                            "subject_id": self.subj,
-                            "user_type": user_type,
-                            "lane": "deny",
-                            "scope": scope,
-                        },
-                    )
-                await asyncio.sleep(sleep)
-                sleep = min(sleep * 1.5, 0.25)
+            if await _quota_lock.acquire_blocking(key, ttl_sec=ttl_sec, wait_total_sec=5.0):
+                _log("quota_lock", "Acquired quota_lock", key=key, scope=scope, ttl_sec=ttl_sec)
+                return
+            _log("quota_lock", "Failed to acquire quota_lock within wait window", "WARN", key=key, scope=scope)
+            await _econ_fail(
+                code="quota_lock_timeout",
+                title="System busy",
+                message="Too many concurrent requests are planning quotas right now. Please retry.",
+                event_type="rate_limit.denied",
+                data={
+                    "reason": "quota_lock_timeout",
+                    "user_message": _build_user_message(reason="quota_lock_timeout", reset_text=None),
+                    "bundle_id": bundle_id,
+                    "subject_id": self.subj,
+                    "user_type": user_type,
+                    "lane": "deny",
+                    "scope": scope,
+                },
+            )
 
         async def _release_quota_lock_if_held() -> None:
-            nonlocal quota_lock_key, quota_lock_token, quota_lock_acquired
-            if quota_lock_acquired and quota_lock_key and quota_lock_token:
-                await _quota_lock_release(quota_lock_key, quota_lock_token)
-                _log("quota_lock", "Released quota_lock", key=quota_lock_key)
-            quota_lock_key = None
-            quota_lock_token = None
-            quota_lock_acquired = False
+            key = _quota_lock.key
+            if await _quota_lock.release_if_held():
+                _log("quota_lock", "Released quota_lock", key=key)
 
         await self.ensure_policies_initialized()
 
@@ -1293,81 +1234,70 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                 await _acquire_quota_lock_or_deny(scope=scope_for_lock)
 
                 try:
-                    plan_reserved_tokens = int(getattr(admit, "reserved_tokens", 0) or 0)
-                    plan_reservation_id = getattr(admit, "reservation_id", None)
-                    plan_reservation_active = (lane == "plan" and plan_reserved_tokens > 0 and plan_reservation_id is not None)
-
-                    plan_project_tokens_est = int(plan_reserved_tokens)
-                    if funding_source == "subscription":
-                        plan_project_tokens_est = int(est_turn_tokens)
-                        if has_wallet:
-                            cap_usd = float(subscription_available_usd or 0.0)
-                            if cap_usd < 0:
-                                cap_usd = 0.0
-                            if usd_per_token > 0:
-                                cap_tokens = int(cap_usd / (usd_per_token * SAFETY_MARGIN))
-                            else:
-                                cap_tokens = 0
-                            plan_project_tokens_est = min(int(est_turn_tokens), int(cap_tokens))
-                    elif funding_source == "project" and project_budget:
-                        od_lim = project_budget.get("overdraft_limit_usd")
-                        if od_lim is not None:
-                            cap_usd = float(project_budget.get("available_usd") or 0.0) + float(od_lim or 0.0)
-                            if cap_usd < 0:
-                                cap_usd = 0.0
-                            if usd_per_token > 0:
-                                cap_tokens = int(cap_usd / (usd_per_token * SAFETY_MARGIN))
-                                plan_project_tokens_est = min(int(plan_project_tokens_est), int(cap_tokens))
-                        # od_lim == None => unlimited, keep full plan_project_tokens_est
-                    if funding_source == "subscription":
-                        overflow_tokens_est = max(int(est_turn_tokens) - int(plan_project_tokens_est), 0)
-                    else:
-                        overflow_tokens_est = max(int(est_turn_tokens) - int(plan_project_tokens_est), 0)
-                    if plan_limit is None:
-                        plan_remaining = est_turn_tokens
-                        tokens_spent_stat = f'Tokens spent from plan in this month: {int(admit.snapshot.get("tok_month", 0) or 0)}'
-                    else:
-                        tok_so_far = int(admit.snapshot.get(f"tok_{scope}", 0) or 0)
-                        tokens_spent_stat = f"Tokens spent from plan in this {scope}: {tok_so_far}"
-                        plan_remaining = max(int(plan_limit) - int(tok_so_far), 0)
-
-                    _log(
-                        "reserve.plan",
-                        "Reservation plan (plan lane)",
-                        est_turn_tokens=est_turn_tokens,
-                        tokens_spent_stat=tokens_spent_stat,
-                        plan_limit=plan_limit,
-                        plan_remaining=plan_remaining,
-                        plan_covered_tokens_est=plan_project_tokens_est,
-                        overflow_tokens_est=overflow_tokens_est,
-                        usd_per_token=usd_per_token,
+                    from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import (
+                        FundingContext, reserve_plan_funding, ReserveStatus,
                     )
 
-                    if plan_project_tokens_est > 0:
-                        # Budget system stores amounts in integer cents; anything below $0.01
-                        # rounds to 0 cents in _usd_to_cents() and raises ValueError in reserve().
-                        _min_reserve_usd = 1.0 / 100
-                        if float(plan_project_tokens_est) * float(usd_per_token) * SAFETY_MARGIN < _min_reserve_usd:
-                            _log(
-                                "reserve.plan",
-                                "Plan token reservation below minimum chargeable amount; treating as exhausted",
-                                "WARN",
-                                plan_project_tokens_est=plan_project_tokens_est,
-                                computed_usd=float(plan_project_tokens_est) * float(usd_per_token) * SAFETY_MARGIN,
-                                min_reserve_usd=_min_reserve_usd,
-                            )
-                            plan_project_tokens_est = 0
+                    # plan-lane reservation: the money flow is owned by the shared
+                    # funding_flow.reserve_plan_funding (single reservation owner). run()
+                    # keeps the quota-lock + lane-switch/denial SSE shell below.
+                    _reserve_ctx = FundingContext(
+                        rl=self.rl, budget_limiter=self.budget_limiter, cp_manager=self.cp_manager,
+                        tenant=tenant, project=project, user_id=user_id, subject_id=self.subj,
+                        bundle_id=bundle_id, rl_bundle_id=rl_bundle_id, scope_id=turn_id,
+                        usd_per_token=usd_per_token, now=plan_admit_now,
+                        subscription_limiter=subscription_budget_limiter,
+                        log=lambda stage, msg, level="INFO", **kv: _log(stage, msg, level, **kv),
+                    )
+                    _outcome = await reserve_plan_funding(
+                        _reserve_ctx, admit=admit, funding_source=funding_source,
+                        budget_bypass=budget_bypass, est_turn_tokens=int(est_turn_tokens),
+                        has_wallet=has_wallet, subscription_available_usd=subscription_available_usd,
+                        project_budget_snapshot=project_budget, personal_can_pay_turn=personal_can_pay_turn,
+                        allow_paid_lane_fallback=allow_paid_lane_fallback, ttl_sec=900,
+                    )
 
-                    if plan_project_tokens_est <= 0:
-                        if budget_bypass:
-                            _log(
-                                "reserve.plan",
-                                "Budget bypass: zero plan reservation; skipping paid switch",
-                                "WARN",
-                                est_turn_tokens=est_turn_tokens,
-                                plan_reserved_tokens=plan_reserved_tokens,
-                            )
-                        elif not personal_can_pay_turn:
+                    if _outcome.status is ReserveStatus.OK:
+                        _res = _outcome.reservation
+                        plan_reserved_tokens = int(_res.plan_reserved_tokens or 0)
+                        plan_reservation_id = _res.plan_reservation_id
+                        plan_reservation_active = bool(_res.plan_reservation_active)
+                        plan_project_tokens_est = int(_res.plan_project_tokens_est or 0)
+                        app_reservation_id = _res.app_reservation_id
+                        app_reserved_usd = float(_res.app_reserved_usd or 0.0)
+                        app_reservation_active = bool(_res.app_reservation_active)
+                        if _res.wallet_reservation_active:
+                            personal_reservation_id = _res.wallet_reservation_id
+                            personal_reserved_tokens = int(_res.wallet_reserved_tokens or 0)
+                            personal_reservation_active = True
+                            _log("reserve.personal", "Reserved personal overflow tokens",
+                                 reservation_id=personal_reservation_id, tokens_reserved=personal_reserved_tokens)
+
+                    elif _outcome.status is ReserveStatus.SWITCH_TO_PAID:
+                        _switch_reason = _outcome.switch_reason or "plan_tokens_exhausted_for_turn"
+                        if _switch_reason in ("subscription_budget_zero_for_turn", "subscription_reservation_failed"):
+                            _switch_title = "Switching to paid lane (wallet funding)"
+                        else:
+                            _switch_title = "Switching to personal credits"
+                        await _emit_event(
+                            type="rate_limit.lane_switch",
+                            status="running",
+                            title=_switch_title,
+                            data={
+                                "reason": _switch_reason,
+                                "bundle_id": bundle_id,
+                                "subject_id": self.subj,
+                                "user_type": user_type,
+                                "snapshot": admit.snapshot,
+                                "lane_from": "plan",
+                                "lane_to": "paid",
+                            },
+                        )
+                        await _switch_plan_to_paid_or_die(switch_reason=_switch_reason)
+
+                    else:  # ReserveStatus.DENIED
+                        _deny_code = _outcome.deny_code or "no_funding_source"
+                        if _deny_code == "plan_exhausted_no_personal":
                             payload = _build_rate_limit_payload(
                                 policy=_policy_for_insight(admit_result=admit, fallback_policy=base_policy),
                                 snapshot=admit.snapshot,
@@ -1390,173 +1320,63 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                                     "lane": "deny",
                                 },
                             )
-                        elif funding_source == "subscription" and has_wallet:
-                            await _emit_event(
-                                type="rate_limit.lane_switch",
-                                status="running",
-                                title="Switching to paid lane (wallet funding)",
+                        elif _deny_code.endswith("_budget_reservation_failed_no_personal"):
+                            _app_reserved_usd_msg = float(est_turn_tokens) * float(usd_per_token) * SAFETY_MARGIN
+                            await _econ_fail(
+                                code=f"{funding_source}_budget_reservation_failed_no_personal",
+                                title=f"Insufficient {funding_label}",
+                                message=f"{funding_label.title()} cannot reserve plan funds and user cannot pay.",
+                                event_type="rate_limit.project_exhausted" if funding_source == "project" else "rate_limit.subscription_exhausted",
                                 data={
-                                    "reason": "subscription_budget_zero_for_turn",
+                                    "reason": f"{funding_source}_budget_reservation_failed",
                                     "bundle_id": bundle_id,
                                     "subject_id": self.subj,
                                     "user_type": user_type,
-                                    "snapshot": admit.snapshot,
-                                    "lane_from": "plan",
-                                    "lane_to": "paid",
+                                    "funding_source": funding_source,
+                                    "app_reserved_usd": _app_reserved_usd_msg,
+                                    "user_budget_tokens": user_budget_tokens,
                                 },
                             )
-                            await _switch_plan_to_paid_or_die(switch_reason="subscription_budget_zero_for_turn")
-                        elif allow_paid_lane_fallback:
-                            await _emit_event(
-                                type="rate_limit.lane_switch",
-                                status="running",
-                                title="Switching to personal credits",
+                        elif _deny_code == "personal_reservation_failed_plan":
+                            payload = _build_rate_limit_payload(
+                                policy=_policy_for_insight(admit_result=admit, fallback_policy=effective_policy),
+                                snapshot=admit.snapshot,
+                                reason=admit.reason or "plan_token_overflow",
+                                used_plan_override=admit.used_plan_override,
+                                needed_tokens=int(est_turn_tokens),
+                                remaining_tokens=int(plan_project_tokens_est),
+                            )
+                            await _econ_fail(
+                                code="personal_reservation_failed_plan",
+                                title="Insufficient personal credits",
+                                message="Insufficient personal credits to cover overflow.",
+                                event_type="rate_limit.denied",
                                 data={
-                                    "reason": "plan_tokens_exhausted_for_turn",
+                                    "reason": "personal_reservation_failed",
                                     "bundle_id": bundle_id,
                                     "subject_id": self.subj,
                                     "user_type": user_type,
-                                    "snapshot": admit.snapshot,
-                                    "lane_from": "plan",
-                                    "lane_to": "paid",
+                                    "tokens_required": int(est_turn_tokens),
+                                    "rate_limit": payload,
+                                    "lane": lane,
                                 },
                             )
-
-                            await _switch_plan_to_paid_or_die(switch_reason="plan_tokens_exhausted_for_turn")
-                        else:
-                            _log(
-                                "reserve.plan",
-                                "Plan budget exhausted; using wallet for overflow (no paid-lane switch)",
-                                "WARN",
-                                est_turn_tokens=est_turn_tokens,
-                                plan_reserved_tokens=plan_reserved_tokens,
+                        else:  # no_funding_source (and any unmapped deny)
+                            await _econ_fail(
+                                code="no_funding_source",
+                                title="No funding source",
+                                message="No plan or project funding source is available for this user type.",
+                                event_type="rate_limit.no_funding",
+                                data={
+                                    "reason": "no_funding_source",
+                                    "bundle_id": bundle_id,
+                                    "subject_id": self.subj,
+                                    "user_type": user_type,
+                                    "funding_source": funding_source,
+                                    "user_message": MSG_NO_FUNDING,
+                                    "notification_type": "error",
+                                },
                             )
-                    else:
-                        if not budget_bypass:
-                            app_reserved_usd = float(plan_project_tokens_est) * float(usd_per_token) * SAFETY_MARGIN
-                            app_reservation_id = uuid4()
-
-                            try:
-                                reserve_kwargs = dict(
-                                    reservation_id=app_reservation_id,
-                                    bundle_id=bundle_id,
-                                    provider=None,
-                                    request_id=turn_id,
-                                    amount_usd=float(app_reserved_usd),
-                                    ttl_sec=900,
-                                    notes=f"plan reserve: est_turn={est_turn_tokens}, plan_cover_est={plan_project_tokens_est}, ref=anthropic/claude-sonnet-4-5-20250929",
-                                )
-                                if funding_source == "project":
-                                    reserve_kwargs["user_id"] = user_id
-
-                                rr = await funding_limiter.reserve(**reserve_kwargs)
-                                app_reservation_active = True
-                                _log(
-                                    "reserve.app",
-                                    f"Reserved {funding_label} (plan lane)",
-                                    reservation_id=str(rr.reservation_id),
-                                    app_reserved_usd=rr.reserved_usd,
-                                    expires_at=rr.expires_at,
-                                    snapshot=dataclasses.asdict(rr.snapshot),
-                                )
-                            except BudgetInsufficientFunds as e:
-                                _log("reserve.app", f"{funding_label.title()} reservation denied", "WARN", error=str(e), app_reserved_usd=app_reserved_usd)
-
-                                if not personal_can_pay_turn:
-                                    await _econ_fail(
-                                        code=f"{funding_source}_budget_reservation_failed_no_personal",
-                                        title=f"Insufficient {funding_label}",
-                                        message=f"{funding_label.title()} cannot reserve plan funds and user cannot pay.",
-                                        event_type="rate_limit.project_exhausted" if funding_source == "project" else "rate_limit.subscription_exhausted",
-                                        data={
-                                            "reason": f"{funding_source}_budget_reservation_failed",
-                                            "bundle_id": bundle_id,
-                                            "subject_id": self.subj,
-                                            "user_type": user_type,
-                                            "funding_source": funding_source,
-                                            "app_reserved_usd": app_reserved_usd,
-                                            "user_budget_tokens": user_budget_tokens,
-                                        },
-                                    )
-
-                                if funding_source == "subscription" and has_wallet:
-                                    await _emit_event(
-                                        type="rate_limit.lane_switch",
-                                        status="running",
-                                        title="Switching to paid lane (wallet funding)",
-                                        data={
-                                            "reason": "subscription_reservation_failed",
-                                            "bundle_id": bundle_id,
-                                            "subject_id": self.subj,
-                                            "user_type": user_type,
-                                            "snapshot": admit.snapshot,
-                                            "lane_from": "plan",
-                                            "lane_to": "paid",
-                                        },
-                                    )
-                                    await _switch_plan_to_paid_or_die(switch_reason="subscription_reservation_failed")
-                                elif allow_paid_lane_fallback:
-                                    await _emit_event(
-                                        type="rate_limit.lane_switch",
-                                        status="running",
-                                        title="Switching to personal credits",
-                                        data={
-                                            "reason": "app_budget_reservation_failed",
-                                            "bundle_id": bundle_id,
-                                            "subject_id": self.subj,
-                                            "user_type": user_type,
-                                            "snapshot": admit.snapshot,
-                                            "lane_from": "plan",
-                                            "lane_to": "paid",
-                                        },
-                                    )
-                                    await _switch_plan_to_paid_or_die(switch_reason="app_budget_reservation_failed")
-                                else:
-                                    # Fall back to wallet-only for this turn
-                                    plan_project_tokens_est = 0
-                                    app_reserved_usd = 0.0
-
-                    if lane == "plan" and (funding_source != "subscription" or has_wallet):
-                        overflow_tokens_est = max(int(est_turn_tokens) - int(plan_project_tokens_est), 0)
-                        if overflow_tokens_est > 0:
-                            ok = await self.cp_manager.user_credits_mgr.reserve_lifetime_tokens(
-                                tenant=tenant,
-                                project=project,
-                                user_id=user_id,
-                                reservation_id=turn_id,
-                                tokens=int(overflow_tokens_est),
-                                ttl_sec=900,
-                                bundle_id=bundle_id,
-                                notes=f"auto-reserve: lane=plan, overflow={overflow_tokens_est}, est_turn={est_turn_tokens}",
-                            )
-                            if not ok:
-                                payload = _build_rate_limit_payload(
-                                    policy=_policy_for_insight(admit_result=admit, fallback_policy=effective_policy),
-                                    snapshot=admit.snapshot,
-                                    reason=admit.reason or "plan_token_overflow",
-                                    used_plan_override=admit.used_plan_override,
-                                    needed_tokens=int(est_turn_tokens),
-                                    remaining_tokens=int(plan_project_tokens_est),
-                                )
-                                await _econ_fail(
-                                    code="personal_reservation_failed_plan",
-                                    title="Insufficient personal credits",
-                                    message="Insufficient personal credits to cover overflow.",
-                                    event_type="rate_limit.denied",
-                                    data={
-                                        "reason": "personal_reservation_failed",
-                                        "bundle_id": bundle_id,
-                                        "subject_id": self.subj,
-                                        "user_type": user_type,
-                                        "tokens_required": int(overflow_tokens_est),
-                                        "rate_limit": payload,
-                                        "lane": lane,
-                                    },
-                                )
-                            personal_reservation_id = turn_id
-                            personal_reserved_tokens = int(overflow_tokens_est)
-                            personal_reservation_active = True
-                            _log("reserve.personal", "Reserved personal overflow tokens", reservation_id=turn_id, tokens_reserved=personal_reserved_tokens)
                 finally:
                     try:
                         await _release_quota_lock_if_held()
@@ -1564,80 +1384,60 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                         _log("quota_lock", "Failed to release quota_lock", "WARN", error=str(ex))
 
             if lane == "paid" and not budget_bypass:
-                if has_active_subscription and funding_limiter:
-                    app_reserved_usd = float(est_turn_tokens) * float(usd_per_token) * SAFETY_MARGIN
-                    app_reservation_id = uuid4()
-                    try:
-                        rr = await funding_limiter.reserve(
-                            reservation_id=app_reservation_id,
-                            bundle_id=bundle_id,
-                            provider=None,
-                            request_id=turn_id,
-                            amount_usd=float(app_reserved_usd),
-                            ttl_sec=900,
-                            notes=f"paid reserve: est_turn={est_turn_tokens}, ref=anthropic/claude-sonnet-4-5-20250929",
-                        )
-                        app_reservation_active = True
-                        paid_funding_source = "subscription"
-                        _log(
-                            "reserve.app",
-                            "Reserved subscription balance (paid lane)",
-                            reservation_id=str(rr.reservation_id),
-                            app_reserved_usd=rr.reserved_usd,
-                            expires_at=rr.expires_at,
-                            snapshot=dataclasses.asdict(rr.snapshot),
-                        )
-                    except BudgetInsufficientFunds as e:
-                        _log(
-                            "reserve.app",
-                            "Subscription reservation denied (paid lane)",
-                            "WARN",
-                            error=str(e),
-                            app_reserved_usd=app_reserved_usd,
-                        )
-                        if not wallet_can_pay_turn:
-                            await _econ_fail(
-                                code="subscription_reservation_failed_paid",
-                                title="Insufficient subscription balance",
-                                message="Subscription balance cannot cover this request and no wallet credits are available.",
-                                event_type="rate_limit.subscription_exhausted",
-                                data={
-                                    "reason": "subscription_reservation_failed",
-                                    "bundle_id": bundle_id,
-                                    "subject_id": self.subj,
-                                    "user_type": user_type,
-                                    "tokens_required": int(est_turn_tokens),
-                                    "lane": lane,
-                                },
-                            )
+                from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import (
+                    FundingContext, reserve_paid_funding, ReserveStatus,
+                )
 
-                if not app_reservation_active:
-                    if not (plan_balance and plan_balance.has_lifetime_budget()):
+                # paid-lane reservation: the money flow is owned by the shared
+                # funding_flow.reserve_paid_funding (subscription primary then wallet).
+                _paid_ctx = FundingContext(
+                    rl=self.rl, budget_limiter=self.budget_limiter, cp_manager=self.cp_manager,
+                    tenant=tenant, project=project, user_id=user_id, subject_id=self.subj,
+                    bundle_id=bundle_id, rl_bundle_id=rl_bundle_id, scope_id=turn_id,
+                    usd_per_token=usd_per_token, now=plan_admit_now,
+                    subscription_limiter=subscription_budget_limiter,
+                    log=lambda stage, msg, level="INFO", **kv: _log(stage, msg, level, **kv),
+                )
+                _paid_outcome = await reserve_paid_funding(
+                    _paid_ctx, admit=admit, est_turn_tokens=int(est_turn_tokens),
+                    has_active_subscription=has_active_subscription,
+                    has_wallet=bool(plan_balance and plan_balance.has_lifetime_budget()),
+                    wallet_can_pay_turn=wallet_can_pay_turn, ttl_sec=900,
+                )
+
+                if _paid_outcome.status is ReserveStatus.OK:
+                    _res = _paid_outcome.reservation
+                    paid_funding_source = _res.funding_source
+                    if _res.funding_source == "subscription":
+                        app_reservation_id = _res.app_reservation_id
+                        app_reserved_usd = float(_res.app_reserved_usd or 0.0)
+                        app_reservation_active = True
+                        _log("reserve.app", "Reserved subscription balance (paid lane)",
+                             reservation_id=str(app_reservation_id), app_reserved_usd=app_reserved_usd)
+                    else:
+                        personal_reservation_id = _res.wallet_reservation_id
+                        personal_reserved_tokens = int(_res.wallet_reserved_tokens or 0)
+                        personal_reservation_active = True
+                        _log("reserve.personal", "Reserved personal tokens (paid lane)",
+                             reservation_id=personal_reservation_id, tokens_reserved=personal_reserved_tokens)
+                else:  # ReserveStatus.DENIED
+                    _pcode = _paid_outcome.deny_code or "paid_no_personal_budget"
+                    if _pcode == "paid_subscription_reservation_failed":
                         await _econ_fail(
-                            code="paid_lane_requires_personal_budget",
-                            title="Insufficient personal credits",
-                            message="Paid lane requires wallet credits.",
-                            event_type="rate_limit.denied",
+                            code="subscription_reservation_failed_paid",
+                            title="Insufficient subscription balance",
+                            message="Subscription balance cannot cover this request and no wallet credits are available.",
+                            event_type="rate_limit.subscription_exhausted",
                             data={
-                                "reason": "no_personal_budget",
+                                "reason": "subscription_reservation_failed",
                                 "bundle_id": bundle_id,
                                 "subject_id": self.subj,
                                 "user_type": user_type,
+                                "tokens_required": int(est_turn_tokens),
                                 "lane": lane,
                             },
                         )
-
-                    ok = await self.cp_manager.user_credits_mgr.reserve_lifetime_tokens(
-                        tenant=tenant,
-                        project=project,
-                        user_id=user_id,
-                        reservation_id=turn_id,
-                        tokens=int(est_turn_tokens),
-                        ttl_sec=900,
-                        bundle_id=bundle_id,
-                        notes=f"auto-reserve paid: lane=paid, est_turn={est_turn_tokens}",
-                    )
-                    if not ok:
+                    elif _pcode == "paid_wallet_reservation_failed":
                         await _econ_fail(
                             code="personal_reservation_failed_paid",
                             title="Insufficient personal credits",
@@ -1652,17 +1452,20 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                                 "lane": lane,
                             },
                         )
-
-                    personal_reservation_id = turn_id
-                    personal_reserved_tokens = int(est_turn_tokens)
-                    personal_reservation_active = True
-                    paid_funding_source = "wallet"
-                    _log(
-                        "reserve.personal",
-                        "Reserved personal tokens (paid lane)",
-                        reservation_id=turn_id,
-                        tokens_reserved=personal_reserved_tokens,
-                    )
+                    else:  # paid_no_personal_budget
+                        await _econ_fail(
+                            code="paid_lane_requires_personal_budget",
+                            title="Insufficient personal credits",
+                            message="Paid lane requires wallet credits.",
+                            event_type="rate_limit.denied",
+                            data={
+                                "reason": "no_personal_budget",
+                                "bundle_id": bundle_id,
+                                "subject_id": self.subj,
+                                "user_type": user_type,
+                                "lane": lane,
+                            },
+                        )
         except EconomicsLimitException:
             await _cleanup_reservations("pre_run_fail")
             raise
@@ -1897,8 +1700,12 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                             limit=getattr(effective_policy, "tokens_per_hour", None),
                             reserved=0,
                         )
-                        commit_tokens_for_snapshot = int(plan_quota_commit_tokens) if lane == "plan" else 0
-                        post_run_snapshot["tok_hour"] = int(tok_h_now or 0) + int(commit_tokens_for_snapshot)
+                        # settle (settle_plan_funding) has already committed this turn's tokens
+                        # before we read the rolling window, so tok_h_now is the post-commit value.
+                        # Do NOT add the commit again — that double-counted the rolling hour and
+                        # produced false post-run "tokens_per_hour exceeded" violations (routing the
+                        # turn to the exhausted path even when usage was still under the limit).
+                        post_run_snapshot["tok_hour"] = int(tok_h_now or 0)
                         if reset_at:
                             post_run_snapshot["tok_hour_reset_at"] = int(reset_at)
                 except Exception as ex:
@@ -1969,34 +1776,45 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                     or (pr_tok is not None and pr_tok < int(est_turn_tokens))
                 ):
                     if pr_mr is not None and pr_mr == 0:
-                        # Synthesize the exhausted dimension so _format_reset_time can produce a specific time
                         rem = post_insight.remaining
-                        exhausted = []
-                        if rem.get("requests_per_day") == 0 and getattr(effective_policy, "requests_per_day", None) is not None:
-                            exhausted.append("requests_per_day")
-                        if rem.get("requests_per_month") == 0 and getattr(effective_policy, "requests_per_month", None) is not None:
-                            exhausted.append("requests_per_month")
-                        if rem.get("tokens_per_hour") == 0 and getattr(effective_policy, "tokens_per_hour", None) is not None:
-                            exhausted.append("tokens_per_hour")
-                        if rem.get("tokens_per_day") == 0 and getattr(effective_policy, "tokens_per_day", None) is not None:
-                            exhausted.append("tokens_per_day")
-                        exhausted_insight = compute_quota_insight(
-                            policy=effective_policy,
-                            snapshot=post_run_snapshot,
-                            reason="|".join(exhausted) if exhausted else None,
-                            used_plan_override=admit.used_plan_override if admit else False,
-                            user_budget_tokens=user_budget_tokens,
-                            est_tokens_per_turn=est_turn_tokens,
-                        )
-                        reset_text = _format_reset_time(
-                            retry_after_sec=exhausted_insight.retry_after_sec,
-                            now=now,
-                            user_timezone=getattr(self.comm_context.user, "timezone", None) if self.comm_context and self.comm_context.user else None,
-                        ) if exhausted_insight.retry_after_sec else None
-                        if reset_text:
-                            warning_user_message = msg_warning_last_msg_reset(reset_text)
+                        req_candidates = [rem.get(k) for k in ("requests_per_day", "requests_per_month", "total_requests") if rem.get(k) is not None]
+                        request_remaining = min(req_candidates) if req_candidates else None
+                        request_exhausted = request_remaining is not None and request_remaining <= 0
+                        if (not request_exhausted) and pr_tok is not None and pr_tok > 0:
+                            # Token budget is the binding constraint and a sub-turn remainder is
+                            # left (requests still available): surface the token balance instead of
+                            # a bare "last message". Without this the low-tokens message is
+                            # unreachable — messages_remaining is always 0 once the spendable token
+                            # balance drops below one turn's estimate (total_token_remaining < est).
+                            warning_user_message = msg_warning_low_tokens(max(int(pr_tok) // 1000, 1))
                         else:
-                            warning_user_message = MSG_WARNING_LAST_MSG_SOON
+                            # Synthesize the exhausted dimension so _format_reset_time can produce a specific time
+                            exhausted = []
+                            if rem.get("requests_per_day") == 0 and getattr(effective_policy, "requests_per_day", None) is not None:
+                                exhausted.append("requests_per_day")
+                            if rem.get("requests_per_month") == 0 and getattr(effective_policy, "requests_per_month", None) is not None:
+                                exhausted.append("requests_per_month")
+                            if rem.get("tokens_per_hour") == 0 and getattr(effective_policy, "tokens_per_hour", None) is not None:
+                                exhausted.append("tokens_per_hour")
+                            if rem.get("tokens_per_day") == 0 and getattr(effective_policy, "tokens_per_day", None) is not None:
+                                exhausted.append("tokens_per_day")
+                            exhausted_insight = compute_quota_insight(
+                                policy=effective_policy,
+                                snapshot=post_run_snapshot,
+                                reason="|".join(exhausted) if exhausted else None,
+                                used_plan_override=admit.used_plan_override if admit else False,
+                                user_budget_tokens=user_budget_tokens,
+                                est_tokens_per_turn=est_turn_tokens,
+                            )
+                            reset_text = _format_reset_time(
+                                retry_after_sec=exhausted_insight.retry_after_sec,
+                                now=now,
+                                user_timezone=getattr(self.comm_context.user, "timezone", None) if self.comm_context and self.comm_context.user else None,
+                            ) if exhausted_insight.retry_after_sec else None
+                            if reset_text:
+                                warning_user_message = msg_warning_last_msg_reset(reset_text)
+                            else:
+                                warning_user_message = MSG_WARNING_LAST_MSG_SOON
                     elif pr_mr is not None and pr_mr == 1:
                         # Check if the binding constraint is requests or tokens
                         rem = post_insight.remaining

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
@@ -1775,237 +1775,115 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                     violations.append("tokens_per_month")
                 return violations
 
-            post_run_snapshot = None
-            post_run_violations = []
-            plan_settlement_allocation = None
-            plan_quota_commit_tokens = int(ranked_tokens) if lane == "plan" else 0
-            project_absorption_tokens = 0
-            project_absorption_usd = 0.0
+            # ---- post-run settlement: delegate the money core to funding_flow ----
+            # All lanes (plan project/subscription, paid wallet/subscription, bypass)
+            # settle through the shared funding_flow — single settlement owner. run()
+            # keeps only the observability shell below (charge.split log, underfunded
+            # event, post-run quota snapshot/warning, per-provider analytics).
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.funding_flow import (
+                FundingContext, PlanFundingReservation, settle_plan_funding,
+            )
 
-            def _cost_for_tokens(tokens: int) -> float:
-                if int(tokens or 0) <= 0 or ranked_tokens <= 0 or total_cost <= 0:
-                    return 0.0
-                return float(total_cost) * safe_frac(float(tokens), float(ranked_tokens))
+            # snapshot the pre-commit RL reservation size (funding_flow finalizes it)
+            plan_reserved_tokens_pre = int(plan_reserved_tokens or 0)
 
-            if budget_bypass:
-                plan_covered_tokens = int(ranked_tokens)
-                plan_covered_usd = float(total_cost)
-                overflow_tokens = 0
-                overflow_usd = 0.0
-            elif lane == "paid" and use_subscription_funding:
-                plan_covered_tokens = int(ranked_tokens)
-                plan_covered_usd = float(total_cost)
-                overflow_tokens = 0
-                overflow_usd = 0.0
-            elif lane == "plan":
-                quota_available_tokens: Optional[int] = None
-                quota_reserved_tokens = 0
-                try:
-                    quota_capacity = await self.rl.token_capacity_for_reservation(
-                        bundle_id=rl_bundle_id,
-                        subject_id=self.subj,
-                        policy=effective_policy,
-                        reservation_id=plan_reservation_id if plan_reservation_active else None,
-                        reserved_tokens=int(plan_reserved_tokens or 0) if plan_reservation_active else 0,
-                        now=now,
-                    )
-                    quota_available_tokens = quota_capacity.get("available_tokens")
-                    quota_reserved_tokens = int(quota_capacity.get("own_reserved_tokens") or 0)
-                except Exception as ex:
-                    quota_available_tokens = 0 if plan_reservation_active else int(plan_project_tokens_est or 0)
-                    quota_reserved_tokens = int(plan_reserved_tokens or 0) if plan_reservation_active else 0
-                    _log(
-                        "charge.capacity",
-                        "Failed to read fresh quota capacity; using reservation estimate",
-                        "WARN",
-                        error=str(ex),
-                        quota_available_tokens=quota_available_tokens,
-                        quota_reserved_tokens=quota_reserved_tokens,
-                    )
-
-                primary_funding_available_usd: Optional[float] = 0.0
-                if funding_source == "project":
-                    try:
-                        fresh_project_budget = await self.budget_limiter.get_app_budget_balance()
-                        primary_funding_available_usd = float(fresh_project_budget.get("available_usd") or 0.0)
-                    except Exception as ex:
-                        primary_funding_available_usd = 0.0 if app_reservation_active else float(funding_available_usd or 0.0)
-                        _log(
-                            "charge.capacity",
-                            "Failed to read fresh project budget; using pre-run snapshot",
-                            "WARN",
-                            error=str(ex),
-                            primary_funding_available_usd=primary_funding_available_usd,
-                        )
-                elif funding_source == "subscription" and subscription_budget_limiter:
-                    try:
-                        fresh_subscription_budget = await subscription_budget_limiter.get_subscription_budget_balance()
-                        primary_funding_available_usd = float(fresh_subscription_budget.get("available_usd") or 0.0)
-                    except Exception as ex:
-                        primary_funding_available_usd = 0.0 if app_reservation_active else float(funding_available_usd or 0.0)
-                        _log(
-                            "charge.capacity",
-                            "Failed to read fresh subscription budget; using pre-run snapshot",
-                            "WARN",
-                            error=str(ex),
-                            primary_funding_available_usd=primary_funding_available_usd,
-                        )
-
-                wallet_available_tokens = 0
-                if plan_balance and plan_balance.has_lifetime_budget():
-                    try:
-                        wallet_balance = await self.cp_manager.user_credits_mgr.get_lifetime_balance(
-                            tenant=tenant,
-                            project=project,
-                            user_id=user_id,
-                        )
-                        wallet_available_tokens = int(wallet_balance or 0)
-                    except Exception as ex:
-                        wallet_available_tokens = max(
-                            int(user_budget_tokens or 0)
-                            - (int(personal_reserved_tokens or 0) if personal_reservation_active else 0),
-                            0,
-                        )
-                        _log(
-                            "charge.capacity",
-                            "Failed to read fresh wallet balance; using pre-run snapshot",
-                            "WARN",
-                            error=str(ex),
-                            wallet_available_tokens=wallet_available_tokens,
-                        )
-
-                plan_settlement_allocation = allocate_plan_wallet_settlement(
-                    PlanWalletSettlementInput(
-                        actual_tokens=int(ranked_tokens),
-                        actual_cost_usd=float(total_cost),
-                        quota_available_tokens=quota_available_tokens,
-                        quota_reserved_tokens=int(quota_reserved_tokens),
-                        primary_funding_available_usd=primary_funding_available_usd,
-                        primary_funding_reserved_usd=float(app_reserved_usd or 0.0) if app_reservation_active else 0.0,
-                        primary_funding_reserved_tokens=int(plan_project_tokens_est or 0),
-                        wallet_available_tokens=int(wallet_available_tokens),
-                        wallet_reserved_tokens=int(personal_reserved_tokens or 0) if personal_reservation_active else 0,
-                    )
-                )
-                plan_covered_tokens = int(plan_settlement_allocation.primary_funding_tokens)
-                plan_covered_usd = float(plan_settlement_allocation.primary_funding_usd)
-                overflow_tokens = max(int(ranked_tokens) - int(plan_covered_tokens), 0)
-                overflow_usd = max(float(total_cost) - float(plan_covered_usd), 0.0)
-                project_absorption_tokens = int(plan_settlement_allocation.project_absorption_tokens)
-                project_absorption_usd = float(plan_settlement_allocation.project_absorption_usd)
-                plan_quota_commit_tokens = int(plan_settlement_allocation.quota_tokens)
+            # map run()'s lane/funding onto the shared reservation's funding_source
+            if lane == "paid" and use_subscription_funding:
+                _settle_funding_source = "subscription"
+                _settle_paid_lane = True
+            elif lane == "paid":
+                _settle_funding_source = "wallet"
+                _settle_paid_lane = False
             else:
-                plan_covered_tokens = 0
-                plan_covered_usd = 0.0
-                overflow_tokens = int(ranked_tokens)
-                overflow_usd = float(total_cost)
+                _settle_funding_source = funding_source
+                _settle_paid_lane = False
+
+            _settle_res = PlanFundingReservation(
+                funding_source=_settle_funding_source,
+                budget_bypass=budget_bypass,
+                est_turn_tokens=int(est_turn_tokens),
+                plan_reservation_id=plan_reservation_id,
+                plan_reserved_tokens=int(plan_reserved_tokens or 0),
+                plan_reservation_active=bool(plan_reservation_active),
+                app_reservation_id=app_reservation_id,
+                app_reserved_usd=float(app_reserved_usd or 0.0),
+                app_reservation_active=bool(app_reservation_active),
+                plan_project_tokens_est=int(plan_project_tokens_est or 0),
+                wallet_reservation_id=personal_reservation_id,
+                wallet_reserved_tokens=int(personal_reserved_tokens or 0),
+                wallet_reservation_active=bool(personal_reservation_active),
+                has_wallet=bool(has_wallet),
+                paid_lane=_settle_paid_lane,
+            )
+            _settle_ctx = FundingContext(
+                rl=self.rl,
+                budget_limiter=self.budget_limiter,
+                cp_manager=self.cp_manager,
+                tenant=tenant,
+                project=project,
+                user_id=user_id,
+                subject_id=self.subj,
+                bundle_id=bundle_id,
+                rl_bundle_id=rl_bundle_id,
+                scope_id=turn_id,
+                usd_per_token=usd_per_token,
+                now=plan_admit_now,
+                subscription_limiter=subscription_budget_limiter,
+                log=lambda stage, msg, level="INFO", **kv: _log(stage, msg, level, **kv),
+            )
+            settlement = await settle_plan_funding(
+                _settle_ctx,
+                _settle_res,
+                ranked_tokens=int(ranked_tokens),
+                total_cost_usd=float(total_cost),
+                effective_policy=effective_policy,
+                plan_has_lifetime_budget=bool(plan_balance and plan_balance.has_lifetime_budget()),
+                user_budget_tokens=user_budget_tokens,
+            )
+
+            # funding_flow finalized the RL reservation + lock and committed every hold;
+            # mark run()'s inline handles consumed so the finally-cleanup is a no-op.
+            lock_released = True
+            plan_reservation_active = False
+            plan_reservation_id = None
+            plan_reserved_tokens = 0
+            app_reservation_active = False
+            personal_reservation_active = False
+
+            # settlement result -> the observability vars run() keeps
+            plan_settlement_allocation = settlement.allocation
+            plan_covered_usd = float(settlement.primary_funding_usd)
+            project_absorption_usd = float(settlement.project_absorption_usd)
+            plan_quota_commit_tokens = int(settlement.quota_commit_tokens)
+            wallet_consumed_tokens = int(settlement.wallet_consumed_tokens)
+            user_uncovered_tokens = int(settlement.user_uncovered_tokens)
+            user_uncovered_usd = float(settlement.user_uncovered_usd)
+            extra_project_items = list(settlement.extra_project_items or [])
+            app_spend_usd = float(settlement.primary_funding_usd)
+            user_target_tokens = int(wallet_consumed_tokens) + int(user_uncovered_tokens)
 
             _log(
                 "charge.split",
-                "Computed actual split",
+                "Computed actual split (settled via funding_flow)",
                 ranked_tokens=ranked_tokens,
-                funding_source=funding_source,
-                plan_covered_tokens=plan_covered_tokens,
-                overflow_tokens=overflow_tokens,
-                wallet_tokens=int(plan_settlement_allocation.wallet_tokens) if plan_settlement_allocation else None,
-                project_absorption_tokens=project_absorption_tokens,
-                quota_tokens=plan_quota_commit_tokens if lane == "plan" else None,
-                primary_funding_reserved_tokens=int(plan_project_tokens_est or 0) if lane == "plan" else None,
-                total_cost=total_cost,
+                funding_source=_settle_funding_source,
                 plan_covered_usd=plan_covered_usd,
-                overflow_usd=overflow_usd,
-                wallet_usd=float(plan_settlement_allocation.wallet_usd) if plan_settlement_allocation else None,
                 project_absorption_usd=project_absorption_usd,
+                quota_tokens=plan_quota_commit_tokens if lane == "plan" else None,
+                wallet_tokens=int(plan_settlement_allocation.wallet_tokens) if plan_settlement_allocation else None,
+                wallet_consumed_tokens=wallet_consumed_tokens,
+                user_uncovered_tokens=user_uncovered_tokens,
+                user_uncovered_usd=user_uncovered_usd,
+                total_cost=total_cost,
             )
 
-            if lane == "paid" and use_subscription_funding:
-                user_target_tokens = 0
-            elif lane == "paid":
-                user_target_tokens = int(ranked_tokens)
-            elif plan_settlement_allocation is not None:
-                user_target_tokens = int(plan_settlement_allocation.wallet_tokens)
-            else:
-                user_target_tokens = 0
-
-            if (
-                user_target_tokens > 0
-                and personal_reservation_active
-                and personal_reserved_tokens > 0
-                and int(user_target_tokens) > int(personal_reserved_tokens)
-            ):
-                _log(
-                    "reserve.personal",
-                    "Actual personal spend exceeded reserved amount",
-                    "WARN",
-                    lane=lane,
-                    user_target_tokens=int(user_target_tokens),
-                    personal_reserved_tokens=int(personal_reserved_tokens),
-                    overflow_tokens=int(user_target_tokens) - int(personal_reserved_tokens),
-                )
-
-            user_uncovered_tokens = 0
-            wallet_consumed_tokens = 0
-            if user_target_tokens > 0 and not budget_bypass:
-                remaining_user_target = int(user_target_tokens)
-                if personal_reservation_active and personal_reservation_id and personal_reserved_tokens > 0:
-                    rid = str(personal_reservation_id)
-                    reserved_target = min(int(remaining_user_target), int(personal_reserved_tokens))
-                    try:
-                        reserved_uncovered = await self.cp_manager.user_credits_mgr.commit_reserved_lifetime_tokens(
-                            tenant=tenant,
-                            project=project,
-                            user_id=user_id,
-                            reservation_id=rid,
-                            tokens=int(reserved_target),
-                        )
-                    finally:
-                        personal_reservation_active = False
-                    reserved_consumed = max(int(reserved_target) - int(reserved_uncovered or 0), 0)
-                    wallet_consumed_tokens += int(reserved_consumed)
-                    remaining_user_target = max(int(remaining_user_target) - int(reserved_consumed), 0)
-
-                if remaining_user_target > 0:
-                    user_uncovered_tokens = await self.cp_manager.user_credits_mgr.consume_lifetime_tokens(
-                        tenant=tenant,
-                        project=project,
-                        user_id=user_id,
-                        tokens=int(remaining_user_target),
-                    )
-                    wallet_consumed_tokens += max(int(remaining_user_target) - int(user_uncovered_tokens or 0), 0)
-
-            if personal_reservation_active and user_target_tokens <= 0 and personal_reservation_id:
-                try:
-                    await self.cp_manager.user_credits_mgr.release_lifetime_token_reservation(
-                        tenant=tenant, project=project, user_id=user_id,
-                        reservation_id=personal_reservation_id,
-                        reason="run: no_user_spend",
-                    )
-                finally:
-                    personal_reservation_active = False
-
-            user_uncovered_tokens = int(user_uncovered_tokens or 0)
-            user_uncovered_usd = _cost_for_tokens(user_uncovered_tokens)
-
-            if plan_settlement_allocation is not None and user_uncovered_tokens > 0:
-                extra_quota_room = max(
-                    int(plan_settlement_allocation.quota_capacity_tokens) - int(plan_quota_commit_tokens),
-                    0,
-                )
-                extra_quota_tokens = min(int(user_uncovered_tokens), int(extra_quota_room))
-                if extra_quota_tokens > 0:
-                    plan_quota_commit_tokens += int(extra_quota_tokens)
-                    _log(
-                        "charge.split",
-                        "Wallet shortfall reallocated to remaining plan quota",
-                        extra_quota_tokens=int(extra_quota_tokens),
-                        plan_quota_commit_tokens=int(plan_quota_commit_tokens),
-                    )
-
+            post_run_snapshot = None
+            post_run_violations = []
             if effective_policy and not budget_bypass:
                 post_run_snapshot = _post_run_snapshot(
                     admit_snapshot_pre,
                     ranked=int(plan_quota_commit_tokens) if lane == "plan" else int(ranked_tokens),
-                    reserved=int(plan_reserved_tokens),
+                    reserved=int(plan_reserved_tokens_pre),
                     lane_name=lane,
                 )
                 try:
@@ -2045,136 +1923,13 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                 )
                 _log(
                     "charge.user",
-                    f"User underfunded post-fact; {funding_label} will absorb remainder",
+                    f"User underfunded post-fact; {funding_label} absorbed remainder",
                     "WARN",
                     lane=lane,
                     user_target_tokens=int(user_target_tokens),
                     wallet_consumed_tokens=int(wallet_consumed_tokens),
                     user_uncovered_tokens=int(user_uncovered_tokens),
                     user_uncovered_usd=float(user_uncovered_usd),
-                )
-
-            extra_project_items: list[tuple[float, str]] = []
-
-            if budget_bypass:
-                app_spend_usd = float(total_cost)
-                app_note = "post-run settle: admin bypass"
-            elif lane == "paid" and use_subscription_funding:
-                app_spend_usd = float(plan_covered_usd)
-                app_note = "post-run settle: subscription_cost"
-                if app_reservation_active and app_reserved_usd is not None and float(app_spend_usd) > float(app_reserved_usd):
-                    over = float(app_spend_usd) - float(app_reserved_usd)
-                    app_spend_usd = float(app_reserved_usd)
-                    extra_project_items.append((float(over), "shortfall:subscription_overage"))
-                if user_uncovered_usd > 0:
-                    extra_project_items.append((float(user_uncovered_usd), "shortfall:wallet_subscription"))
-            elif lane == "plan" and funding_source == "subscription":
-                app_spend_usd = float(plan_covered_usd)
-                app_note = "post-run settle: subscription_cost"
-                if project_absorption_usd > 0:
-                    extra_project_items.append((float(project_absorption_usd), "shortfall:subscription_overage"))
-                if user_uncovered_usd > 0:
-                    extra_project_items.append((float(user_uncovered_usd), "shortfall:wallet_subscription"))
-            elif lane == "plan":
-                app_spend_usd = float(plan_covered_usd)
-                app_note = "post-run settle: plan_cost"
-                if project_absorption_usd > 0:
-                    project_absorption_note = "shortfall:wallet_plan" if (has_wallet or int(user_target_tokens or 0) > 0) else "shortfall:free_plan"
-                    extra_project_items.append((float(project_absorption_usd), project_absorption_note))
-                if user_uncovered_usd > 0:
-                    extra_project_items.append((float(user_uncovered_usd), "shortfall:wallet_plan"))
-            else:
-                app_spend_usd = 0.0
-                app_note = "shortfall:wallet_paid"
-                if user_uncovered_usd > 0:
-                    extra_project_items.append((float(user_uncovered_usd), "shortfall:wallet_paid"))
-
-            if app_spend_usd > 0 or (app_reservation_active and app_reservation_id):
-                if not funding_limiter:
-                    await self.budget_limiter.force_project_spend(
-                        spent_usd=float(app_spend_usd),
-                        bundle_id=rl_bundle_id,
-                        provider=None,
-                        request_id=turn_id,
-                        user_id=user_id,
-                        note=f"{app_note}; no_funding_source",
-                    )
-                    _log(
-                        "charge.app",
-                        "Force-deducted project spend (no funding source configured)",
-                        "WARN",
-                        spent_usd=float(app_spend_usd),
-                        plan_covered_usd=float(plan_covered_usd),
-                        user_uncovered_usd=float(user_uncovered_usd),
-                    )
-                elif app_reservation_active and app_reservation_id:
-                    if funding_source == "subscription":
-                        await funding_limiter.commit_reserved_spend(
-                            reservation_id=app_reservation_id,
-                            spent_usd=float(app_spend_usd),
-                            project_budget=self.budget_limiter,
-                        )
-                    else:
-                        await funding_limiter.commit_reserved_spend(
-                            reservation_id=app_reservation_id,
-                            spent_usd=float(app_spend_usd),
-                        )
-                    app_reservation_active = False
-                    _log(
-                        "charge.app",
-                        f"Committed {funding_label} reservation (post-run settle)",
-                        reservation_id=str(app_reservation_id),
-                        spent_usd=float(app_spend_usd),
-                        plan_covered_usd=float(plan_covered_usd),
-                        user_uncovered_usd=float(user_uncovered_usd),
-                    )
-                else:
-                    if funding_source == "project":
-                        await self.budget_limiter.force_project_spend(
-                            spent_usd=float(app_spend_usd),
-                            bundle_id=bundle_id,
-                            provider=None,
-                            request_id=turn_id,
-                            user_id=user_id,
-                            note=app_note,
-                        )
-                    else:
-                        # Subscriptions never go negative. If we get here without a reservation,
-                        # charge the project budget as an overage for auditability.
-                        await self.budget_limiter.force_project_spend(
-                            spent_usd=float(app_spend_usd),
-                            bundle_id=bundle_id,
-                            provider=None,
-                            request_id=turn_id,
-                            user_id=user_id,
-                            note="shortfall:subscription_overage; no_reservation",
-                        )
-                        app_note = "shortfall:subscription_overage; no_reservation"
-                    _log(
-                        "charge.app",
-                        "Force-deducted project spend (no reservation)",
-                        spent_usd=float(app_spend_usd),
-                        plan_covered_usd=float(plan_covered_usd),
-                        user_uncovered_usd=float(user_uncovered_usd),
-                    )
-
-            for extra_spend_usd, extra_note in extra_project_items:
-                if extra_spend_usd <= 0:
-                    continue
-                await self.budget_limiter.force_project_spend(
-                    spent_usd=float(extra_spend_usd),
-                    bundle_id=bundle_id,
-                    provider=None,
-                    request_id=turn_id,
-                    user_id=user_id,
-                    note=extra_note,
-                )
-                _log(
-                    "charge.app",
-                    "Project budget absorbed shortfall",
-                    spent_usd=float(extra_spend_usd),
-                    note=extra_note,
-                    funding_source=funding_source,
                 )
 
             if app_spend_usd > 0 and total_cost > 0:
@@ -2194,51 +1949,6 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                         cost_breakdown=cost_breakdown,
                         now=now,
                     )
-
-            if not lock_released:
-                if lane == "plan":
-                    tokens_to_commit = int(plan_quota_commit_tokens)
-                else:
-                    tokens_to_commit = int(ranked_tokens) if ranked_tokens > 0 else int(plan_covered_tokens)
-                if lane == "plan":
-                    await self.rl.commit_with_reservation(
-                        bundle_id=rl_bundle_id,
-                        subject_id=self.subj,
-                        tokens=tokens_to_commit,
-                        lock_id=lock_id,
-                        reservation_id=plan_reservation_id,
-                        now=plan_admit_now,
-                        inc_request=1,
-                    )
-                    lock_released = True
-                    plan_reservation_active = False
-                    plan_reservation_id = None
-                    plan_reserved_tokens = 0
-                    _log(
-                        "rl.commit",
-                        "RL committed (actual tokens) and lock released (reservation finalized)",
-                        tokens=tokens_to_commit,
-                    )
-                elif lane == "paid":
-                    await self.rl.commit_with_reservation(
-                        bundle_id=rl_bundle_id,
-                        subject_id=self.subj,
-                        tokens=tokens_to_commit,
-                        lock_id=lock_id,
-                        reservation_id=None,
-                        now=plan_admit_now,
-                        inc_request=1,
-                    )
-                    lock_released = True
-                    _log(
-                        "rl.commit",
-                        "RL committed (paid lane)",
-                        tokens=tokens_to_commit,
-                    )
-                else:
-                    await self.rl.release(bundle_id=rl_bundle_id, subject_id=self.subj, lock_id=lock_id)
-                    lock_released = True
-                    _log("rl.release", "RL lock released", lane=lane)
 
             if not post_run_violations and post_run_snapshot and not budget_bypass:
                 post_insight = compute_quota_insight(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
@@ -1882,7 +1882,9 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
             if effective_policy and not budget_bypass:
                 post_run_snapshot = _post_run_snapshot(
                     admit_snapshot_pre,
-                    ranked=int(plan_quota_commit_tokens) if lane == "plan" else int(ranked_tokens),
+                    # paid lane consumes 0 plan token quota (wallet/subscription pays
+                    # at payasyougo) -> the post-run snapshot must not add ranked tokens.
+                    ranked=int(plan_quota_commit_tokens) if lane == "plan" else 0,
                     reserved=int(plan_reserved_tokens_pre),
                     lane_name=lane,
                 )
@@ -1895,7 +1897,7 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
                             limit=getattr(effective_policy, "tokens_per_hour", None),
                             reserved=0,
                         )
-                        commit_tokens_for_snapshot = int(plan_quota_commit_tokens) if lane == "plan" else int(ranked_tokens)
+                        commit_tokens_for_snapshot = int(plan_quota_commit_tokens) if lane == "plan" else 0
                         post_run_snapshot["tok_hour"] = int(tok_h_now or 0) + int(commit_tokens_for_snapshot)
                         if reset_at:
                             post_run_snapshot["tok_hour_reset_at"] = int(reset_at)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_memory.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_memory.py
@@ -3467,7 +3467,9 @@ class MemoryEntrypointMixin:
             scope_id=f"mem_reconcile_{job_id}",
             flow="memory.reconciler",
             estimate=EconomicsEstimate(reservation_usd=self._memory_reconciliation_reservation_usd()),
-            policy=FlowPolicy(enforce_concurrency=False, emit_user_events=False),
+            # Reserving surface -> serialize the admit->reserve window per user with
+            # the distributed quota lock (no-op if redis is unavailable).
+            policy=FlowPolicy(enforce_concurrency=False, emit_user_events=False, enforce_quota_lock=True),
         )
 
     async def _memory_reconciliation_mark_economics_denied(self, job: Dict[str, Any], exc) -> None:


### PR DESCRIPTION
Economics had two parallel implementations of the same money core: the chat
`BaseEntrypointWithEconomics.run()` path and the reusable non-chat `EconomicsGuard`
(memory reconciler, tasks, web.search) each carried their own reserve, settle, and
distributed-quota-lock logic. This PR makes the shared `funding_flow` (plus a new
`quota_lock`) the **single owner** of the money core, so both surfaces fund and
settle through one implementation. 
### What changed

**Settlement → one owner**
- `funding_flow.settle_plan_funding` is now a superset covering every settle case
  `run()` reaches: plan (project/subscription) split, paid (wallet / subscription
  primary), bypass, and the no-funding fallback, plus the wallet two-step
  commit/consume with zero-cost release and the project-absorption shortfall
  charges. `SettlementResult` exposes the wallet intermediates
  (`wallet_consumed_tokens` / `user_uncovered_tokens` / `user_uncovered_usd`) that
  `run()`'s observability needs.
- `run()` deletes its ~460-line inline post-run money core and delegates to
  `settle_plan_funding`, keeping only its observability shell (charge.split log,
  `economics.user_underfunded_absorbed` event, post-run quota snapshot/warning,
  per-provider analytics).

**Reservation → one owner (plan + paid lanes)**
- New `funding_flow.reserve_paid_funding`: non-raising paid-lane reservation
  (subscription-primary, else wallet, with wallet fallback when the subscription
  hold is declined), returning a `ReserveOutcome` with canonical deny kinds.
- `run()`'s ~370-line inline plan-lane and paid-lane reserve now delegate to
  `reserve_plan_funding` / `reserve_paid_funding`; `run()` keeps the quota lock, the
  `rate_limit.lane_switch` SSE events, and the `_econ_fail` denial payloads, mapping
  each outcome onto them.
- `EconomicsGuard._switch_to_paid` routes through `reserve_paid_funding`; the
  redundant `_reserve_paid_subscription` is removed.

**Distributed quota lock → one helper**
- New `economics/quota_lock.py` (`QuotaLock` + `quota_lock_key`): SET-NX acquire
  with a px fallback, compare-and-del release that only drops a lock we still hold,
  and a bounded spin-wait. Both `run()` and the guard use it instead of their own
  copies of the redis mechanics; each caller keeps its own gating and the denial it
  raises on timeout.

**Bug fixes**
- **Paid-lane quota double-count:** wallet- and subscription-paid (paid lane)
  tokens previously consumed plan token quota (visible as a wallet debit *and* a
  free-quota increment). Paid-lane settle now commits 0 plan-quota tokens
  (payasyougo); only the request counts.
- **Warning message — low-tokens unreachable:** `rate_limit.warning` now surfaces
  the token balance ("running low on tokens (~NK remaining)") when the token budget
  is the binding constraint with a sub-turn remainder and requests are still
  available. Previously this message could never fire (messages_remaining is 0 once
  the balance drops below one turn's estimate, collapsing to a misleading "last
  message").
- **Rolling-hour snapshot double-count:** since settle now commits before the
  post-run snapshot reads `_rolling_hour_stats`, `tok_h_now` is already post-commit;
  the old code added the commit again, doubling `tok_hour` and raising false
  "tokens_per_hour exceeded" post-run violations.

**UI**
- `UserBillingDashboard`: the Subscription Balance panel gains a "Reserved" cell
  (backend already exposed `reserved_usd`), so a paid-lane subscription hold is
  shown explicitly instead of only inferable from a drop in Available.
