### PR TITLE
Economics descriptor and deploy-time seeder

### DIFF
--- a/app/ai-app/deployment/docker/all_in_one_kdcube/docker-compose.yaml
+++ b/app/ai-app/deployment/docker/all_in_one_kdcube/docker-compose.yaml
@@ -53,6 +53,9 @@ services:
         required: false
     environment:
       - POSTGRES_HOST=postgres-db
+      - PLATFORM_DESCRIPTORS_DIR=/config
+    volumes:
+      - ${KDCUBE_CONFIG_DIR:-./config}:/config
     depends_on:
       postgres-db:
         condition: service_healthy

--- a/app/ai-app/deployment/docker/custom-ui-managed-infra/docker-compose.yaml
+++ b/app/ai-app/deployment/docker/custom-ui-managed-infra/docker-compose.yaml
@@ -8,6 +8,10 @@ services:
     env_file:
       - path: ${KDCUBE_CONFIG_DIR:-.}/.env.postgres.setup
         required: false
+    environment:
+      - PLATFORM_DESCRIPTORS_DIR=/config
+    volumes:
+      - ${KDCUBE_CONFIG_DIR:-.}:/config
     networks:
       - kdcube-internal
       - kdcube-secrets

--- a/app/ai-app/deployment/docker/local-infra-stack/docker-compose.yaml
+++ b/app/ai-app/deployment/docker/local-infra-stack/docker-compose.yaml
@@ -10,6 +10,9 @@ services:
         required: false
     environment:
       - POSTGRES_HOST=postgres-db
+      - PLATFORM_DESCRIPTORS_DIR=/config
+    volumes:
+      - ${KDCUBE_CONFIG_DIR:-.}:/config
     depends_on:
       postgres-db:
         condition: service_healthy

--- a/app/ai-app/deployment/economics.yaml
+++ b/app/ai-app/deployment/economics.yaml
@@ -1,0 +1,55 @@
+# ---------------------------------------------------------------------------
+# Economics descriptor (per tenant/project).
+#
+# Seeded once after deployment by the postgres-setup job (see
+# ops/deployment/economics). Tenant/project are NOT declared here — they are
+# resolved from settings (TENANT_ID / PROJECT_ID).
+#
+# enforce:
+#   false → seed only what is missing (operator/admin edits are preserved)
+#   true  → realign every listed entity to these defaults (incl. lowering a
+#           field back to null / unlimited)
+#
+# Mandatory quota policies (anonymous / free / payasyougo / admin) and the
+# subscription plans free / admin are always seeded from a built-in baseline
+# even if omitted below; entries here override that baseline per field.
+# budget_policies have no baseline and are seeded only for the keys listed here.
+# ---------------------------------------------------------------------------
+version: 1
+enforce: false
+
+# Reservation floor defaults (USD). Only `chat` is consumed at runtime today.
+# Scalar value: a positive number enables the floor; <= 0 disables it. A bundle
+# overrides via bundles.yaml -> config.economics.reservation.<floor> (a bundle
+# value <= 0 disables the floor for that bundle; omitting it inherits this default).
+reservation:
+  chat: 2.0
+
+# Project budget policy. Only the overdraft limit is seeded; the running
+# balance is NEVER touched here (fund it via the admin UI / app-budget topup).
+# overdraft_limit_usd: null = unlimited overdraft.
+project_budget:
+  overdraft_limit_usd: 0.0
+
+# plan_id -> quota policy. null/omitted dimension = unlimited.
+quota_policies:
+  anonymous:  { max_concurrent: 1,  requests_per_day: 2,   requests_per_month: 60,
+                tokens_per_hour: 150000, tokens_per_day: 1500000, tokens_per_month: 20000000 }
+  free:       { max_concurrent: 2,  requests_per_day: 100, requests_per_month: 30000,
+                tokens_per_hour: 133333, tokens_per_day: 333333,  tokens_per_month: 666666 }
+  payasyougo: { max_concurrent: 4,  requests_per_day: 200, requests_per_month: 6000 }
+  admin:      { max_concurrent: 10 }
+
+# provider -> budget policy (spending limits, USD). null = unlimited dimension.
+budget_policies:
+  anthropic:  { usd_per_hour: 10.0, usd_per_day: 200.0, usd_per_month: 5000.0 }
+  openai:     { usd_per_hour: 5.0,  usd_per_day: 100.0, usd_per_month: 2000.0 }
+  brave:      { usd_per_hour: 1.0,  usd_per_day: 20.0,  usd_per_month: 500.0 }
+  duckduckgo: { usd_per_hour: null, usd_per_day: null,  usd_per_month: null }
+
+# plan_id -> subscription catalog entry.
+# free + admin are baked-in baseline (always seeded; entries here override per
+# field). Any other plan_id is opt-in. provider ∈ {internal, stripe};
+# stripe requires stripe_price_id.
+subscription_plans:
+  free: { provider: internal, monthly_price_cents: 0, active: true }

--- a/app/ai-app/docs/economics/economics-descriptor-README.md
+++ b/app/ai-app/docs/economics/economics-descriptor-README.md
@@ -1,0 +1,226 @@
+---
+id: repo:kdcube-ai-app/app/ai-app/docs/economics/economics-descriptor-README.md
+title: "Economics Descriptor"
+summary: "The per tenant/project economics.yaml descriptor and how it is seeded at deploy time."
+tags: ["economics", "descriptor", "seeding", "deployment"]
+keywords: ["economics.yaml", "seeder", "reservation floor", "quota policies", "budget policies", "subscription plans", "overdraft"]
+see_also:
+  - repo:kdcube-ai-app/app/ai-app/docs/economics/economic-README.md
+  - repo:kdcube-ai-app/app/ai-app/docs/economics/economic-enforcement-engine-README.md
+  - repo:kdcube-ai-app/app/ai-app/docs/service/cicd/descriptors-README.md
+---
+# Economics Descriptor
+
+This document describes the `economics.yaml` descriptor: the per tenant/project
+file that carries the default economics for a project, how it is seeded at deploy
+time, and how the runtime reads and writes it back.
+
+Descriptor sample:
+- [economics.yaml](../../deployment/economics.yaml)
+
+Implementation:
+- Built-in baseline — [defaults.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/defaults.py)
+- Seeder — [economics_seed.py](../../src/kdcube-ai-app/kdcube_ai_app/ops/deployment/economics/economics_seed.py)
+- Runtime write-back — [descriptor.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/descriptor.py)
+- Runtime read — [config_scopes.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py)
+
+## Purpose
+
+The descriptor is a platform-owned file that defines the economics defaults of a
+project — quota policies, provider budget policies, the subscription catalog, the
+project overdraft limit, and the reservation floor. It is:
+
+- **seeded once at deploy time** into the project's economics tables, so a fresh
+  project starts with sane economics without any manual steps;
+- **kept current by runtime write-back**, so changes made while the project runs
+  are not regressed the next time the project is provisioned;
+- **the live source for the reservation floor**, which the runtime reads per
+  turn directly from the file.
+
+The descriptor is **per tenant/project**. Tenant and project are not declared in
+the file — they are resolved from settings (`TENANT_ID` / `PROJECT_ID`).
+
+## File location
+
+The descriptor lives on the shared `/config` mount — a host bind mount in local
+deployments and EFS on AWS ECS. The same file is visible to the chat
+proc (where the runtime reads it) and the postgres-setup job (where it is
+seeded).
+
+The path is resolved, in order:
+
+1. `ECONOMICS_YAML_DESCRIPTOR_PATH` (supports `file://` URIs);
+2. `PLATFORM_DESCRIPTORS_DIR` + `/economics.yaml`;
+3. `/config/economics.yaml` (default).
+
+A missing file is not an error — the seeder still seeds the built-in baseline
+(see below), and the runtime falls back to its defensive defaults.
+
+## Structure
+
+```yaml
+version: 1
+enforce: false
+
+reservation:
+  chat: 2.0
+
+project_budget:
+  overdraft_limit_usd: 0.0
+
+quota_policies:
+  anonymous:  { max_concurrent: 1, requests_per_day: 2,   requests_per_month: 60, ... }
+  free:       { max_concurrent: 2, requests_per_day: 100, requests_per_month: 30000, ... }
+  payasyougo: { max_concurrent: 4, requests_per_day: 200, requests_per_month: 6000 }
+  admin:      { max_concurrent: 10 }
+
+budget_policies:
+  anthropic:  { usd_per_hour: 10.0, usd_per_day: 200.0, usd_per_month: 5000.0 }
+  duckduckgo: { usd_per_hour: null, usd_per_day: null,  usd_per_month: null }
+
+subscription_plans:
+  payasyougo: { provider: internal, monthly_price_cents: 0, active: true }
+```
+
+### `version`
+
+Descriptor schema version. Currently `1`.
+
+### `enforce`
+
+Controls how each listed entity is reconciled into the database:
+
+- `false` — seed only what is missing (`INSERT ... ON CONFLICT DO NOTHING`).
+  Existing rows are left untouched.
+- `true` — realign every listed entity to the descriptor values
+  (`INSERT ... ON CONFLICT DO UPDATE SET ...`), including lowering a field back
+  to `null` / unlimited.
+
+### `reservation`
+
+Reservation floor defaults, in USD, keyed by surface. Only `chat` is consumed
+by the runtime.
+
+The value is a **scalar**:
+
+- a positive number enables the floor;
+- a value `<= 0` disables it (the per-turn estimate falls back to a token-based
+  estimate);
+- omitting a surface means there is no platform default for it.
+
+The reservation section is **not** seeded into any table — it is runtime config
+read straight from the file (see [Runtime reads](#runtime-reads)).
+
+### `project_budget`
+
+Only `overdraft_limit_usd` is seeded (into `tenant_project_budget`):
+
+- a number is the overdraft ceiling in USD;
+- `null` means unlimited overdraft.
+
+The running **balance is never written** by the descriptor; it is funded
+separately.
+
+### `quota_policies`
+
+`plan_id -> quota policy`. Each policy carries `max_concurrent`,
+`requests_per_day`, `requests_per_month`, `total_requests`, `tokens_per_hour`,
+`tokens_per_day`, `tokens_per_month`. An omitted or `null` dimension means
+unlimited for that window. Seeded into `plan_quota_policies`.
+
+### `budget_policies`
+
+`provider -> budget policy`. Spending limits in USD: `usd_per_hour`,
+`usd_per_day`, `usd_per_month`; `null` means unlimited for that window. Seeded
+into `application_budget_policies`.
+
+### `subscription_plans`
+
+`plan_id -> catalog entry`: `provider` (`internal` or `stripe`),
+`monthly_price_cents`, `active`, optional `stripe_price_id` (required when
+`provider: stripe`), optional `metadata`. Seeded into `subscription_plans`.
+
+## Built-in baseline
+
+Some entities are always seeded from a platform-owned baseline
+([defaults.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/defaults.py)),
+even when the descriptor omits them. When the descriptor does list them, its
+fields override the baseline per field.
+
+| Entity | Baseline | Descriptor behaviour |
+|---|---|---|
+| `quota_policies` | `anonymous`, `free`, `payasyougo`, `admin` (`DEFAULT_QUOTA_POLICIES`) | Always seeded; descriptor overrides per field; extra `plan_id`s seeded as-is. |
+| `subscription_plans` | `free`, `admin` — internal, `monthly_price_cents: 0`, `active: true` (`DEFAULT_SUBSCRIPTION_PLANS`) | Always seeded; descriptor overrides per field; extra `plan_id`s seeded as-is. |
+| `budget_policies` | none | Opt-in; seeded only for the providers listed. |
+
+The four baseline quota plans (`anonymous` / `free` / `payasyougo` / `admin`)
+are intrinsic to the runtime plan-resolution logic, so they must always exist.
+
+## Seeding
+
+The seeder
+([economics_seed.py](../../src/kdcube-ai-app/kdcube_ai_app/ops/deployment/economics/economics_seed.py))
+runs in the **postgres-setup** job, which already provisions the project schema.
+It is invoked from
+[deploy_project.py](../../src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/deploy_project.py)
+after `step_provision`, and is **non-fatal**: a seeding failure logs a warning
+but does not fail the deployment.
+
+It is plain `psycopg2` raw SQL (the postgres-setup image ships only
+`psycopg2-binary` and `PyYAML`), separate from the schema deployment. Single
+responsibility: write data rows after the schema exists.
+
+Behaviour:
+
+- Loads `economics.yaml` (resolving the path as above); a missing file means
+  baseline-only seeding.
+- Reconciles **per entity** — there is no global early-return gate. `enforce`
+  decides `DO NOTHING` vs `DO UPDATE SET` for every entity.
+- Writes:
+  - `plan_quota_policies` — baseline four + descriptor entries/extras;
+  - `subscription_plans` — baseline `free`/`admin` + descriptor entries/extras;
+  - `application_budget_policies` — descriptor providers only;
+  - `tenant_project_budget` — `overdraft_limit_cents` only (balance untouched).
+- Idempotent: re-running with `enforce: false` is a no-op for existing rows.
+
+## Runtime reads
+
+Only the **reservation** section is read by the runtime from the file; quota,
+budget, and subscription state are read from the economics tables each turn.
+
+`config_scopes.economics_reservation_default(floor)` reads `reservation.<floor>`
+from the file. The reader is cached by file **mtime**, so edits (including
+write-backs) are picked up without a restart, and they propagate to every proc
+replica over the shared mount.
+
+Per-turn resolution in the economics entrypoint
+([entrypoint_with_economic.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py)):
+
+1. the bundle prop `economics.reservation.<floor>` (legacy scalar
+   `economics.reservation_amount_dollars` is also accepted) — a positive value
+   enables the floor, `<= 0` disables it;
+2. if the bundle does not set it, the platform default from the descriptor.
+
+A bundle value therefore overrides the descriptor default; the descriptor is the
+default used when the bundle is silent.
+
+## Runtime write-back
+
+When a project's economics change while it runs, `economics.yaml` is rewritten
+from the live database state
+([descriptor.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/descriptor.py)).
+This keeps the file current so the next deploy-time seed does not regress the
+change.
+
+- Rebuilds `quota_policies`, `budget_policies`, `subscription_plans`, and
+  `project_budget.overdraft_limit_usd` from the database; **preserves/merges**
+  the `reservation` section (which is never stored in the database).
+- Writes atomically (temp file + `os.replace`) under an exclusive `flock`, so
+  concurrent writes do not lose the reservation section.
+- Best-effort: a write failure logs a warning and never fails the originating
+  operation.
+
+## Staging
+
+The installer stages a copy of the descriptor from `deployment/economics.yaml`
+into the project config directory when one is not already present.

--- a/app/ai-app/docs/service/cicd/cli-README.md
+++ b/app/ai-app/docs/service/cicd/cli-README.md
@@ -433,7 +433,7 @@ Behaviour:
 - rebuilds platform Docker images when `--build` is given;
 - restarts the stack (unless `--no-restart` is passed);
 - never modifies `assembly.yaml`, `secrets.yaml`, `bundles.yaml`,
-  `bundles.secrets.yaml`, or `gateway.yaml`.
+  `bundles.secrets.yaml`, `gateway.yaml`, or `economics.yaml`.
 
 This replaces the older pattern of re-running `kdcube init` on an existing
 workdir, which used to silently reseed descriptors under some flag
@@ -500,8 +500,8 @@ kdcube bundle config apply \
 This is a user/operator descriptor-sync workflow, not a platform refresh and
 not routine agent bootstrap. It stages only `bundles.yaml` and optional
 `bundles.secrets.yaml` into the active runtime config directory. It does not
-touch `assembly.yaml`, `gateway.yaml`, or platform `secrets.yaml`, and it does
-not rebuild images or restart Docker.
+touch `assembly.yaml`, `gateway.yaml`, platform `secrets.yaml`, or
+`economics.yaml`, and it does not rebuild images or restart Docker.
 
 Host local bundle paths in seed descriptors are translated to runtime-visible
 `/bundles/...` paths before staging. With `--reload`, changed declared bundle
@@ -534,7 +534,9 @@ kdcube config import \
 ```
 
 With `--include-platform-descriptors`, export writes `assembly.yaml`,
-`secrets.yaml`, `gateway.yaml`, `bundles.yaml`, and `bundles.secrets.yaml`.
+`secrets.yaml`, `gateway.yaml`, `economics.yaml`, `bundles.yaml`, and
+`bundles.secrets.yaml`. For what `economics.yaml` owns, see
+[economics-descriptor-README.md](../../economics/economics-descriptor-README.md).
 
 Exported descriptors are shaped for review and re-seeding, not as a byte-for-byte
 copy of the container runtime files:

--- a/app/ai-app/docs/service/cicd/descriptors-README.md
+++ b/app/ai-app/docs/service/cicd/descriptors-README.md
@@ -14,6 +14,7 @@ see_also:
   - repo:kdcube-ai-app/app/ai-app/docs/configuration/secrets-descriptor-README.md
   - repo:kdcube-ai-app/app/ai-app/docs/configuration/gateway-descriptor-README.md
   - repo:kdcube-ai-app/app/ai-app/docs/configuration/service-runtime-configuration-mapping-README.md
+  - repo:kdcube-ai-app/app/ai-app/docs/economics/economics-descriptor-README.md
 ---
 # Descriptors
 
@@ -24,6 +25,7 @@ These are the supported deployment descriptors:
 - `bundles.secrets.yaml`
 - `secrets.yaml`
 - `gateway.yaml`
+- `economics.yaml`
 
 Descriptor documentation lives in `docs/configuration/`, one page per
 descriptor. Each page now includes:
@@ -47,6 +49,7 @@ Descriptor pages:
 - [bundles-secrets-descriptor-README.md](../../configuration/bundles-secrets-descriptor-README.md)
 - [secrets-descriptor-README.md](../../configuration/secrets-descriptor-README.md)
 - [gateway-descriptor-README.md](../../configuration/gateway-descriptor-README.md)
+- [economics-descriptor-README.md](../../economics/economics-descriptor-README.md)
 
 This page explains the part that differs by run mode: what the descriptors mean,
 which files are authoritative, and which `assembly.yaml` sections matter.
@@ -153,6 +156,7 @@ Typical use:
 | `bundles.secrets.yaml` | file authority only in `secrets-file` mode | file authority only in `secrets-file` mode | export/import format; in `aws-sm` live bundle secrets authority is grouped AWS SM docs |
 | `secrets.yaml` | file authority only in `secrets-file` mode; otherwise installer input | file authority only in `secrets-file` mode | deployment input; actual live authority depends on provider |
 | `gateway.yaml` | staged and rendered into runtime gateway config | pointed to explicitly if the process should load/render it | deployment input rendered into runtime config |
+| `economics.yaml` | staged into `workdir/config/economics.yaml`; seeded into the project economics tables and runtime-readable | pointed to by `ECONOMICS_YAML_DESCRIPTOR_PATH` | deployment input on EFS `/config`; seeded and runtime-readable |
 
 ## Rules that should stay stable
 
@@ -161,6 +165,8 @@ Typical use:
 - `bundles.secrets.yaml` is for bundle secrets
 - `secrets.yaml` is for platform/global secrets
 - `gateway.yaml` is for gateway config only
+- `economics.yaml` is for per tenant/project economics defaults (seeded into the
+  economics tables; reservation floor read at runtime)
 - local host paths belong only to local run modes
 - do not copy local `assembly.paths.*` values into AWS descriptors
 
@@ -188,5 +194,6 @@ provider. See [Bundle Session Auth](../auth/bundle-session-auth-README.md).
   - [bundles-secrets-descriptor-README.md](../../configuration/bundles-secrets-descriptor-README.md)
   - [secrets-descriptor-README.md](../../configuration/secrets-descriptor-README.md)
   - [gateway-descriptor-README.md](../../configuration/gateway-descriptor-README.md)
+  - [economics-descriptor-README.md](../../economics/economics-descriptor-README.md)
 - Runtime env and descriptor mapping:
   - [service-runtime-configuration-mapping-README.md](../../configuration/service-runtime-configuration-mapping-README.md)

--- a/app/ai-app/docs/service/cicd/design/cli--as-control-plane-README.md
+++ b/app/ai-app/docs/service/cicd/design/cli--as-control-plane-README.md
@@ -189,7 +189,7 @@ kdcube refresh \
 ```
 
 `refresh` never modifies `assembly.yaml`, `secrets.yaml`, `bundles.yaml`,
-`bundles.secrets.yaml`, or `gateway.yaml`. When no targeting flags are given
+`bundles.secrets.yaml`, `gateway.yaml`, or `economics.yaml`. When no targeting flags are given
 and no defaults are set, refresh targets the currently-recorded running
 deployment. `--latest`, `--upstream`, and `--release <ref>` reuse the existing
 runtime descriptors but select a new platform source before rebuild/restart.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/EconomicsDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/EconomicsDashboard.tsx
@@ -99,6 +99,10 @@ interface AppBudgetBalance {
     balance_usd: number;
     lifetime_added_usd: number;
     lifetime_spent_usd: number;
+    available_usd?: number | null;
+    reserved_usd?: number | null;
+    overdraft_limit_usd?: number | null;
+    overdraft_used_usd?: number | null;
 }
 
 interface AppBudgetSpending {
@@ -744,6 +748,31 @@ class EconomicsAPI {
 
     async listQuotaPolicies(): Promise<{ status: string; count: number; policies: QuotaPolicy[] }> {
         const response = await this.fetchWithAuth(this.getFullUrl('/policies/quota'));
+        return response.json();
+    }
+
+    async getReservation(): Promise<{ status: string; reservation: Record<string, number> }> {
+        const response = await this.fetchWithAuth(this.getFullUrl('/economics/reservation'));
+        return response.json();
+    }
+
+    async setReservation(floor: string, amount: number): Promise<any> {
+        const response = await this.fetchWithAuth(
+            this.getFullUrl('/economics/reservation'),
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ floor, amount }),
+            },
+        );
+        return response.json();
+    }
+
+    async deleteReservation(floor: string): Promise<any> {
+        const response = await this.fetchWithAuth(
+            this.getFullUrl(`/economics/reservation/${encodeURIComponent(floor)}`),
+            { method: 'DELETE' },
+        );
         return response.json();
     }
 
@@ -1638,6 +1667,9 @@ const EconomicsAdmin: React.FC = () => {
     const [quotaPolicies, setQuotaPolicies] = useState<QuotaPolicy[]>([]);
     const [budgetPolicies, setBudgetPolicies] = useState<BudgetPolicy[]>([]);
     const [appBudget, setAppBudget] = useState<AppBudget | null>(null);
+    const [reservation, setReservation] = useState<Record<string, number>>({});
+    const [reservationFloor, setReservationFloor] = useState<string>('chat');
+    const [reservationAmount, setReservationAmount] = useState<string>('');
 
     // Forms - Grant Trial
     const [trialUserId, setTrialUserId] = useState<string>('');
@@ -1830,7 +1862,7 @@ const EconomicsAdmin: React.FC = () => {
     }, [api, configStatus]);
 
     const loadDataForView = async (mode: string) => {
-        const needsData = ['quotaPolicies', 'budgetPolicies', 'appBudget', 'subscriptions'].includes(mode);
+        const needsData = ['quotaPolicies', 'budgetPolicies', 'appBudget', 'subscriptions', 'reservation'].includes(mode);
         if (!needsData) return;
 
         setLoadingData(true);
@@ -1846,6 +1878,9 @@ const EconomicsAdmin: React.FC = () => {
             } else if (mode === 'appBudget') {
                 const balance = await api.getAppBudgetBalance();
                 setAppBudget(balance);
+            } else if (mode === 'reservation') {
+                const res = await api.getReservation();
+                setReservation(res.reservation || {});
             } else if (mode === 'subscriptions') {
                 const res = await api.listSubscriptionPlans({ limit: 200, offset: 0, activeOnly: false });
                 setSubscriptionPlans(res.plans || []);
@@ -2020,6 +2055,48 @@ const EconomicsAdmin: React.FC = () => {
             setPolicyNotes('');
 
             await loadDataForView('quotaPolicies');
+        } catch (err) {
+            setError((err as Error).message);
+        } finally {
+            setLoadingAction(false);
+        }
+    };
+
+    const handleSetReservation = async (e: React.FormEvent) => {
+        e.preventDefault();
+        clearMessages();
+        setLoadingAction(true);
+        try {
+            const floor = (reservationFloor || 'chat').trim() || 'chat';
+            const amount = parseFloat(reservationAmount);
+            if (Number.isNaN(amount)) {
+                throw new Error('Enter a numeric reservation amount (USD). Use <= 0 to disable the floor.');
+            }
+            const res = await api.setReservation(floor, amount);
+            setReservation(res.reservation || {});
+            setReservationAmount('');
+            setSuccess(
+                amount > 0
+                    ? `Reservation floor for ${floor} set to $${amount.toFixed(2)}`
+                    : `Reservation floor for ${floor} disabled`,
+            );
+        } catch (err) {
+            setError((err as Error).message);
+        } finally {
+            setLoadingAction(false);
+        }
+    };
+
+    const handleDeleteReservation = async (floor: string) => {
+        if (!window.confirm(`Remove the "${floor}" reservation floor? The surface will inherit the platform/bundle default.`)) {
+            return;
+        }
+        clearMessages();
+        setLoadingAction(true);
+        try {
+            const res = await api.deleteReservation(floor);
+            setReservation(res.reservation || {});
+            setSuccess(`Reservation floor "${floor}" removed.`);
         } catch (err) {
             setError((err as Error).message);
         } finally {
@@ -2520,6 +2597,7 @@ const EconomicsAdmin: React.FC = () => {
         { id: 'lookup', label: 'Lookup Balance' },
         { id: 'quotaBreakdown', label: 'User Budget Breakdown' },
         { id: 'quotaPolicies', label: 'Plan Limits' },
+        { id: 'reservation', label: 'Reservation Floors' },
         { id: 'budgetPolicies', label: 'Project Budget Policies' },
         { id: 'lifetimeCredits', label: 'Lifetime Credits' },
         { id: 'appBudget', label: 'App Budget' },
@@ -3412,10 +3490,10 @@ const EconomicsAdmin: React.FC = () => {
                                     <Callout tone="neutral" title="Meaning">
                                         This is the default quota envelope for a plan (free/payasyougo/admin). Daily is calendar day, hourly is a rolling 60‑minute window, and monthly is a rolling 30‑day window (anchored to first usage per bundle).
                                     </Callout>
-                                    <Callout tone="neutral" title="Reservation Floor (Per Bundle)">
-                                        The minimum reservation amount is configured per bundle via bundle props:
-                                        <span className="font-mono"> economics.reservation_amount_dollars</span>.
-                                        This is not set in the economics UI.
+                                    <Callout tone="neutral" title="Reservation Floor">
+                                        The platform reservation floor is set in the <span className="font-semibold">Reservation Floors</span> tab
+                                        (stored in the economics descriptor, picked up live). A bundle can still override per surface via
+                                        bundle props <span className="font-mono"> economics.reservation.&lt;floor&gt;</span>.
                                     </Callout>
                                     {economicsRef && (
                                         <div className="text-xs text-gray-500">
@@ -3589,6 +3667,7 @@ const EconomicsAdmin: React.FC = () => {
                                                     <th className="px-6 py-4 text-left font-semibold">Plan ID</th>
                                                     <th className="px-6 py-4 text-right font-semibold">Max concurrent</th>
                                                     <th className="px-6 py-4 text-right font-semibold">Req/day</th>
+                                                    <th className="px-6 py-4 text-right font-semibold">Req/month</th>
                                                     <th className="px-6 py-4 text-right font-semibold">Tok/hour</th>
                                                     <th className="px-6 py-4 text-right font-semibold">Tok/day</th>
                                                     <th className="px-6 py-4 text-right font-semibold">Tok/month</th>
@@ -3604,6 +3683,7 @@ const EconomicsAdmin: React.FC = () => {
                                                         <td className="px-6 py-4 font-semibold text-gray-900">{policy.plan_id}</td>
                                                         <td className="px-6 py-4 text-right text-gray-700">{policy.max_concurrent ?? '—'}</td>
                                                         <td className="px-6 py-4 text-right text-gray-700">{policy.requests_per_day ?? '—'}</td>
+                                                        <td className="px-6 py-4 text-right text-gray-700">{policy.requests_per_month ?? '—'}</td>
                                                         <td className="px-6 py-4 text-right text-gray-700">{policy.tokens_per_hour?.toLocaleString() ?? '—'}</td>
                                                         <td className="px-6 py-4 text-right text-gray-700">{policy.tokens_per_day?.toLocaleString() ?? '—'}</td>
                                                         <td className="px-6 py-4 text-right text-gray-700">{policy.tokens_per_month?.toLocaleString() ?? '—'}</td>
@@ -3626,6 +3706,94 @@ const EconomicsAdmin: React.FC = () => {
                                     {quotaPolicies.length > 0 && quotaPolicies[0].reference_model && (
                                         <div className="pt-3 text-xs text-gray-500">
                                             Reference: {quotaPolicies[0].reference_model}
+                                        </div>
+                                    )}
+                                </CardBody>
+                            </Card>
+                        </div>
+                    )}
+
+                    {viewMode === 'reservation' && (
+                        <div className="space-y-6">
+                            <Card>
+                                <CardHeader
+                                    title="Reservation Floors"
+                                    subtitle="Platform default per-turn reservation floor (USD). Read live by bundles each turn."
+                                />
+                                <CardBody className="space-y-6">
+                                    <Callout tone="neutral" title="Meaning">
+                                        The reservation floor is the minimum USD reserved before a turn runs. It is stored in the
+                                        economics descriptor (not the database) and is picked up live by running bundles. A value of
+                                        <span className="font-mono"> 0 or less disables</span> the floor (estimate falls back to tokens).
+                                        A bundle can override per surface via bundle props
+                                        <span className="font-mono"> economics.reservation.&lt;floor&gt;</span>; omitting it inherits this default.
+                                        Only <span className="font-mono">chat</span> is consumed today.
+                                    </Callout>
+
+                                    <form onSubmit={handleSetReservation} className="space-y-5">
+                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                            <Input
+                                                label="Surface"
+                                                value={reservationFloor}
+                                                onChange={(e) => setReservationFloor(e.target.value)}
+                                                placeholder="chat"
+                                            />
+                                            <Input
+                                                label="Amount (USD)  •  ≤ 0 disables"
+                                                type="number"
+                                                value={reservationAmount}
+                                                onChange={(e) => setReservationAmount(e.target.value)}
+                                                placeholder="2.0"
+                                            />
+                                        </div>
+                                        <Button type="submit" disabled={loadingAction}>
+                                            Save reservation floor
+                                        </Button>
+                                    </form>
+                                </CardBody>
+                            </Card>
+
+                            <Card>
+                                <CardHeader title="Current floors" subtitle={`${Object.keys(reservation).length} surface(s)`} />
+                                <CardBody>
+                                    {loadingData ? (
+                                        <LoadingSpinner />
+                                    ) : Object.keys(reservation).length === 0 ? (
+                                        <EmptyState message="No reservation floors configured." icon="🪙" />
+                                    ) : (
+                                        <div className="overflow-x-auto">
+                                            <table className="w-full text-sm">
+                                                <thead className="bg-gray-50 border-b border-gray-200/70">
+                                                <tr className="text-gray-600">
+                                                    <th className="px-6 py-4 text-left font-semibold">Surface</th>
+                                                    <th className="px-6 py-4 text-right font-semibold">Floor (USD)</th>
+                                                    <th className="px-6 py-4 text-left font-semibold">State</th>
+                                                    <th className="px-6 py-4 text-right font-semibold">Actions</th>
+                                                </tr>
+                                                </thead>
+                                                <tbody className="divide-y divide-gray-200/70">
+                                                {Object.entries(reservation).map(([floor, amount]) => (
+                                                    <tr key={floor} className="hover:bg-gray-50/70 transition-colors">
+                                                        <td className="px-6 py-4 font-semibold text-gray-900">{floor}</td>
+                                                        <td className="px-6 py-4 text-right text-gray-700">
+                                                            {Number(amount) > 0 ? `$${Number(amount).toFixed(2)}` : '—'}
+                                                        </td>
+                                                        <td className="px-6 py-4 text-gray-600">
+                                                            {Number(amount) > 0 ? 'enabled' : 'disabled'}
+                                                        </td>
+                                                        <td className="px-6 py-4 text-right">
+                                                            <Button
+                                                                variant="danger"
+                                                                onClick={() => handleDeleteReservation(floor)}
+                                                                disabled={loadingAction}
+                                                            >
+                                                                Remove
+                                                            </Button>
+                                                        </td>
+                                                    </tr>
+                                                ))}
+                                                </tbody>
+                                            </table>
                                         </div>
                                     )}
                                 </CardBody>
@@ -3882,6 +4050,15 @@ const EconomicsAdmin: React.FC = () => {
                                                 <StatCard label="Current balance" value={`$${Number(appBudget.balance.balance_usd || 0).toFixed(2)}`} />
                                                 <StatCard label="Lifetime added" value={`$${Number(appBudget.balance.lifetime_added_usd || 0).toFixed(2)}`} />
                                                 <StatCard label="Lifetime spent" value={`$${Number(appBudget.balance.lifetime_spent_usd || 0).toFixed(2)}`} />
+                                                <StatCard
+                                                    label="Overdraft limit"
+                                                    value={appBudget.balance.overdraft_limit_usd == null
+                                                        ? 'Unlimited'
+                                                        : `$${Number(appBudget.balance.overdraft_limit_usd).toFixed(2)}`}
+                                                />
+                                                {appBudget.balance.available_usd != null && (
+                                                    <StatCard label="Available" value={`$${Number(appBudget.balance.available_usd).toFixed(2)}`} />
+                                                )}
                                             </div>
 
                                             <div className="rounded-2xl border border-gray-200/70 bg-gray-50 p-5">
@@ -5269,7 +5446,7 @@ Shortfall ledger notes:
                         </div>
                     )}
                     {/* Data lists loading indicator (global hint) */}
-                    {(viewMode === 'quotaPolicies' || viewMode === 'budgetPolicies' || viewMode === 'appBudget') && loadingData && (
+                    {(viewMode === 'quotaPolicies' || viewMode === 'budgetPolicies' || viewMode === 'appBudget' || viewMode === 'reservation') && loadingData && (
                         <div className="text-center text-sm text-gray-500">Loading…</div>
                     )}
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/control_plane.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/control_plane.py
@@ -303,6 +303,12 @@ class TopUpAppBudgetRequest(BaseModel):
     notes: Optional[str] = Field(None)
 
 
+class SetReservationRequest(BaseModel):
+    """Set a reservation floor (USD) for a surface. amount <= 0 disables the floor."""
+    floor: str = Field("chat", description="Reservation surface (only 'chat' today)")
+    amount: float = Field(..., description="USD floor; <= 0 disables the floor")
+
+
 # ============================================================================
 # Helper Functions
 # ============================================================================
@@ -334,6 +340,19 @@ def _get_control_plane_manager(ctx):
     # Cache on router state
     ctx.state.control_plane_manager = mgr
     return mgr
+
+
+async def _sync_economics_descriptor_best_effort(mgr, settings) -> None:
+    """
+    Mirror live economics (DB) into economics.yaml after an admin mutation, so a
+    later deploy-time re-seed does not regress runtime changes. Best-effort: the
+    descriptor sync never fails the admin request.
+    """
+    try:
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import sync_economics_descriptor
+        await sync_economics_descriptor(mgr, tenant=settings.TENANT, project=settings.PROJECT)
+    except Exception as e:
+        logger.warning(f"[economics.descriptor] write-back skipped: {e}")
 
 
 # ============================================================================
@@ -829,6 +848,7 @@ async def upsert_subscription_plan(
         created_by=session.username or session.user_id,
         notes=payload.notes,
     )
+    await _sync_economics_descriptor_best_effort(mgr, settings)
     return {"status": "ok", "plan": plan.__dict__}
 
 @router.get("/subscriptions/periods/{user_id}")
@@ -1348,6 +1368,7 @@ async def set_quota_policy(
             f"[set_quota_policy] {settings.TENANT}/{settings.PROJECT}/{payload.plan_id}: "
             f"policy updated by {session.username or session.user_id}"
         )
+        await _sync_economics_descriptor_best_effort(mgr, settings)
 
         return {
             "status": "ok",
@@ -1441,6 +1462,7 @@ async def set_budget_policy(
             f"[set_budget_policy] {settings.TENANT}/{settings.PROJECT}/{payload.provider}: "
             f"policy updated by {session.username or session.user_id}"
         )
+        await _sync_economics_descriptor_best_effort(mgr, settings)
 
         return {
             "status": "ok",
@@ -1452,6 +1474,92 @@ async def set_budget_policy(
         }
     except Exception as e:
         logger.exception(f"[set_budget_policy] Failed for {payload.provider}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ============================================================================
+# Reservation surfaces (descriptor-backed; live runtime source)
+# ============================================================================
+
+@router.get("/economics/reservation")
+async def get_reservation_surfaces(
+        session: UserSession = Depends(auth_without_pressure())
+):
+    """
+    Current reservation floors (USD) from the economics descriptor. These are
+    read live by the runtime per turn; a value <= 0 disables the floor.
+    """
+    from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import read_reservation
+    return {"status": "ok", "reservation": read_reservation()}
+
+
+@router.post("/economics/reservation", status_code=201)
+async def set_reservation_surface(
+        payload: SetReservationRequest,
+        session: UserSession = Depends(auth_without_pressure())
+):
+    """
+    Set a reservation floor and write it straight into the economics descriptor
+    so bundles pick it up live (and a re-seed does not regress it).
+    """
+    try:
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import (
+            sync_economics_descriptor, read_reservation,
+        )
+        mgr = _get_control_plane_manager(router)
+        settings = get_settings()
+        floor = (payload.floor or "chat").strip() or "chat"
+        ok = await sync_economics_descriptor(
+            mgr, tenant=settings.TENANT, project=settings.PROJECT,
+            reservation_overrides={floor: float(payload.amount)},
+        )
+        if not ok:
+            raise HTTPException(status_code=500, detail="Failed to write economics descriptor")
+        logger.info(
+            f"[set_reservation] {settings.TENANT}/{settings.PROJECT} {floor}={payload.amount} "
+            f"by {session.username or session.user_id}"
+        )
+        return {"status": "ok", "reservation": read_reservation()}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("[set_reservation] Failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/economics/reservation/{floor}")
+async def delete_reservation_surface(
+        floor: str,
+        session: UserSession = Depends(auth_without_pressure())
+):
+    """
+    Remove a reservation floor from the economics descriptor entirely. The
+    surface then inherits the platform/bundle default (instead of being pinned).
+    """
+    try:
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import (
+            sync_economics_descriptor, read_reservation,
+        )
+        mgr = _get_control_plane_manager(router)
+        settings = get_settings()
+        floor = (floor or "").strip()
+        if not floor:
+            raise HTTPException(status_code=400, detail="Reservation floor is required")
+        ok = await sync_economics_descriptor(
+            mgr, tenant=settings.TENANT, project=settings.PROJECT,
+            reservation_deletes=[floor],
+        )
+        if not ok:
+            raise HTTPException(status_code=500, detail="Failed to write economics descriptor")
+        logger.info(
+            f"[delete_reservation] {settings.TENANT}/{settings.PROJECT} {floor} "
+            f"by {session.username or session.user_id}"
+        )
+        return {"status": "ok", "reservation": read_reservation()}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("[delete_reservation] Failed")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py
@@ -122,6 +122,39 @@ def _load_assembly_plain(dotted_path: str) -> Any:
     )
 
 
+def _load_economics_plain(dotted_path: str) -> Any:
+    return _resolve_dotted_value(
+        _load_plain_yaml(
+            _descriptor_path(
+                env_name="ECONOMICS_YAML_DESCRIPTOR_PATH",
+                filename="economics.yaml",
+                default="/config/economics.yaml",
+            )
+        ),
+        dotted_path,
+    )
+
+
+def economics_reservation_default(floor: str = "chat") -> float | None:
+    """
+    Platform reservation floor default (USD) from economics.yaml. Cached by file
+    mtime (via _load_plain_yaml), so descriptor edits are picked up without a
+    restart.
+
+    A scalar is the canonical form (`reservation.<floor>: 2.0`); a `{amount: ...}`
+    mapping is tolerated. Returns the amount only when it is a positive number;
+    a value <= 0, missing, or unparseable means "no floor" (None).
+    """
+    node = _load_economics_plain(f"reservation.{floor}")
+    if isinstance(node, dict):
+        node = node.get("amount")
+    try:
+        amount = float(node) if node is not None else None
+    except (TypeError, ValueError):
+        return None
+    return amount if (amount is not None and amount > 0) else None
+
+
 def _load_global_secret_plain(dotted_path: str) -> Any:
     data = _load_plain_yaml(
         _descriptor_path(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/defaults.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/defaults.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# sdk/infra/economics/defaults.py
+
+"""
+Platform-owned default economics.
+
+These are the mandatory baked-in quota policies for the four plan ids that are
+intrinsic to the runtime plan-resolution logic in the economics entrypoint
+(`anonymous`, `free`, `payasyougo`, `admin`). They are owned by the platform,
+not by any bundle.
+
+Two consumers share this single source of truth:
+  - the deploy-time seeder always seeds these four (descriptor entries override
+    them per field);
+  - the runtime keeps a defensive fallback when a DB policy row is absent.
+
+Subscription plans have a small baked-in baseline too: `free` and `admin` are
+always seeded (descriptor entries override them per field), mirroring the quota
+baseline. Any other subscription plan is descriptor opt-in.
+
+`budget_policies` has NO baked-in baseline: it is descriptor opt-in and
+admin-driven only, so there are no default constants here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import QuotaPolicy
+
+# The four plan ids that the runtime resolves users into. Order is informational.
+MANDATORY_QUOTA_PLAN_IDS = ("anonymous", "free", "payasyougo", "admin")
+
+# Built-in baseline for the mandatory quota plans. A None dimension means
+# "unlimited" for that window.
+DEFAULT_QUOTA_POLICIES: Dict[str, QuotaPolicy] = {
+    "anonymous": QuotaPolicy(
+        max_concurrent=1,
+        requests_per_day=2,
+        requests_per_month=60,
+        total_requests=None,
+        tokens_per_hour=150_000,
+        tokens_per_day=1_500_000,
+        tokens_per_month=20_000_000,
+    ),
+    "free": QuotaPolicy(
+        max_concurrent=2,
+        requests_per_day=100,
+        requests_per_month=30000,
+        total_requests=None,
+        tokens_per_hour=133_333,
+        tokens_per_day=333_333,
+        tokens_per_month=666_666,
+    ),
+    "payasyougo": QuotaPolicy(
+        max_concurrent=4,
+        requests_per_day=200,
+        requests_per_month=6000,
+        total_requests=None,
+    ),
+    "admin": QuotaPolicy(
+        max_concurrent=10,
+    ),
+}
+
+
+def default_quota_policy(plan_id: str) -> QuotaPolicy:
+    """Defensive fallback used by the runtime when a DB policy row is missing."""
+    return (
+        DEFAULT_QUOTA_POLICIES.get(plan_id)
+        or DEFAULT_QUOTA_POLICIES.get("free")
+        or DEFAULT_QUOTA_POLICIES["anonymous"]
+    )
+
+
+# Subscription plan ids that the platform always seeds (descriptor overrides per
+# field). Both are internal, free-of-charge catalog entries by default.
+MANDATORY_SUBSCRIPTION_PLAN_IDS = ("free", "admin")
+
+DEFAULT_SUBSCRIPTION_PLANS: Dict[str, Dict[str, Any]] = {
+    "free": {"provider": "internal", "monthly_price_cents": 0, "active": True},
+    "admin": {"provider": "internal", "monthly_price_cents": 0, "active": True},
+}

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/descriptor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/descriptor.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# apps/chat/sdk/infra/economics/descriptor.py
+
+"""
+Runtime write-back of the economics descriptor (mounted-file authority).
+
+The economics descriptor (`economics.yaml`) lives on the shared, writable
+`/config` mount — a host bind mount locally and EFS on AWS ECS (see
+docs/ops/ecs/ecs-deployment-README.md: "ECS deployment relies on EFS for shared
+mutable state", `/config` is EFS-backed). Both ingress (where admin mutations
+run) and proc (where the runtime reads) see the same file.
+
+Two distinct purposes:
+  - quota / budget / subscription: Postgres is the live runtime authority. The
+    descriptor is only a persistence snapshot so the next deploy-time
+    `seed_economics` does not regress runtime/admin changes.
+  - reservation: the descriptor file IS the live runtime source (read per turn
+    via config_scopes.economics_reservation_default, mtime-cached). Writing the
+    file here lets bundles pick up reservation changes in real time across
+    replicas over the shared mount.
+
+This is best-effort: callers must not fail the admin mutation if the descriptor
+write fails.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+import yaml
+
+from kdcube_ai_app.apps.chat.sdk.config_scopes import _descriptor_path
+
+logger = logging.getLogger(__name__)
+
+_QUOTA_FIELDS = (
+    "max_concurrent",
+    "requests_per_day",
+    "requests_per_month",
+    "total_requests",
+    "tokens_per_hour",
+    "tokens_per_day",
+    "tokens_per_month",
+)
+_BUDGET_FIELDS = ("usd_per_hour", "usd_per_day", "usd_per_month")
+_DEFAULT_RESERVATION = {"chat": 2.0}
+
+
+def _economics_descriptor_path() -> Path:
+    return _descriptor_path(
+        env_name="ECONOMICS_YAML_DESCRIPTOR_PATH",
+        filename="economics.yaml",
+        default="/config/economics.yaml",
+    )
+
+
+def _num(v) -> Optional[float]:
+    return None if v is None else float(v)
+
+
+def read_reservation() -> Dict[str, Any]:
+    """Current reservation surfaces from the descriptor file (for admin display)."""
+    existing = _read_existing(_economics_descriptor_path())
+    reservation = existing.get("reservation")
+    return dict(reservation) if isinstance(reservation, dict) else dict(_DEFAULT_RESERVATION)
+
+
+def _read_existing(path: Path) -> Dict[str, Any]:
+    try:
+        if path.exists():
+            data = yaml.safe_load(path.read_text()) or {}
+            return data if isinstance(data, dict) else {}
+    except Exception as e:
+        logger.warning("[economics.descriptor] failed to read %s: %s", path, e)
+    return {}
+
+
+async def build_economics_descriptor(
+    cp_manager,
+    *,
+    tenant: str,
+    project: str,
+    existing: Optional[Dict[str, Any]] = None,
+    reservation_overrides: Optional[Mapping[str, Any]] = None,
+    reservation_deletes: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """Assemble a descriptor dict from live DB state, preserving reservation."""
+    quota = await cp_manager.list_plan_quota_policies(tenant=tenant, project=project, limit=1000)
+    quota_policies: Dict[str, Any] = {
+        p.plan_id: {k: getattr(p, k) for k in _QUOTA_FIELDS if getattr(p, k) is not None}
+        for p in quota
+    }
+
+    budget = await cp_manager.list_tenant_project_budget_policies(tenant=tenant, project=project, limit=1000)
+    budget_policies = {
+        b.provider: {k: _num(getattr(b, k)) for k in _BUDGET_FIELDS}
+        for b in budget
+    }
+
+    plans = await cp_manager.subscription_mgr.list_plans(
+        tenant=tenant, project=project, active_only=False, limit=5000
+    )
+    subscription_plans: Dict[str, Any] = {}
+    for pl in plans:
+        entry = {
+            "provider": pl.provider,
+            "monthly_price_cents": int(pl.monthly_price_cents or 0),
+            "active": bool(pl.active),
+        }
+        if getattr(pl, "stripe_price_id", None):
+            entry["stripe_price_id"] = pl.stripe_price_id
+        subscription_plans[pl.plan_id] = entry
+
+    # Overdraft limit lives in tenant_project_budget; the balance is intentionally
+    # never part of the descriptor.
+    overdraft_usd: Optional[float] = 0.0
+    try:
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.project_budget import ProjectBudgetLimiter
+        limiter = ProjectBudgetLimiter(
+            redis=getattr(cp_manager, "_redis", None),
+            pg_pool=getattr(cp_manager, "_pg_pool", None),
+            tenant=tenant,
+            project=project,
+        )
+        snap = await limiter.get_app_budget_balance()
+        overdraft_usd = snap.get("overdraft_limit_usd")
+    except Exception as e:
+        logger.warning("[economics.descriptor] overdraft read failed: %s", e)
+
+    existing = existing if existing is not None else {}
+    reservation = dict(existing.get("reservation") or _DEFAULT_RESERVATION)
+    if reservation_overrides:
+        reservation.update(reservation_overrides)
+    for floor in (reservation_deletes or ()):
+        reservation.pop(floor, None)
+
+    return {
+        "version": int(existing.get("version", 1)),
+        "enforce": bool(existing.get("enforce", False)),
+        "reservation": reservation,
+        "project_budget": {"overdraft_limit_usd": overdraft_usd},
+        "quota_policies": quota_policies,
+        "budget_policies": budget_policies,
+        "subscription_plans": subscription_plans,
+    }
+
+
+def _write_locked(path: Path, builder) -> None:
+    """
+    Hold an exclusive flock around read-modify-write so concurrent admin
+    mutations don't lose the reservation section, then replace atomically.
+    `builder(existing_dict) -> new_dict`.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(f".{path.name}.lock")
+    with open(lock_path, "a+") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            existing = _read_existing(path)
+            payload = builder(existing)
+            text = yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(text, encoding="utf-8")
+            os.replace(tmp, path)
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+
+async def sync_economics_descriptor(
+    cp_manager,
+    *,
+    tenant: str,
+    project: str,
+    reservation_overrides: Optional[Mapping[str, Any]] = None,
+    reservation_deletes: Optional[Iterable[str]] = None,
+) -> bool:
+    """
+    Rewrite economics.yaml from the live DB state (preserving/merging the
+    reservation section). Best-effort: returns True on success, False on
+    failure (never raises). Call after an admin economics mutation.
+    """
+    path = _economics_descriptor_path()
+    deletes = tuple(reservation_deletes or ())
+    try:
+        # Build under the lock so we read the freshest reservation section.
+        existing = _read_existing(path)
+        descriptor = await build_economics_descriptor(
+            cp_manager, tenant=tenant, project=project,
+            existing=existing, reservation_overrides=reservation_overrides,
+            reservation_deletes=deletes,
+        )
+
+        def _builder(current: Dict[str, Any]) -> Dict[str, Any]:
+            # Re-merge reservation under the lock in case it changed between the
+            # async DB read and acquiring the lock.
+            merged = dict(descriptor)
+            reservation = dict(current.get("reservation") or _DEFAULT_RESERVATION)
+            if reservation_overrides:
+                reservation.update(reservation_overrides)
+            for floor in deletes:
+                reservation.pop(floor, None)
+            merged["reservation"] = reservation
+            return merged
+
+        _write_locked(path, _builder)
+        logger.info("[economics.descriptor] synced %s for %s/%s", path, tenant, project)
+        return True
+    except Exception as e:
+        logger.warning("[economics.descriptor] sync failed for %s/%s: %s", tenant, project, e)
+        return False

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
@@ -19,6 +19,8 @@ from uuid import uuid4, UUID
 
 from kdcube_ai_app.apps.chat.sdk.protocol import ExternalEventPayload
 from kdcube_ai_app.apps.chat.sdk.solutions.chatbot.entrypoint import BaseEntrypoint
+from kdcube_ai_app.apps.chat.sdk.infra.economics.defaults import DEFAULT_QUOTA_POLICIES
+from kdcube_ai_app.apps.chat.sdk.config_scopes import economics_reservation_default
 from kdcube_ai_app.infra.plugin.bundle_loader import on_reactive_event
 from kdcube_ai_app.infra.service_hub.inventory import Config, _mid
 from kdcube_ai_app.apps.chat.sdk.infra.economics.events_resources import (
@@ -116,101 +118,26 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
         if pg_pool is not None or redis is not None:
             self._bind_economics_runtime()
 
-    @property
-    def configuration(self) -> Dict[str, Any]:
-        config = dict(super().configuration)
-        econ = dict(config.get("economics") or {})
-        econ.setdefault("reservation_amount_dollars", 2.0)
-        config["economics"] = econ
-        return config
-
-
     async def ensure_policies_initialized(self):
         """
-        Ensure policies are seeded from bundle configuration (one-time operation).
-        Optional hook for bundles that seed policies from config.
-        Run from a master bundle only.
-        Override in subclasses as needed.
+        Deprecated no-op. Default economics is now seeded at deploy time by the
+        postgres-setup job from the economics.yaml descriptor (see
+        docs/economics/economics-descriptor-seeding-README.md), not from bundle
+        runtime. Kept as a shim so existing bundle callers do not break.
         """
-        if self._policies_initialized:
-            return
-
-        tenant = self.settings.TENANT
-        project = self.settings.PROJECT
-        bundle_id = self.config.ai_bundle_spec.id
-
-        self._policies_initialized = \
-            await self.cp_manager.tenant_project_plan_quota_policies_initialize_from_master_app(tenant=tenant,
-                                                                                                  project=project,
-                                                                                                  bundle_id=bundle_id,
-                                                                                                  app_quota_policies=self.app_quota_policies,
-                                                                                                  app_budget_policies=self.app_budget_policies)
+        self._policies_initialized = True
+        return True
 
     @property
     def app_quota_policies(self):
-        from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import QuotaPolicy
-
-        anonymous_policy = QuotaPolicy(
-            max_concurrent=1,
-            requests_per_day=2,
-            requests_per_month=60,
-            total_requests=None,
-            tokens_per_hour=150_000,
-            tokens_per_day=1_500_000,
-            tokens_per_month=20_000_000,
-        )
-        return {
-            "anonymous": anonymous_policy,
-            "free": QuotaPolicy(
-                max_concurrent=2,
-                requests_per_day=100,
-                requests_per_month=30000,
-                total_requests=None,
-                tokens_per_hour=133_333,
-                tokens_per_day=333_333,
-                tokens_per_month=666_666,
-            ),
-            "payasyougo": QuotaPolicy(
-                max_concurrent=4,
-                requests_per_day=200,
-                requests_per_month=6000,
-                total_requests=None,
-            ),
-            "admin": QuotaPolicy(
-                max_concurrent=10,
-            )
-        }
-
-    @property
-    def app_budget_policies(self):
-        from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import ProviderBudgetPolicy
-
-        return {
-            "anthropic": ProviderBudgetPolicy(
-                provider="anthropic",
-                usd_per_hour=10.0,
-                usd_per_day=200.0,
-                usd_per_month=5000.0,
-            ),
-            "openai": ProviderBudgetPolicy(
-                provider="openai",
-                usd_per_hour=5.0,
-                usd_per_day=100.0,
-                usd_per_month=2000.0,
-            ),
-            "brave": ProviderBudgetPolicy(
-                provider="brave",
-                usd_per_hour=1.0,
-                usd_per_day=20.0,
-                usd_per_month=500.0,
-            ),
-            "duckduckgo": ProviderBudgetPolicy(
-                provider="duckduckgo",
-                usd_per_hour=None,
-                usd_per_day=None,
-                usd_per_month=None,
-            ),
-        }
+        """
+        Platform default quota policies for the four baked-in plans
+        (anonymous/free/payasyougo/admin). Sourced from the shared defaults
+        module — the single source of truth shared with the deploy-time seeder.
+        Subclasses may still override. Used as a defensive runtime fallback and
+        by the non-chat enforcement engine.
+        """
+        return dict(DEFAULT_QUOTA_POLICIES)
 
     async def execute_core(self, *, state: Dict[str, Any], thread_id: str, params: Dict[str, Any]):
         raise NotImplementedError("execute_core() must be implemented by subclasses")
@@ -595,8 +522,6 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
             if await _quota_lock.release_if_held():
                 _log("quota_lock", "Released quota_lock", key=key)
 
-        await self.ensure_policies_initialized()
-
         self._turn_id = self._turn_id or _mid("turn")
         turn_id = self._turn_id
         lock_id = turn_id
@@ -642,11 +567,22 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
         except Exception:
             output_budget = DEFAULT_OUTPUT_BUDGET
         output_budget = max(500, min(output_budget, DEFAULT_OUTPUT_BUDGET))
+        # Chat reservation floor. Bundle prop economics.reservation.chat (scalar
+        # USD; legacy economics.reservation_amount_dollars also accepted) wins:
+        # a positive value enables the floor, a value <= 0 disables it (→ token
+        # based estimate). If the bundle does not define it, inherit the platform
+        # default from economics.yaml (which already returns positive-or-None).
         reservation_amount_dollars = None
         try:
-            raw_reservation = econ_props.get("reservation_amount_dollars")
-            if raw_reservation is not None:
-                reservation_amount_dollars = float(raw_reservation)
+            res_node = (econ_props.get("reservation") or {}).get("chat")
+            if isinstance(res_node, dict):  # tolerate {amount: ...}
+                res_node = res_node.get("amount")
+            b_amount = res_node if res_node is not None else econ_props.get("reservation_amount_dollars")
+            if b_amount is not None:
+                b_amount = float(b_amount)
+                reservation_amount_dollars = b_amount if b_amount > 0 else None
+            else:
+                reservation_amount_dollars = economics_reservation_default("chat")
         except Exception:
             reservation_amount_dollars = None
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/economics/__init__.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/economics/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# ops/deployment/economics/__init__.py
+
+from kdcube_ai_app.ops.deployment.economics.economics_seed import (
+    seed_economics,
+    load_economics_descriptor,
+)
+
+__all__ = ["seed_economics", "load_economics_descriptor"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/economics/economics_seed.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/economics/economics_seed.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# ops/deployment/economics/economics_seed.py
+
+"""
+Economics seeder (raw SQL, psycopg2 — runs in the postgres-setup job).
+
+Single responsibility: seed default economics data per tenant/project AFTER the
+schema is provisioned. Schema deployment lives in db_deployment.py; this module
+only writes data rows. See docs/economics/economics-descriptor-README.md.
+
+seed_economics(): descriptor (+ baked-in baseline) -> DB.
+
+Entities:
+  - quota_policies          (4 mandatory baked-in plans + descriptor extras)
+  - application_budget_policies   (descriptor opt-in)
+  - subscription_plans            (free/admin baked-in + descriptor extras)
+  - tenant_project_budget         (overdraft limit only; balance untouched)
+Reservation floors are runtime config (not seeded).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+from psycopg2.extras import Json
+
+from kdcube_ai_app.ops.deployment.sql.db_deployment import project_schema
+from kdcube_ai_app.apps.chat.sdk.infra.economics.defaults import (
+    DEFAULT_QUOTA_POLICIES,
+    MANDATORY_QUOTA_PLAN_IDS,
+    DEFAULT_SUBSCRIPTION_PLANS,
+    MANDATORY_SUBSCRIPTION_PLAN_IDS,
+)
+
+_QUOTA_FIELDS = (
+    "max_concurrent",
+    "requests_per_day",
+    "requests_per_month",
+    "total_requests",
+    "tokens_per_hour",
+    "tokens_per_day",
+    "tokens_per_month",
+)
+_BUDGET_FIELDS = ("usd_per_hour", "usd_per_day", "usd_per_month")
+
+_SEED_CREATED_BY = "economics_seed"
+_SEED_NOTES = "Seeded from economics.yaml descriptor"
+
+_DEFAULT_RESERVATION = {"chat": {"amount": 2.0, "active": True}}
+
+
+def _log(msg: str) -> None:
+    import sys
+    print(f"[economics_seed] {msg}", file=sys.stderr, flush=True)
+
+
+# ─── descriptor loading ───────────────────────────────────────────────────────
+
+def _resolve_descriptor_path(explicit: Optional[str] = None) -> Optional[Path]:
+    """economics.yaml location: explicit arg > env > descriptors dir > /config."""
+    candidates = []
+    if explicit:
+        candidates.append(explicit)
+    env_path = str(os.getenv("ECONOMICS_YAML_DESCRIPTOR_PATH") or "").strip()
+    if env_path:
+        candidates.append(env_path)
+    descriptors_dir = str(os.getenv("PLATFORM_DESCRIPTORS_DIR") or "").strip()
+    if descriptors_dir:
+        candidates.append(str(Path(descriptors_dir) / "economics.yaml"))
+    candidates.append("/config/economics.yaml")
+
+    for raw in candidates:
+        if not raw:
+            continue
+        if raw.startswith("file://"):
+            from urllib.parse import unquote, urlparse
+            raw = unquote(urlparse(raw).path)
+        p = Path(raw).expanduser()
+        if p.exists():
+            return p
+    return None
+
+
+def load_economics_descriptor(path: Optional[str] = None) -> Dict[str, Any]:
+    """Parse economics.yaml. Returns {} when no file is present."""
+    resolved = _resolve_descriptor_path(path)
+    if resolved is None:
+        _log("No economics.yaml found; seeding mandatory quota baseline only.")
+        return {}
+    try:
+        data = yaml.safe_load(resolved.read_text()) or {}
+        _log(f"Loaded descriptor: {resolved}")
+        return data if isinstance(data, dict) else {}
+    except Exception as e:
+        _log(f"WARN failed to parse {resolved}: {e}; baseline only.")
+        return {}
+
+
+def _effective_quota_policies(descriptor: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """
+    Built-in baseline for the four mandatory plans, overridden per field by the
+    descriptor; any extra plan_id in the descriptor is included as-is.
+    """
+    desc_quota = dict(descriptor.get("quota_policies") or {})
+    effective: Dict[str, Dict[str, Any]] = {}
+
+    for plan_id in MANDATORY_QUOTA_PLAN_IDS:
+        base = dataclasses.asdict(DEFAULT_QUOTA_POLICIES[plan_id])
+        override = desc_quota.get(plan_id) or {}
+        # Field present in the descriptor wins (including explicit null).
+        for k in _QUOTA_FIELDS:
+            if k in override:
+                base[k] = override[k]
+        effective[plan_id] = {k: base.get(k) for k in _QUOTA_FIELDS}
+
+    for plan_id, override in desc_quota.items():
+        if plan_id in effective:
+            continue
+        override = override or {}
+        effective[plan_id] = {k: override.get(k) for k in _QUOTA_FIELDS}
+
+    return effective
+
+
+def _effective_subscription_plans(descriptor: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """
+    Built-in baseline for the mandatory subscription plans (free, admin),
+    overridden per field by the descriptor; any extra plan_id in the descriptor
+    is included as-is.
+    """
+    desc_plans = dict(descriptor.get("subscription_plans") or {})
+    effective: Dict[str, Dict[str, Any]] = {}
+
+    for plan_id in MANDATORY_SUBSCRIPTION_PLAN_IDS:
+        base = dict(DEFAULT_SUBSCRIPTION_PLANS[plan_id])
+        # Field present in the descriptor wins (including explicit null).
+        base.update(desc_plans.get(plan_id) or {})
+        effective[plan_id] = base
+
+    for plan_id, override in desc_plans.items():
+        if plan_id in effective:
+            continue
+        effective[plan_id] = dict(override or {})
+
+    return effective
+
+
+# ─── generic upsert ────────────────────────────────────────────────────────────
+
+def _upsert(mgr, schema: str, table: str, conflict_cols: tuple, row: Dict[str, Any], enforce: bool) -> None:
+    cols = list(row.keys())
+    placeholders = ", ".join(["%s"] * len(cols))
+    col_sql = ", ".join(cols)
+    conflict_sql = ", ".join(conflict_cols)
+
+    if enforce:
+        update_cols = [c for c in cols if c not in conflict_cols]
+        set_sql = ", ".join([f"{c} = EXCLUDED.{c}" for c in update_cols] + ["updated_at = NOW()"])
+        conflict_action = f"DO UPDATE SET {set_sql}"
+    else:
+        conflict_action = "DO NOTHING"
+
+    sql = (
+        f"INSERT INTO {schema}.{table} ({col_sql}) VALUES ({placeholders}) "
+        f"ON CONFLICT ({conflict_sql}) {conflict_action}"
+    )
+    mgr.execute_sql(sql, data=tuple(row[c] for c in cols))
+
+
+# ─── seed ───────────────────────────────────────────────────────────────────────
+
+def seed_economics(tenant: str, project: str, *, mgr=None, path: Optional[str] = None) -> None:
+    """
+    Seed default economics for tenant/project. Idempotent: per-entity
+    reconciliation, never a global gate. enforce (from the descriptor) decides
+    DO NOTHING vs full realignment.
+    """
+    from kdcube_ai_app.infra.relational.psql.psql_base import PostgreSqlDbMgr
+
+    mgr = mgr or PostgreSqlDbMgr()
+    schema = project_schema(tenant, project)
+    descriptor = load_economics_descriptor(path)
+    enforce = bool(descriptor.get("enforce", False))
+    _log(f"Seeding {tenant}/{project} (schema={schema}, enforce={enforce})")
+
+    # 1) quota policies — always includes the four baked-in plans.
+    quota = _effective_quota_policies(descriptor)
+    for plan_id, fields in quota.items():
+        row = {"tenant": tenant, "project": project, "plan_id": plan_id, **fields,
+               "created_by": _SEED_CREATED_BY, "notes": _SEED_NOTES}
+        _upsert(mgr, schema, "plan_quota_policies", ("tenant", "project", "plan_id"), row, enforce)
+    _log(f"quota_policies: {len(quota)} ({', '.join(quota)})")
+
+    # 2) provider budget policies — descriptor opt-in only.
+    budget = dict(descriptor.get("budget_policies") or {})
+    for provider, fields in budget.items():
+        fields = fields or {}
+        row = {"tenant": tenant, "project": project, "provider": provider,
+               **{k: fields.get(k) for k in _BUDGET_FIELDS},
+               "created_by": _SEED_CREATED_BY, "notes": _SEED_NOTES}
+        _upsert(mgr, schema, "application_budget_policies", ("tenant", "project", "provider"), row, enforce)
+    if budget:
+        _log(f"budget_policies: {len(budget)} ({', '.join(budget)})")
+
+    # 3) subscription plans catalog — always includes the baked-in free/admin plans.
+    plans = _effective_subscription_plans(descriptor)
+    for plan_id, fields in plans.items():
+        fields = fields or {}
+        metadata = fields.get("metadata")
+        row = {"tenant": tenant, "project": project, "plan_id": plan_id,
+               "provider": fields.get("provider", "internal"),
+               "stripe_price_id": fields.get("stripe_price_id"),
+               "monthly_price_cents": int(fields.get("monthly_price_cents") or 0),
+               "active": bool(fields.get("active", True)),
+               "metadata": Json(metadata) if metadata is not None else None,
+               "created_by": _SEED_CREATED_BY, "notes": _SEED_NOTES}
+        _upsert(mgr, schema, "subscription_plans", ("tenant", "project", "plan_id"), row, enforce)
+    _log(f"subscription_plans: {len(plans)} ({', '.join(plans)})")
+
+    # 4) project budget — overdraft limit only; balance is never written here.
+    pb = descriptor.get("project_budget")
+    if isinstance(pb, dict) and "overdraft_limit_usd" in pb:
+        od_usd = pb.get("overdraft_limit_usd")
+        od_cents = None if od_usd is None else int(round(float(od_usd) * 100))
+        row = {"tenant": tenant, "project": project, "overdraft_limit_cents": od_cents}
+        _upsert(mgr, schema, "tenant_project_budget", ("tenant", "project"), row, enforce)
+        _log(f"project_budget.overdraft_limit_cents = {od_cents}")
+
+    _log("Seeding complete.")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/deploy_project.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/deploy_project.py
@@ -60,3 +60,12 @@ if __name__ == "__main__":
     step_provision(tenant, project, "chatbot")
     step_provision(tenant, project, "knowledge_base")
     # step_deprovision(tenant, project, "knowledge_base")
+
+    # Seed default economics (separate concern from schema deployment).
+    # Non-fatal: the runtime keeps a defensive quota fallback, so a seeding
+    # failure must not block schema provisioning.
+    try:
+        from kdcube_ai_app.ops.deployment.economics import seed_economics
+        seed_economics(tenant, project)
+    except Exception as e:
+        print(f"[deploy_project] WARNING economics seeding failed (non-fatal): {e}")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -45,7 +45,7 @@ CLI_LOCK_FILE = Path.home() / ".kdcube" / "cli-lock.json"
 DEFAULT_REPO_DIRNAME = "repo"
 DOCKER_STATUS_TIMEOUT_SECONDS = 20
 DOCKER_CLEAN_TIMEOUT_SECONDS = 120
-PLATFORM_DESCRIPTOR_FILENAMES = ("assembly.yaml", "secrets.yaml", "gateway.yaml")
+PLATFORM_DESCRIPTOR_FILENAMES = ("assembly.yaml", "secrets.yaml", "gateway.yaml", "economics.yaml")
 STANDARD_INIT_SECRET_PROMPTS: tuple[tuple[str, str], ...] = (
     ("services.openai.api_key", "OpenAI API key"),
     ("services.anthropic.api_key", "Anthropic API key"),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -1138,6 +1138,31 @@ def stage_gateway_descriptor(
     ensure_gateway_template(target_path, ai_app_root)
 
 
+def ensure_economics_template(target_path: Path, ai_app_root: Path) -> bool:
+    if target_path.exists():
+        return True
+    src = ai_app_root / "deployment/economics.yaml"
+    if not src.exists():
+        return False
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, target_path)
+    return True
+
+
+def stage_economics_descriptor(
+    target_path: Path,
+    *,
+    source_path: Optional[Path],
+    ai_app_root: Path,
+) -> bool:
+    if source_path and source_path.exists():
+        if target_path.resolve() != source_path.resolve():
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source_path, target_path)
+        return True
+    return ensure_economics_template(target_path, ai_app_root)
+
+
 def stage_descriptor_directory(
     target_dir: Path,
     *,
@@ -1209,6 +1234,13 @@ def stage_descriptor_directory(
     )
     have_gateway = gateway_target.exists()
 
+    economics_target = target_dir / "economics.yaml"
+    have_economics = stage_economics_descriptor(
+        economics_target,
+        source_path=_source("economics.yaml"),
+        ai_app_root=ai_app_root,
+    )
+
     assembly = load_release_descriptor(assembly_target)
     bundles = load_release_descriptor(bundles_target) if have_bundles and bundles_target.exists() else {}
     bundles_secrets = (
@@ -1225,6 +1257,7 @@ def stage_descriptor_directory(
         "bundles_path": bundles_target if have_bundles else None,
         "bundles_secrets_path": bundles_secrets_target if have_bundles_secrets else None,
         "gateway_path": gateway_target if have_gateway else None,
+        "economics_path": economics_target if have_economics else None,
         "assembly": assembly,
         "bundles_data": bundles,
         "bundles_secrets_data": bundles_secrets,
@@ -1235,6 +1268,7 @@ def stage_descriptor_directory(
         "have_bundles": have_bundles,
         "have_bundles_secrets": have_bundles_secrets,
         "have_gateway": have_gateway,
+        "have_economics": have_economics,
     }
 
 


### PR DESCRIPTION
  Move a project's economics defaults out of bundle code into a platform-owned
  economics.yaml descriptor (per tenant/project), seeded once at deploy time and
  kept current by runtime write-back.

  Descriptor & baseline
  - economics.yaml: version, enforce, reservation (scalar floor per surface; only chat consumed), project_budget.overdraft_limit_usd, quota_policies, budget_policies, subscription_plans.
  - infra/economics/defaults.py: built-in baseline always seeded even if omitted, overridden per field by the descriptor — quota plans anonymous/free/payasyougo/ admin and subscription plans free/admin. budget_policies have no baseline.
  - enforce: false -> seed missing only (DO NOTHING); true -> realign all listed entities (DO UPDATE SET), including lowering a field back to null.

  Seeder
  - ops/deployment/economics/economics_seed.py: raw psycopg2 seeder run in the postgres-setup job, invoked from deploy_project.py after step_provision (non-fatal). Per-entity reconciliation; reservation/balance never seeded.
  - postgres-setup compose services mount /config and set PLATFORM_DESCRIPTORS_DIR.

  Runtime
  - config_scopes.economics_reservation_default reads reservation.<floor> from the file (mtime-cached). entrypoint_with_economic resolves the per-turn floor: bundle prop wins, otherwise the descriptor default.
  - infra/economics/descriptor.py: rewrites economics.yaml from live DB state after an economics change, preserving the reservation section (atomic write under an flock, best-effort) so the next seed does not regress runtime changes.

  Admin
  - control_plane.py: GET/POST/DELETE /economics/reservation[/{floor}] and best-effort descriptor sync on quota/budget/subscription mutations.
  - EconomicsDashboard: Reservation Floors tab (add/remove floors), Req/month column, overdraft + available StatCards on App Budget.

  CLI & docs
  - economics.yaml added to PLATFORM_DESCRIPTOR_FILENAMES (exported/applied with the other platform descriptors); installer stages it from deployment/.
  - New docs/economics/economics-descriptor-README.md; descriptor set enumerations in cicd docs updated to include economics.yaml.