### PR TITLE
fix(auth): route AUTH_PROVIDER=session to SessionTokenAuthManager (unshadow dead code)

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/resolvers.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/resolvers.py
@@ -165,7 +165,7 @@ def create_auth_manager():
         logger.info("Using CognitoAuthManager for authentication")
         return CognitoAuthManager(send_validation_error_details=True)
 
-    if provider in {"session", "bundle", "bundle-session"}:
+    if provider in {"bundle", "bundle-session"}:
         # Docs: repo:./app/ai-app/docs/service/auth/bundle-session-auth-README.md
         from kdcube_ai_app.auth.bundle import BundleSessionAuthManager
         logger.info("Using BundleSessionAuthManager for authentication")


### PR DESCRIPTION
## Problem

`create_auth_manager()` in `apps/chat/ingress/resolvers.py` has two branches that handle `provider == "session"`:

```python
if provider in {"session", "bundle", "bundle-session"}:
    from kdcube_ai_app.auth.bundle import BundleSessionAuthManager
    return BundleSessionAuthManager(...)          # "session" returns HERE
...
if provider == "session":                          # unreachable dead code
    from kdcube_ext.auth.session_manager import SessionTokenAuthManager
    return SessionTokenAuthManager(...)
```

The first set includes `"session"`, so it returns `BundleSessionAuthManager` and the later `SessionTokenAuthManager` branch is **dead code**.

## Impact

Deployments running `AUTH_PROVIDER=session` with **bundle-minted stateless `kst1` session tokens** (`kdcube_ext.auth.tokens`, signed with the shared `services.session_token.secret`) have **every gateway request rejected**:

```
AuthenticationError: bundle session token subject/session is missing
  bundle/sessions.py:592 validate_token -> BundleSessionInvalid
```

`BundleSessionAuthManager` expects stateful `sid`/`sub` claims plus a Redis session record, which stateless `kst1` tokens don't carry. The Telegram bot path keeps working (it authenticates via init-data, not the gateway), but **all Mini-App / widget authenticated requests fail** — observed as the realtime dashboard not connecting and render/file-host calls failing.

## Fix

Drop `"session"` from the `BundleSessionAuthManager` set so `"session"` falls through to `SessionTokenAuthManager`. `"bundle"` / `"bundle-session"` still select `BundleSessionAuthManager` explicitly.

Verified live: after this change (hotpatched + `docker restart`), the gateway logs `Using SessionTokenAuthManager` and the `subject/session is missing` rejections stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)