### PR TITLE
Fix react-v3 close-gate discarding ready answer at max_iterations; quiet gateway anonymous-auth log flood

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/runtime.py
@@ -4155,7 +4155,8 @@ class ReactSolverV2:
                 try_close = getattr(self.ctx_browser, "try_close_external_event_handler", None) if self.ctx_browser else None
                 if callable(try_close):
                     handler_closed = await try_close()
-                if handler_closed is False:
+                _max_it_cg = int(state.get("max_iterations") or 0)
+                if handler_closed is False and not (_max_it_cg and int(iteration) + 1 >= _max_it_cg):
                     state["retry_decision"] = True
                     state["exit_reason"] = None
                     state["final_answer"] = None
@@ -4165,6 +4166,14 @@ class ReactSolverV2:
                     except Exception:
                         pass
                 else:
+                    if handler_closed is False:
+                        # Close gate wanted another round, but none remain (the next
+                        # decision node would immediately exit on max_iterations).
+                        # Deliver the ready answer instead of discarding it.
+                        try:
+                            self.log.log("[react.v3] event-bus close gate deferred at max_iterations; delivering ready answer instead", level="INFO")
+                        except Exception:
+                            pass
                     final_answer_text = (decision.get("final_answer") or "").strip()
                     state["exit_reason"] = "steer" if bool(state.get("steer_finalize_mode")) else action
                     state["final_answer"] = final_answer_text

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/gateway/gateway.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/gateway/gateway.py
@@ -311,9 +311,15 @@ class RequestGateway:
             }
 
         except (AuthenticationError, Exception) as ex:
-            logger.warning("Gateway auth failed silently:\n%s", traceback.format_exc())
-            # if _auth_debug_enabled():
-            #     logger.info("Gateway auth failed: %s", str(ex))
+            # Degrading to ANONYMOUS is the expected, handled path for requests
+            # without a valid bundle session (anonymous visitors, missing/expired
+            # tokens). Emitting a full traceback at WARNING for each one floods
+            # the log (observed: ~1k/day on a public demo). Keep it terse; full
+            # detail only when auth debug is enabled.
+            if _auth_debug_enabled():
+                logger.warning("Gateway auth failed silently:\n%s", traceback.format_exc())
+            else:
+                logger.debug("Gateway auth degraded to anonymous: %s", type(ex).__name__)
             return UserType.ANONYMOUS, None
 
     async def get_system_status(self) -> Dict[str, Any]:


### PR DESCRIPTION
Two small, independent reliability fixes found while reviewing production logs of a deployed bundle (SignalK marine assistant on yey.boats).

## 1. `react/v3`: preserve the ready final answer when the close gate defers at `max_iterations`

**Bug.** In `ReactSolverV2`, after a `complete`/`exit` decision the event-bus close gate calls `try_close_external_event_handler()`. When it returns `False` (handler can't close yet), the code sets `retry_decision=True` and **clears the already-produced `final_answer`** to force another decision round. If this happens on the final iteration, the next `_decision_node` immediately exits with `exit_reason="max_iterations"` and an **empty** answer — so a turn that *had* an answer ready delivers nothing.

**Observed in prod:**
```
[react.v3] event-bus close gate deferred final answer; forcing another round
[react.v3] retry_decision=True -> route=decision
[react.v3] route=exit exit_reason=max_iterations
```
(the agent's own reasoning showed it was on iteration 5/5 and about to "provide a clean final answer").

**Fix.** Guard the close-gate branch: when no further round can run (`iteration + 1 >= max_iterations`), deliver the ready answer instead of clearing it and forcing a doomed round. Behaviour is otherwise unchanged (when rounds remain, it still defers as before). `max_iterations==0`/unset → no behaviour change.

## 2. `gateway`: don't log a full traceback for the expected degrade-to-anonymous

`RequestGateway._authenticate` degrades **any** auth failure to `ANONYMOUS` — the expected, handled path for anonymous visitors and missing/expired bundle-session tokens. It logged a full WARNING traceback for *every* one, flooding logs on public deployments (~1k/day observed; `BundleSessionInvalid: bundle session token subject/session is missing`).

**Fix.** Keep the full traceback only when `AUTH_DEBUG` is enabled (`_auth_debug_enabled()`, already used elsewhere in the file); otherwise emit a terse DEBUG line. Control flow is unchanged (still returns `ANONYMOUS`).

## Notes
- Both changes are minimal and localized; no API changes.
- Verified the patched files parse; not yet runtime-tested in this repo's CI (developed against a vendored copy). Please run the react-v3 test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)