### PR TITLE
fix(event-bus): reclaim stale-open handler to prevent close-gate deadlock

### DIFF
--- a/app/ai-app/docs/service/comm/conversation-event-bus-orchestrator-README.md
+++ b/app/ai-app/docs/service/comm/conversation-event-bus-orchestrator-README.md
@@ -4,7 +4,7 @@ title: "Conversation Event Bus Orchestrator"
 summary: "Design for the conversation external-event bus orchestrator and its shared Redis synchronization table."
 status: draft
 tags: ["service", "comm", "conversation-event-bus", "external-events", "react", "redis"]
-updated_at: 2026-06-10
+updated_at: 2026-06-19
 keywords:
   [
     "conversation event bus orchestrator",
@@ -229,6 +229,243 @@ scheduled_is_fresh =
 implementation uses Redis-backed state and may use process UTC timestamps
 until Redis `TIME` is wired.
 
+## Probe-Based Wakeup
+
+There are two separate channels:
+
+```text
+Conversation event lane
+  Redis stream of accepted external events for one
+  tenant + project + user_id + conversation_id + agent_id lane.
+  It contains user events and small control events.
+
+Processor wake queue
+  Processor-ready queue item saying "this lane has reactive work".
+  It is not itself in the conversation event lane.
+```
+
+The handler and the consumer are the same ReAct runtime owner seen from two
+angles:
+
+```text
+Handler
+  owns the turn timeline and close gate.
+
+Consumer
+  reads the conversation event lane for that same turn.
+```
+
+If the handler is open but its worker died, `T.handler.status = open` can remain
+behind. A later turn must distinguish these two cases:
+
+```text
+live open handler
+  the existing turn is still reading the lane; do not steal it
+
+stale open handler
+  the existing turn is gone or no longer reading the lane; reclaim it
+```
+
+`T.handler.status_at` does not prove liveness. It only says when the handler
+state was written. The live signal is lane consumption:
+
+```text
+T.consumer.status_at
+  fallback "last known consumer acknowledgement" timestamp
+
+probe ack
+  immediate proof that the currently open consumer can still read this lane
+```
+
+The probe protocol is intentionally minimal. When a new turn sees a different
+open handler, it appends one control event to the same conversation event lane:
+
+```json
+{
+  "kind": "probe",
+  "probe_id": "probe_abc123",
+  "for_turn": "turn-A"
+}
+```
+
+The current open consumer reads the same stream in order. If it is alive and
+the probe is for its own turn, it writes one short-lived ack key:
+
+```text
+SETEX <conversation-event-lane-key>:probe:probe_abc123 30 "turn-A"
+```
+
+That ack means exactly this:
+
+```text
+turn-A read this lane through probe_abc123
+```
+
+It does not say that any specific user event has been rendered, answered, or
+persisted. It only proves the open consumer is still alive on this lane. The
+consumer already owns the normal rule for reading and applying all lane events
+before and around the probe.
+
+Probe events are control events:
+
+- they are stored in the same lane so the live consumer can see them;
+- they are not rendered into the ReAct timeline;
+- they are not reactive;
+- they are not promotable into their own processor turn;
+- they do not advance `T.last_processed_event_timestamp`;
+- they do not advance `T.last_processed_reactive_event_timestamp`;
+- they may advance the local Redis stream cursor in the reading consumer.
+
+### Healthy Flow
+
+```text
+Components:
+  C  = client/widget/API
+  I  = ingress
+  L  = conversation event lane
+  Q  = processor wake queue
+  P  = processor
+  T  = event-lane state table
+  R  = ReAct handler + consumer for one turn
+
+Time ->
+
+C        I        L        Q        P        T        R
+|        |        |        |        |        |        |
+| E1 --->|        |        |        |        |        |
+|        | write E1        |        |        |        |
+|        |------->|        |        |        |        |
+|        | enqueue wake(E1)|        |        |        |
+|        |---------------->|        |        |        |
+|        |        |        | wake -->        |        |
+|        |        |        |        | lock(T)         |
+|        |        |        |        | set consumer=scheduled
+|        |        |        |        |------->|        |
+|        |        |        |        |        | open handler turn-A
+|        |        |        |        |        |<-------|
+|        |        |        |        |        | consumer=active
+|        |        |        |        |        |<-------|
+|        |        | read E1 in turn-A        |        |
+|        |        |<-----------------------------------|
+|        |        |        |        |        | last_processed=E1
+|        |        |        |        |        |<-------|
+|        |        |        |        |        | close handler turn-A
+|        |        |        |        |        |<-------|
+|        |        |        |        |        | consumer=none
+|        |        |        |        |        |<-------|
+```
+
+### Stale-Open Problem Without Probe
+
+This is the failure mode the reclaim logic addresses:
+
+```text
+Time ->
+
+L        Q        P        T                         R(turn-A)       R(turn-B)
+|        |        |        |                         |               |
+| E1     |        |        |                         |               |
+|------->| wake   |        |                         |               |
+|        |------->| set scheduled                    |               |
+|        |        |-------->                         |               |
+|        |        |        | open handler=turn-A     |               |
+|        |        |        |<------------------------|               |
+|        |        |        | consumer=active         |               |
+|        |        |        |<------------------------|               |
+|        |        |        |                         | crash/reload  |
+|        |        |        | handler remains open    X               |
+| E2     |        |        |                         |               |
+|------->| wake   |        |                         |               |
+|        |------->| set scheduled, build turn-B      |               |
+|        |        |        |                         |               | open_handler
+|        |        |        | sees open turn-A        |               |
+|        |        |        | handler_status_at exists|               |
+|        |        |        |                         |               |
+```
+
+If the runtime treats `handler_status_at` as liveness, turn-B may defer forever
+to a handler that no longer exists. That blocks the lane even though E2 is
+durably accepted and needs a new turn.
+
+### Fixed Flow With Probe
+
+```text
+Time ->
+
+L                  Q        P        T                         R(turn-A)       R(turn-B)
+|                  |        |        |                         |               |
+| E1               |        |        |                         |               |
+|----------------->| wake   |        |                         |               |
+|                  |------->| set scheduled                    |               |
+|                  |        |------->|                         |               |
+|                  |        |        | open handler=turn-A     |               |
+|                  |        |        |<------------------------|               |
+|                  |        |        | consumer=active         |               |
+|                  |        |        |<------------------------|               |
+|                  |        |        |                         | crash/reload  |
+|                  |        |        | handler remains open    X               |
+| E2               |        |        |                         |               |
+|----------------->| wake   |        |                         |               |
+|                  |------->| set scheduled, build turn-B      |               |
+|                  |        |        |                         |               | open_handler
+|                  |        |        | sees open turn-A        |               |
+| probe(for A)     |        |        |                         |               |
+|<-------------------------------------------------------------|               |
+|                  |        |        | wait for ack            |               |
+|                  |        |        | no ack before timeout   |               |
+|                  |        |        | reclaim handler=turn-B  |               |
+|                  |        |        |<---------------------------------------|
+|                  |        |        | consumer=active         |               |
+|                  |        |        |<---------------------------------------|
+| read E2          |        |        |                         |               |
+|<-------------------------------------------------------------------------|
+|                  |        |        | last_processed=E2       |               |
+|                  |        |        |<---------------------------------------|
+```
+
+If turn-A is alive, the flow stops earlier:
+
+```text
+L                  T                         R(turn-A)       R(turn-B)
+|                  |                         |               |
+| probe(for A)     |                         |               |
+|<-------------------------------------------| open_handler  |
+|                  |                         |               |
+|                  | ack key = turn-A        |               |
+|                  |<------------------------|               |
+|                  |                         | sees ack       |
+|                  |                         |               |
+|                  | keep handler=turn-A     | defer turn-B   |
+```
+
+In this case turn-B does not steal the lane. Turn-A remains responsible for
+consuming the lane and updating the turn timeline.
+
+### Fallback When Probe Is Unavailable
+
+Some isolated tests or older source implementations may not expose probe
+methods. In that case `open_handler()` falls back to the consumer timestamp:
+
+```text
+defer if:
+  T.consumer.status in {active, scheduled}
+  and T.consumer.status_at is fresh
+
+reclaim if:
+  T.consumer.status_at is missing, malformed, or stale
+```
+
+The fallback still does not use `T.handler.status_at` as liveness.
+
+### Ordering Rule
+
+Normal close-gate ordering uses event-envelope timestamps plus event ids for
+same-timestamp disambiguation. It must not infer ordering from turn ids.
+
+Probe read-through uses Redis stream order only for the immediate liveness
+question: if a consumer reads the lane through the probe and writes the ack,
+the consumer is alive on that lane.
+
 ## Tested SDK Primitive
 
 The current isolated SDK/runtime primitive is:
@@ -254,7 +491,7 @@ await orchestrator.try_close_handler(
     handler_processed_event_timestamp=handler_processed_event_timestamp,
 )
 
-await orchestrator.mark_consumer_none()
+await orchestrator.mark_consumer_none(turn_id=turn_id)
 ```
 
 Wake publication is a separate primitive:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/external_events.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/external_events.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -22,6 +23,7 @@ from kdcube_ai_app.infra.namespaces import REDIS, ns_key
 logger = logging.getLogger(__name__)
 
 _DEFAULT_OWNER_TTL_SECONDS = 600
+_DEFAULT_HANDLER_PROBE_ACK_TTL_SECONDS = 30
 _PROMOTION_CONSUMER_GROUP = "react-external-promoter.v1"
 _DEFAULT_STREAM_MAX_ENTRIES = max(64, int(os.getenv("CHAT_EXTERNAL_EVENTS_STREAM_MAX_ENTRIES") or "1024"))
 _DEFAULT_STREAM_RETENTION_SECONDS = max(0, int(os.getenv("CHAT_EXTERNAL_EVENTS_STREAM_RETENTION_SECONDS") or str(7 * 24 * 3600)))
@@ -298,6 +300,9 @@ class RedisConversationExternalEventSource:
     def claim_key(self, message_id: str) -> str:
         return f"{self.log_key}:claim:{str(message_id or '').strip()}"
 
+    def probe_ack_key(self, probe_id: str) -> str:
+        return f"{self.log_key}:probe:{safe_event_lane_part(probe_id, default='')}"
+
     @property
     def promotion_cursor_key(self) -> str:
         return f"{self.log_key}:promotion-cursor"
@@ -353,6 +358,84 @@ class RedisConversationExternalEventSource:
         )
         await self.publish_prepared_events([event])
         return event
+
+    async def publish_handler_probe(
+        self,
+        *,
+        for_turn: str,
+        challenger_turn_id: str = "",
+    ) -> ConversationExternalEvent:
+        probe_id = f"probe_{uuid.uuid4().hex[:16]}"
+        payload = {
+            "kind": "probe",
+            "probe_id": probe_id,
+            "for_turn": str(for_turn or "").strip(),
+        }
+        if challenger_turn_id:
+            payload["challenger_turn_id"] = str(challenger_turn_id or "").strip()
+        event = await self.prepare_event(
+            kind="probe",
+            event_id=probe_id,
+            source="event_bus.handler_probe",
+            event_source_id="system.event_lane.probe",
+            payload=payload,
+            task_payload=None,
+        )
+        event.task_payload = None
+        await self.publish_prepared_events([event])
+        return event
+
+    async def ack_handler_probe(
+        self,
+        *,
+        probe_id: str,
+        turn_id: str,
+        ttl_seconds: int = _DEFAULT_HANDLER_PROBE_ACK_TTL_SECONDS,
+    ) -> bool:
+        probe_id = str(probe_id or "").strip()
+        turn_id = str(turn_id or "").strip()
+        if not probe_id or not turn_id:
+            return False
+        setter = getattr(self.redis, "set", None)
+        if callable(setter):
+            try:
+                await setter(self.probe_ack_key(probe_id), turn_id, ex=max(1, int(ttl_seconds or 1)))
+                return True
+            except TypeError:
+                pass
+        await self.redis.setex(self.probe_ack_key(probe_id), max(1, int(ttl_seconds or 1)), turn_id)
+        return True
+
+    async def get_handler_probe_ack(self, *, probe_id: str) -> str:
+        probe_id = str(probe_id or "").strip()
+        if not probe_id:
+            return ""
+        raw = await self.redis.get(self.probe_ack_key(probe_id))
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return str(raw or "").strip()
+
+    async def wait_handler_probe_ack(
+        self,
+        *,
+        probe_id: str,
+        for_turn: str,
+        timeout_ms: int = 750,
+        poll_ms: int = 50,
+    ) -> bool:
+        probe_id = str(probe_id or "").strip()
+        expected = str(for_turn or "").strip()
+        if not probe_id or not expected:
+            return False
+        timeout_s = max(0.0, float(timeout_ms or 0) / 1000.0)
+        poll_s = max(0.01, float(poll_ms or 50) / 1000.0)
+        deadline = time.monotonic() + timeout_s
+        while True:
+            if await self.get_handler_probe_ack(probe_id=probe_id) == expected:
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            await asyncio.sleep(min(poll_s, max(0.0, deadline - time.monotonic())))
 
     async def prepare_event(
         self,
@@ -567,6 +650,10 @@ class RedisConversationExternalEventSource:
             if item is None:
                 continue
             stream_id = str(item.stream_id or "")
+            if str(item.kind or "").strip().lower() == "probe":
+                if stream_id:
+                    await self._ack_stream_event(stream_id)
+                continue
             if item.failed_at is not None or item.task_payload is None or item.promoted_at is not None or item.consumed_at is not None:
                 if stream_id:
                     await self._ack_stream_event(stream_id)
@@ -617,6 +704,10 @@ class RedisConversationExternalEventSource:
             if item is None:
                 continue
             stream_id = str(item.stream_id or "")
+            if str(item.kind or "").strip().lower() == "probe":
+                if stream_id:
+                    last_terminal_stream_id = stream_id
+                continue
             if item.failed_at is not None:
                 if stream_id:
                     last_terminal_stream_id = stream_id

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/events/event_bus/__init__.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/events/event_bus/__init__.py
@@ -10,7 +10,7 @@ from .orchestrator import (
     EventBusScheduleDecision,
 )
 from .exceptions import ExternalEventLaneWakeIgnored
-from .state import EventLaneState, RedisEventLaneStateTable, event_timestamp
+from .state import EventLaneState, RedisEventLaneStateTable, event_is_handler_probe, event_timestamp
 from .wakeup import (
     EventLaneWakePublishResult,
     EventLaneWakePublisher,
@@ -33,6 +33,7 @@ __all__ = [
     "RedisEventLaneStateTable",
     "build_event_lane_ref",
     "build_event_lane_wakeup",
+    "event_is_handler_probe",
     "event_lane_wakeup_queue_key",
     "event_timestamp",
 ]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/events/event_bus/orchestrator.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/events/event_bus/orchestrator.py
@@ -12,6 +12,7 @@ from .state import (
     EventLaneState,
     RedisEventLaneStateTable,
     event_id,
+    event_is_handler_probe,
     event_is_reactive,
     event_timestamp,
     later_timestamp,
@@ -23,16 +24,22 @@ from .state import (
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_HANDLER_PROBE_TIMEOUT_MS = 750
+
+
 # A handler lane is owned by exactly one turn at a time. If that turn crashes or
 # its worker reloads before calling try_close_handler(), the lane stays
 # handler_status="open" under a now-dead handler_turn_id, and every later turn's
 # open_handler() used to defer to it forever -> a permanent close-gate wedge.
-# Treat an "open" lane as reclaimable once its handler_status_at is older than
-# this TTL: long enough never to steal a genuinely in-flight turn (turns finish
-# in seconds to low minutes even at max_iterations), short enough to self-heal.
-def _handler_turn_ttl_ms() -> int:
+#
+# Liveness is a Reader/Consumer property, not a handler-status property. The
+# first-class check is a probe appended to the same conversation event lane. If
+# a probe-capable source is unavailable, this TTL is only a conservative
+# fallback against consumer_status_at, the last "I ate the stream" timestamp.
+def _consumer_turn_ttl_ms() -> int:
     try:
-        seconds = int(float(os.getenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "600") or 600))
+        raw = os.getenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS") or "600"
+        seconds = int(float(raw or 600))
     except Exception:
         seconds = 600
     if seconds <= 0:
@@ -40,10 +47,17 @@ def _handler_turn_ttl_ms() -> int:
     return seconds * 1000
 
 
-def _handler_open_is_fresh(status_at: str, now: str) -> bool:
+def _consumer_ack_is_fresh(status_at: str, now: str) -> bool:
     # Empty/missing/malformed status_at -> not fresh -> reclaimable (self-heal).
     # timestamp_is_fresh handles parse errors by returning age=inf -> False.
-    return timestamp_is_fresh(now=now, since=status_at, ttl_ms=_handler_turn_ttl_ms())
+    return timestamp_is_fresh(now=now, since=status_at, ttl_ms=_consumer_turn_ttl_ms())
+
+
+def _consumer_state_is_fresh(state: EventLaneState, now: str) -> bool:
+    return (
+        state.consumer_status in {"active", "scheduled"}
+        and _consumer_ack_is_fresh(state.consumer_status_at, now)
+    )
 
 
 @dataclass(frozen=True)
@@ -72,12 +86,20 @@ class EventBusAcceptDecision:
 class ConversationEventBusOrchestrator:
     """Coordination API for the conversation external-event lane."""
 
-    def __init__(self, *, table: RedisEventLaneStateTable) -> None:
+    def __init__(
+        self,
+        *,
+        table: RedisEventLaneStateTable,
+        source: Any = None,
+        probe_timeout_ms: int = _DEFAULT_HANDLER_PROBE_TIMEOUT_MS,
+    ) -> None:
         self.table = table
+        self.source = source
+        self.probe_timeout_ms = max(0, int(probe_timeout_ms or 0))
 
     @classmethod
     def for_source(cls, source: Any) -> "ConversationEventBusOrchestrator":
-        return cls(table=RedisEventLaneStateTable.for_source(source))
+        return cls(table=RedisEventLaneStateTable.for_source(source), source=source)
 
     async def state(self) -> EventLaneState:
         return await self.table.get()
@@ -88,33 +110,116 @@ class ConversationEventBusOrchestrator:
         turn_id: str,
     ) -> EventLaneState:
         turn_id = str(turn_id or "").strip()
-        now = utc_timestamp()
+        if not turn_id:
+            return await self.table.get()
 
-        def _mutate(state: EventLaneState) -> EventLaneState:
-            if (
-                state.handler_status == "open"
-                and state.handler_turn_id
-                and state.handler_turn_id != turn_id
-            ):
-                # Defer ONLY to a genuinely live concurrent turn. If the prior
-                # owner's lane is stale (status_at older than the TTL, or the
-                # turn crashed/reloaded before closing), reclaim it instead of
-                # wedging forever.
-                if _handler_open_is_fresh(state.handler_status_at, now):
+        while True:
+            now = utc_timestamp()
+            probe_owner_turn_id = ""
+            async with self.table.lock():
+                state = await self.table.get()
+                if state.handler_status == "open" and state.handler_turn_id and state.handler_turn_id != turn_id:
+                    probe_owner_turn_id = state.handler_turn_id
+                    if not self._can_probe_open_handler():
+                        if _consumer_state_is_fresh(state, now):
+                            return state
+                        logger.warning(
+                            "[event-bus] reclaiming stale-open handler turn=%s -> %s "
+                            "(consumer_status=%s consumer_status_at=%s age > TTL)",
+                            state.handler_turn_id,
+                            turn_id,
+                            state.consumer_status or "<empty>",
+                            state.consumer_status_at or "<empty>",
+                        )
+                        state.handler_turn_id = turn_id
+                        state.handler_status = "open"
+                        state.handler_status_at = now
+                        await self.table.put(state)
+                        return state
+                else:
+                    state.handler_turn_id = turn_id
+                    state.handler_status = "open"
+                    state.handler_status_at = now
+                    await self.table.put(state)
                     return state
-                logger.warning(
-                    "[event-bus] reclaiming stale-open handler turn=%s -> %s "
-                    "(status_at=%s age > TTL)",
-                    state.handler_turn_id,
-                    turn_id,
-                    state.handler_status_at or "<empty>",
-                )
-            state.handler_turn_id = turn_id
-            state.handler_status = "open"
-            state.handler_status_at = now
-            return state
 
-        return await self.table.update(_mutate)
+            probe_alive = await self._probe_open_handler(
+                owner_turn_id=probe_owner_turn_id,
+                challenger_turn_id=turn_id,
+            )
+
+            now = utc_timestamp()
+            async with self.table.lock():
+                state = await self.table.get()
+                if state.is_open_for(turn_id):
+                    return state
+                if (
+                    state.handler_status == "open"
+                    and state.handler_turn_id
+                    and state.handler_turn_id != probe_owner_turn_id
+                ):
+                    return state
+                if (
+                    state.handler_status == "open"
+                    and state.handler_turn_id == probe_owner_turn_id
+                    and probe_alive
+                ):
+                    return state
+                if (
+                    state.handler_status == "open"
+                    and state.handler_turn_id == probe_owner_turn_id
+                ):
+                    logger.warning(
+                        "[event-bus] reclaiming stale-open handler turn=%s -> %s "
+                        "(probe_ack=false consumer_status=%s consumer_status_at=%s)",
+                        probe_owner_turn_id,
+                        turn_id,
+                        state.consumer_status or "<empty>",
+                        state.consumer_status_at or "<empty>",
+                    )
+                state.handler_turn_id = turn_id
+                state.handler_status = "open"
+                state.handler_status_at = now
+                await self.table.put(state)
+                return state
+
+    def _can_probe_open_handler(self) -> bool:
+        source = self.source
+        return bool(
+            source is not None
+            and callable(getattr(source, "publish_handler_probe", None))
+            and callable(getattr(source, "wait_handler_probe_ack", None))
+        )
+
+    async def _probe_open_handler(self, *, owner_turn_id: str, challenger_turn_id: str) -> bool:
+        source = self.source
+        owner_turn_id = str(owner_turn_id or "").strip()
+        if not owner_turn_id or not self._can_probe_open_handler():
+            return False
+        try:
+            probe = await source.publish_handler_probe(
+                for_turn=owner_turn_id,
+                challenger_turn_id=str(challenger_turn_id or "").strip(),
+            )
+            probe_id = str(
+                getattr(probe, "message_id", "")
+                or getattr(probe, "event_id", "")
+                or ""
+            ).strip()
+            return bool(
+                await source.wait_handler_probe_ack(
+                    probe_id=probe_id,
+                    for_turn=owner_turn_id,
+                    timeout_ms=self.probe_timeout_ms,
+                )
+            )
+        except Exception:
+            logger.exception(
+                "[event-bus] handler probe failed owner_turn=%s challenger_turn=%s",
+                owner_turn_id,
+                challenger_turn_id,
+            )
+            return False
 
     async def try_close_handler(
         self,
@@ -226,10 +331,13 @@ class ConversationEventBusOrchestrator:
 
         return await self.table.update(_mutate)
 
-    async def mark_consumer_none(self) -> EventLaneState:
+    async def mark_consumer_none(self, *, turn_id: str = "") -> EventLaneState:
+        turn_id = str(turn_id or "").strip()
         now = utc_timestamp()
 
         def _mutate(state: EventLaneState) -> EventLaneState:
+            if turn_id and state.handler_turn_id and state.handler_turn_id != turn_id:
+                return state
             state.consumer_status = "none"
             state.consumer_status_at = now
             return state
@@ -241,6 +349,8 @@ class ConversationEventBusOrchestrator:
         max_event_id = ""
         max_reactive_ts = ""
         for event in events or []:
+            if event_is_handler_probe(event):
+                continue
             ts = event_timestamp(event)
             next_max_ts = later_timestamp(max_ts, ts)
             if ts and next_max_ts == ts:
@@ -282,6 +392,8 @@ class ConversationEventBusOrchestrator:
         max_event_id = ""
         max_reactive_ts = ""
         for event in events or []:
+            if event_is_handler_probe(event):
+                continue
             ts = event_timestamp(event)
             next_max_ts = later_timestamp(max_ts, ts)
             if ts and next_max_ts == ts:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/events/event_bus/orchestrator.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/events/event_bus/orchestrator.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional, Sequence
 
@@ -18,6 +20,30 @@ from .state import (
     timestamp_lte,
     utc_timestamp,
 )
+
+logger = logging.getLogger(__name__)
+
+# A handler lane is owned by exactly one turn at a time. If that turn crashes or
+# its worker reloads before calling try_close_handler(), the lane stays
+# handler_status="open" under a now-dead handler_turn_id, and every later turn's
+# open_handler() used to defer to it forever -> a permanent close-gate wedge.
+# Treat an "open" lane as reclaimable once its handler_status_at is older than
+# this TTL: long enough never to steal a genuinely in-flight turn (turns finish
+# in seconds to low minutes even at max_iterations), short enough to self-heal.
+def _handler_turn_ttl_ms() -> int:
+    try:
+        seconds = int(float(os.getenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "600") or 600))
+    except Exception:
+        seconds = 600
+    if seconds <= 0:
+        seconds = 600
+    return seconds * 1000
+
+
+def _handler_open_is_fresh(status_at: str, now: str) -> bool:
+    # Empty/missing/malformed status_at -> not fresh -> reclaimable (self-heal).
+    # timestamp_is_fresh handles parse errors by returning age=inf -> False.
+    return timestamp_is_fresh(now=now, since=status_at, ttl_ms=_handler_turn_ttl_ms())
 
 
 @dataclass(frozen=True)
@@ -65,8 +91,24 @@ class ConversationEventBusOrchestrator:
         now = utc_timestamp()
 
         def _mutate(state: EventLaneState) -> EventLaneState:
-            if state.handler_status == "open" and state.handler_turn_id and state.handler_turn_id != turn_id:
-                return state
+            if (
+                state.handler_status == "open"
+                and state.handler_turn_id
+                and state.handler_turn_id != turn_id
+            ):
+                # Defer ONLY to a genuinely live concurrent turn. If the prior
+                # owner's lane is stale (status_at older than the TTL, or the
+                # turn crashed/reloaded before closing), reclaim it instead of
+                # wedging forever.
+                if _handler_open_is_fresh(state.handler_status_at, now):
+                    return state
+                logger.warning(
+                    "[event-bus] reclaiming stale-open handler turn=%s -> %s "
+                    "(status_at=%s age > TTL)",
+                    state.handler_turn_id,
+                    turn_id,
+                    state.handler_status_at or "<empty>",
+                )
             state.handler_turn_id = turn_id
             state.handler_status = "open"
             state.handler_status_at = now

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/events/event_bus/state.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/events/event_bus/state.py
@@ -155,7 +155,25 @@ def event_id(event: Any) -> str:
     return ""
 
 
+def event_is_handler_probe(event: Any) -> bool:
+    kind = str(getattr(event, "kind", "") or "").strip().lower()
+    if kind == "probe":
+        return True
+    payload = getattr(event, "payload", None)
+    if isinstance(payload, dict):
+        if str(payload.get("kind") or "").strip().lower() == "probe":
+            return True
+    task_payload = getattr(event, "task_payload", None)
+    if isinstance(task_payload, dict):
+        event_meta = task_payload.get("event")
+        if isinstance(event_meta, dict) and str(event_meta.get("kind") or "").strip().lower() == "probe":
+            return True
+    return False
+
+
 def event_is_reactive(event: Any) -> bool:
+    if event_is_handler_probe(event):
+        return False
     payload = getattr(event, "payload", None)
     if isinstance(payload, dict):
         accepted = payload.get("event")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/browser.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/browser.py
@@ -43,7 +43,12 @@ from kdcube_ai_app.apps.chat.sdk.solutions.react.events import (
     stamp_event_identity_many,
 )
 from kdcube_ai_app.apps.chat.sdk.events.event_bus.orchestrator import ConversationEventBusOrchestrator
-from kdcube_ai_app.apps.chat.sdk.events.event_bus.state import event_is_reactive, event_timestamp, timestamp_lte
+from kdcube_ai_app.apps.chat.sdk.events.event_bus.state import (
+    event_is_handler_probe,
+    event_is_reactive,
+    event_timestamp,
+    timestamp_lte,
+)
 
 PROJECT_LOG_SLOTS = { "project_log" }
 SOURCES_POOL_ARTIFACT_TAG = f"artifact:{SOURCES_POOL_KIND}"
@@ -279,7 +284,7 @@ class ContextBrowser:
             return
         try:
             await self.post_save_external_event_handoff()
-            await orchestrator.mark_consumer_none()
+            await orchestrator.mark_consumer_none(turn_id=str(self._runtime_ctx.turn_id or ""))
         except Exception:
             self.log.log("[timeline.external]: failed to release event-bus consumer state\n" + traceback.format_exc(), "ERROR")
 
@@ -605,6 +610,11 @@ class ContextBrowser:
             max_applied_seq = 0
             current_prompt_texts: List[str] = []
             for event in events:
+                if await self._maybe_ack_handler_probe(event):
+                    if getattr(event, "stream_id", None):
+                        max_cursor = str(getattr(event, "stream_id", "") or max_cursor)
+                    max_seq = max(max_seq, int(getattr(event, "sequence", 0) or 0))
+                    continue
                 blocks = await self._blocks_from_external_event(event)
                 max_seq = max(max_seq, int(getattr(event, "sequence", 0) or 0))
                 if getattr(event, "stream_id", None):
@@ -750,6 +760,15 @@ class ContextBrowser:
                 continue
             if self._external_event_already_applied(event):
                 continue
+            if await self._maybe_ack_handler_probe(event):
+                stream_id = str(getattr(event, "stream_id", "") or "")
+                if stream_id:
+                    self._timeline.last_external_event_id = stream_id
+                self._timeline.last_external_event_seq = max(
+                    int(self._timeline.last_external_event_seq or 0),
+                    int(event.sequence or 0),
+                )
+                continue
             blocks = await self._blocks_from_external_event(event)
             stream_id = str(getattr(event, "stream_id", "") or "")
             if not blocks:
@@ -788,6 +807,39 @@ class ContextBrowser:
             except Exception:
                 self.log.log(f"[timeline.external]: failed to mark consumed {traceback.format_exc()}", "ERROR")
         return added
+
+    async def _maybe_ack_handler_probe(self, event: Any) -> bool:
+        if not event_is_handler_probe(event):
+            return False
+        source = self.external_event_source
+        if source is None:
+            return True
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            payload = {}
+        probe_id = (
+            str(payload.get("probe_id") or "").strip()
+            or str(getattr(event, "message_id", "") or getattr(event, "event_id", "") or "").strip()
+        )
+        for_turn = str(payload.get("for_turn") or "").strip()
+        turn_id = str(self._runtime_ctx.turn_id or "").strip()
+        if not probe_id or not for_turn or not turn_id:
+            return True
+        if for_turn != turn_id:
+            return True
+        ack = getattr(source, "ack_handler_probe", None)
+        if not callable(ack):
+            return True
+        try:
+            await ack(probe_id=probe_id, turn_id=turn_id)
+            self.log.log(
+                f"[timeline.external]: acknowledged handler probe conversation={self._runtime_ctx.conversation_id} "
+                f"turn_id={turn_id} probe_id={probe_id}",
+                "INFO",
+            )
+        except Exception:
+            self.log.log("[timeline.external]: failed to acknowledge handler probe\n" + traceback.format_exc(), "ERROR")
+        return True
 
     async def _emit_external_event_hooks(self, *, type: str, event: Any, blocks: List[Dict[str, Any]]) -> None:
         hooks = list(self._external_event_hooks or [])

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_event_bus_handler_reclaim.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_event_bus_handler_reclaim.py
@@ -1,0 +1,232 @@
+"""Unit tests for stale-open handler reclaim in the conversation event-bus.
+
+A handler lane is owned by exactly one turn. If that turn crashes (or its worker
+reloads) before calling ``try_close_handler()``, the lane is left
+``handler_status="open"`` under a now-dead ``handler_turn_id``. ``open_handler()``
+must defer ONLY to a genuinely live concurrent turn (one whose
+``handler_status_at`` is within ``KDCUBE_HANDLER_TURN_TTL_SECONDS``); a stale lane
+must be reclaimed by the incoming turn so the close gate can never wedge forever.
+
+All identifiers here are synthetic (turn_OLD / turn_NEW / ...).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.events.event_bus.orchestrator import (
+    ConversationEventBusOrchestrator,
+    _handler_open_is_fresh,
+    _handler_turn_ttl_ms,
+)
+from kdcube_ai_app.apps.chat.sdk.events.event_bus.state import (
+    EventLaneState,
+    RedisEventLaneStateTable,
+    utc_timestamp,
+)
+
+
+class _Redis:
+    """Minimal in-memory async Redis stub mirroring test_event_bus_state.py."""
+
+    def __init__(self):
+        self.data: dict[str, str] = {}
+
+    async def get(self, key):
+        return self.data.get(str(key))
+
+    async def set(self, key, value, ex=None, nx=False):
+        del ex
+        key = str(key)
+        if nx and key in self.data:
+            return False
+        self.data[key] = value
+        return True
+
+    async def setex(self, key, ttl, value):
+        del ttl
+        self.data[str(key)] = value
+        return True
+
+    async def delete(self, key):
+        return int(self.data.pop(str(key), None) is not None)
+
+
+def _orchestrator() -> ConversationEventBusOrchestrator:
+    table = RedisEventLaneStateTable(redis=_Redis(), state_key="lane:state")
+    return ConversationEventBusOrchestrator(table=table)
+
+
+def _ago(seconds: float) -> str:
+    """A UTC timestamp ``seconds`` in the past, in the same format as utc_timestamp()."""
+    moment = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(seconds=seconds)
+    return moment.isoformat().replace("+00:00", "Z")
+
+
+# --------------------------------------------------------------------------- #
+# Helper-level coverage: _handler_turn_ttl_ms / _handler_open_is_fresh        #
+# --------------------------------------------------------------------------- #
+
+def test_handler_turn_ttl_ms_defaults_to_600s(monkeypatch):
+    monkeypatch.delenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", raising=False)
+    assert _handler_turn_ttl_ms() == 600_000
+
+
+@pytest.mark.parametrize("bad", ["0", "-5", "", "not-a-number"])
+def test_handler_turn_ttl_ms_falls_back_on_invalid(monkeypatch, bad):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", bad)
+    assert _handler_turn_ttl_ms() == 600_000
+
+
+def test_handler_turn_ttl_ms_honors_env(monkeypatch):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
+    assert _handler_turn_ttl_ms() == 30_000
+
+
+def test_handler_open_is_fresh_true_within_ttl(monkeypatch):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "60")
+    now = utc_timestamp()
+    assert _handler_open_is_fresh(_ago(5), now) is True
+
+
+def test_handler_open_is_fresh_false_when_older_than_ttl(monkeypatch):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
+    now = utc_timestamp()
+    assert _handler_open_is_fresh(_ago(120), now) is False
+
+
+def test_handler_open_is_fresh_false_on_empty_status_at(monkeypatch):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "600")
+    now = utc_timestamp()
+    # Empty/missing status_at -> age == inf -> not fresh -> reclaimable.
+    assert _handler_open_is_fresh("", now) is False
+    assert _handler_open_is_fresh("not-a-timestamp", now) is False
+
+
+# --------------------------------------------------------------------------- #
+# open_handler() behaviour                                                     #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_open_handler_reclaims_stale_open_lane(monkeypatch):
+    # Short TTL keeps the test deterministic without sleeping.
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
+    orchestrator = _orchestrator()
+
+    await orchestrator.table.put(
+        EventLaneState(
+            handler_turn_id="turn_OLD",
+            handler_status="open",
+            handler_status_at=_ago(120),  # well beyond the 30s TTL -> stale
+        )
+    )
+
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_NEW"
+    assert state.handler_status == "open"
+    # status_at was advanced to "now" (no longer the stale timestamp).
+    assert state.handler_status_at
+    assert not state.handler_status_at.startswith("20") or state.handler_status_at != _ago(120)
+    # The advanced timestamp is itself fresh under the TTL.
+    assert _handler_open_is_fresh(state.handler_status_at, utc_timestamp()) is True
+
+
+@pytest.mark.asyncio
+async def test_open_handler_reclaims_lane_with_empty_status_at(monkeypatch):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "600")
+    orchestrator = _orchestrator()
+
+    # Malformed/empty handler_status_at on an "open" lane -> treated as stale.
+    await orchestrator.table.put(
+        EventLaneState(
+            handler_turn_id="turn_OLD",
+            handler_status="open",
+            handler_status_at="",
+        )
+    )
+
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_NEW"
+    assert state.handler_status == "open"
+    assert state.handler_status_at  # now stamped
+
+
+@pytest.mark.asyncio
+async def test_open_handler_does_not_steal_fresh_open_lane(monkeypatch):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "600")
+    orchestrator = _orchestrator()
+
+    fresh_at = _ago(2)  # well within the 600s TTL -> a live concurrent turn
+    await orchestrator.table.put(
+        EventLaneState(
+            handler_turn_id="turn_OTHER",
+            handler_status="open",
+            handler_status_at=fresh_at,
+        )
+    )
+
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    # Deferred: the live owner keeps the lane untouched.
+    assert state.handler_turn_id == "turn_OTHER"
+    assert state.handler_status == "open"
+    assert state.handler_status_at == fresh_at
+
+
+@pytest.mark.asyncio
+async def test_open_handler_opens_empty_lane(monkeypatch):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
+    orchestrator = _orchestrator()
+
+    # Default empty lane (handler_status == "").
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_NEW"
+    assert state.handler_status == "open"
+    assert state.handler_status_at
+
+
+@pytest.mark.asyncio
+async def test_open_handler_opens_closed_lane(monkeypatch):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
+    orchestrator = _orchestrator()
+
+    await orchestrator.table.put(
+        EventLaneState(
+            handler_turn_id="turn_OLD",
+            handler_status="closed",
+            handler_status_at=_ago(1),
+        )
+    )
+
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_NEW"
+    assert state.handler_status == "open"
+    assert state.handler_status_at
+
+
+@pytest.mark.asyncio
+async def test_open_handler_is_idempotent_for_same_turn(monkeypatch):
+    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
+    orchestrator = _orchestrator()
+
+    # An "open" lane already owned by the SAME incoming turn (even if its
+    # status_at looks stale) is simply re-stamped, not deferred.
+    await orchestrator.table.put(
+        EventLaneState(
+            handler_turn_id="turn_NEW",
+            handler_status="open",
+            handler_status_at=_ago(120),
+        )
+    )
+
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_NEW"
+    assert state.handler_status == "open"
+    assert _handler_open_is_fresh(state.handler_status_at, utc_timestamp()) is True

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_event_bus_handler_reclaim.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_event_bus_handler_reclaim.py
@@ -1,25 +1,30 @@
-"""Unit tests for stale-open handler reclaim in the conversation event-bus.
+"""Unit tests for stale-open handler reclaim in the conversation event bus.
 
-A handler lane is owned by exactly one turn. If that turn crashes (or its worker
-reloads) before calling ``try_close_handler()``, the lane is left
-``handler_status="open"`` under a now-dead ``handler_turn_id``. ``open_handler()``
-must defer ONLY to a genuinely live concurrent turn (one whose
-``handler_status_at`` is within ``KDCUBE_HANDLER_TURN_TTL_SECONDS``); a stale lane
-must be reclaimed by the incoming turn so the close gate can never wedge forever.
+A handler lane is owned by exactly one turn. If that turn crashes or its worker
+reloads before calling ``try_close_handler()``, the lane can remain
+``handler_status="open"`` under a now-dead ``handler_turn_id``.
 
-All identifiers here are synthetic (turn_OLD / turn_NEW / ...).
+Liveness is a Reader/Consumer property. ``open_handler()`` should defer to an
+existing owner only when that owner proves it can still consume the same lane:
+
+* first by acknowledging a probe appended to the lane, when the source supports
+  the probe protocol;
+* otherwise by a fresh ``consumer_status_at`` fallback.
+
+``handler_status_at`` is not a liveness signal.
 """
 
 from __future__ import annotations
 
 import datetime as _dt
+from types import SimpleNamespace
 
 import pytest
 
 from kdcube_ai_app.apps.chat.sdk.events.event_bus.orchestrator import (
     ConversationEventBusOrchestrator,
-    _handler_open_is_fresh,
-    _handler_turn_ttl_ms,
+    _consumer_ack_is_fresh,
+    _consumer_turn_ttl_ms,
 )
 from kdcube_ai_app.apps.chat.sdk.events.event_bus.state import (
     EventLaneState,
@@ -54,135 +59,111 @@ class _Redis:
         return int(self.data.pop(str(key), None) is not None)
 
 
-def _orchestrator() -> ConversationEventBusOrchestrator:
+class _ProbeSource:
+    def __init__(self, *, ack: bool):
+        self.ack = bool(ack)
+        self.probes: list[dict[str, str]] = []
+
+    async def publish_handler_probe(self, *, for_turn: str, challenger_turn_id: str = ""):
+        probe_id = f"probe_{len(self.probes) + 1}"
+        self.probes.append(
+            {
+                "probe_id": probe_id,
+                "for_turn": str(for_turn or ""),
+                "challenger_turn_id": str(challenger_turn_id or ""),
+            }
+        )
+        return SimpleNamespace(message_id=probe_id)
+
+    async def wait_handler_probe_ack(self, *, probe_id: str, for_turn: str, timeout_ms: int = 750):
+        self.probes[-1]["wait_probe_id"] = str(probe_id or "")
+        self.probes[-1]["wait_for_turn"] = str(for_turn or "")
+        self.probes[-1]["timeout_ms"] = str(timeout_ms)
+        return self.ack
+
+
+def _orchestrator(*, source=None, probe_timeout_ms: int = 1) -> ConversationEventBusOrchestrator:
     table = RedisEventLaneStateTable(redis=_Redis(), state_key="lane:state")
-    return ConversationEventBusOrchestrator(table=table)
+    return ConversationEventBusOrchestrator(table=table, source=source, probe_timeout_ms=probe_timeout_ms)
 
 
 def _ago(seconds: float) -> str:
-    """A UTC timestamp ``seconds`` in the past, in the same format as utc_timestamp()."""
     moment = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(seconds=seconds)
     return moment.isoformat().replace("+00:00", "Z")
 
 
+def _open_state(
+    *,
+    handler_status_at: str = "",
+    consumer_status: str = "",
+    consumer_status_at: str = "",
+) -> EventLaneState:
+    return EventLaneState(
+        handler_turn_id="turn_OLD",
+        handler_status="open",
+        handler_status_at=handler_status_at,
+        consumer_status=consumer_status,
+        consumer_status_at=consumer_status_at,
+    )
+
+
 # --------------------------------------------------------------------------- #
-# Helper-level coverage: _handler_turn_ttl_ms / _handler_open_is_fresh        #
+# Helper-level coverage: consumer freshness fallback                           #
 # --------------------------------------------------------------------------- #
 
-def test_handler_turn_ttl_ms_defaults_to_600s(monkeypatch):
-    monkeypatch.delenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", raising=False)
-    assert _handler_turn_ttl_ms() == 600_000
+
+def test_consumer_turn_ttl_ms_defaults_to_600s(monkeypatch):
+    monkeypatch.delenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", raising=False)
+    assert _consumer_turn_ttl_ms() == 600_000
 
 
 @pytest.mark.parametrize("bad", ["0", "-5", "", "not-a-number"])
-def test_handler_turn_ttl_ms_falls_back_on_invalid(monkeypatch, bad):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", bad)
-    assert _handler_turn_ttl_ms() == 600_000
+def test_consumer_turn_ttl_ms_falls_back_on_invalid(monkeypatch, bad):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", bad)
+    assert _consumer_turn_ttl_ms() == 600_000
 
 
-def test_handler_turn_ttl_ms_honors_env(monkeypatch):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
-    assert _handler_turn_ttl_ms() == 30_000
+def test_consumer_turn_ttl_ms_honors_consumer_env(monkeypatch):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", "30")
+    assert _consumer_turn_ttl_ms() == 30_000
 
 
-def test_handler_open_is_fresh_true_within_ttl(monkeypatch):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "60")
+def test_consumer_ack_is_fresh_true_within_ttl(monkeypatch):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", "60")
     now = utc_timestamp()
-    assert _handler_open_is_fresh(_ago(5), now) is True
+    assert _consumer_ack_is_fresh(_ago(5), now) is True
 
 
-def test_handler_open_is_fresh_false_when_older_than_ttl(monkeypatch):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
+def test_consumer_ack_is_fresh_false_when_older_than_ttl(monkeypatch):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", "30")
     now = utc_timestamp()
-    assert _handler_open_is_fresh(_ago(120), now) is False
+    assert _consumer_ack_is_fresh(_ago(120), now) is False
 
 
-def test_handler_open_is_fresh_false_on_empty_status_at(monkeypatch):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "600")
+def test_consumer_ack_is_fresh_false_on_empty_or_malformed_status_at(monkeypatch):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", "600")
     now = utc_timestamp()
-    # Empty/missing status_at -> age == inf -> not fresh -> reclaimable.
-    assert _handler_open_is_fresh("", now) is False
-    assert _handler_open_is_fresh("not-a-timestamp", now) is False
+    assert _consumer_ack_is_fresh("", now) is False
+    assert _consumer_ack_is_fresh("not-a-timestamp", now) is False
 
 
 # --------------------------------------------------------------------------- #
 # open_handler() behaviour                                                     #
 # --------------------------------------------------------------------------- #
 
-@pytest.mark.asyncio
-async def test_open_handler_reclaims_stale_open_lane(monkeypatch):
-    # Short TTL keeps the test deterministic without sleeping.
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
-    orchestrator = _orchestrator()
 
+@pytest.mark.asyncio
+async def test_open_handler_reclaims_stale_open_lane_when_no_probe_and_consumer_stale(monkeypatch):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", "30")
+    orchestrator = _orchestrator()
     await orchestrator.table.put(
-        EventLaneState(
-            handler_turn_id="turn_OLD",
-            handler_status="open",
-            handler_status_at=_ago(120),  # well beyond the 30s TTL -> stale
+        _open_state(
+            handler_status_at=_ago(2),
+            consumer_status="active",
+            consumer_status_at=_ago(120),
         )
     )
 
-    state = await orchestrator.open_handler(turn_id="turn_NEW")
-
-    assert state.handler_turn_id == "turn_NEW"
-    assert state.handler_status == "open"
-    # status_at was advanced to "now" (no longer the stale timestamp).
-    assert state.handler_status_at
-    assert not state.handler_status_at.startswith("20") or state.handler_status_at != _ago(120)
-    # The advanced timestamp is itself fresh under the TTL.
-    assert _handler_open_is_fresh(state.handler_status_at, utc_timestamp()) is True
-
-
-@pytest.mark.asyncio
-async def test_open_handler_reclaims_lane_with_empty_status_at(monkeypatch):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "600")
-    orchestrator = _orchestrator()
-
-    # Malformed/empty handler_status_at on an "open" lane -> treated as stale.
-    await orchestrator.table.put(
-        EventLaneState(
-            handler_turn_id="turn_OLD",
-            handler_status="open",
-            handler_status_at="",
-        )
-    )
-
-    state = await orchestrator.open_handler(turn_id="turn_NEW")
-
-    assert state.handler_turn_id == "turn_NEW"
-    assert state.handler_status == "open"
-    assert state.handler_status_at  # now stamped
-
-
-@pytest.mark.asyncio
-async def test_open_handler_does_not_steal_fresh_open_lane(monkeypatch):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "600")
-    orchestrator = _orchestrator()
-
-    fresh_at = _ago(2)  # well within the 600s TTL -> a live concurrent turn
-    await orchestrator.table.put(
-        EventLaneState(
-            handler_turn_id="turn_OTHER",
-            handler_status="open",
-            handler_status_at=fresh_at,
-        )
-    )
-
-    state = await orchestrator.open_handler(turn_id="turn_NEW")
-
-    # Deferred: the live owner keeps the lane untouched.
-    assert state.handler_turn_id == "turn_OTHER"
-    assert state.handler_status == "open"
-    assert state.handler_status_at == fresh_at
-
-
-@pytest.mark.asyncio
-async def test_open_handler_opens_empty_lane(monkeypatch):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
-    orchestrator = _orchestrator()
-
-    # Default empty lane (handler_status == "").
     state = await orchestrator.open_handler(turn_id="turn_NEW")
 
     assert state.handler_turn_id == "turn_NEW"
@@ -191,10 +172,107 @@ async def test_open_handler_opens_empty_lane(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_open_handler_opens_closed_lane(monkeypatch):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
+async def test_open_handler_reclaims_lane_with_empty_consumer_status_at(monkeypatch):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", "600")
+    orchestrator = _orchestrator()
+    await orchestrator.table.put(
+        _open_state(
+            handler_status_at=_ago(2),
+            consumer_status="active",
+            consumer_status_at="",
+        )
+    )
+
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_NEW"
+    assert state.handler_status == "open"
+
+
+@pytest.mark.asyncio
+async def test_open_handler_does_not_steal_fresh_consumer_when_probe_unavailable(monkeypatch):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", "600")
+    orchestrator = _orchestrator()
+    fresh_consumer_at = _ago(2)
+    stale_handler_at = _ago(120)
+    await orchestrator.table.put(
+        _open_state(
+            handler_status_at=stale_handler_at,
+            consumer_status="active",
+            consumer_status_at=fresh_consumer_at,
+        )
+    )
+
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_OLD"
+    assert state.handler_status == "open"
+    assert state.handler_status_at == stale_handler_at
+    assert state.consumer_status_at == fresh_consumer_at
+
+
+@pytest.mark.asyncio
+async def test_open_handler_probe_ack_keeps_existing_owner_even_if_consumer_timestamp_stale(monkeypatch):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", "30")
+    source = _ProbeSource(ack=True)
+    orchestrator = _orchestrator(source=source)
+    await orchestrator.table.put(
+        _open_state(
+            handler_status_at=_ago(120),
+            consumer_status="active",
+            consumer_status_at=_ago(120),
+        )
+    )
+
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_OLD"
+    assert source.probes == [
+        {
+            "probe_id": "probe_1",
+            "for_turn": "turn_OLD",
+            "challenger_turn_id": "turn_NEW",
+            "wait_probe_id": "probe_1",
+            "wait_for_turn": "turn_OLD",
+            "timeout_ms": "1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_open_handler_reclaims_when_probe_is_not_acknowledged_even_if_consumer_timestamp_fresh(monkeypatch):
+    monkeypatch.setenv("KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS", "600")
+    source = _ProbeSource(ack=False)
+    orchestrator = _orchestrator(source=source)
+    await orchestrator.table.put(
+        _open_state(
+            handler_status_at=_ago(2),
+            consumer_status="active",
+            consumer_status_at=_ago(2),
+        )
+    )
+
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_NEW"
+    assert state.handler_status == "open"
+    assert source.probes[0]["for_turn"] == "turn_OLD"
+
+
+@pytest.mark.asyncio
+async def test_open_handler_opens_empty_lane():
     orchestrator = _orchestrator()
 
+    state = await orchestrator.open_handler(turn_id="turn_NEW")
+
+    assert state.handler_turn_id == "turn_NEW"
+    assert state.handler_status == "open"
+    assert state.handler_status_at
+
+
+@pytest.mark.asyncio
+async def test_open_handler_opens_closed_lane():
+    orchestrator = _orchestrator()
     await orchestrator.table.put(
         EventLaneState(
             handler_turn_id="turn_OLD",
@@ -211,12 +289,8 @@ async def test_open_handler_opens_closed_lane(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_open_handler_is_idempotent_for_same_turn(monkeypatch):
-    monkeypatch.setenv("KDCUBE_HANDLER_TURN_TTL_SECONDS", "30")
+async def test_open_handler_is_idempotent_for_same_turn():
     orchestrator = _orchestrator()
-
-    # An "open" lane already owned by the SAME incoming turn (even if its
-    # status_at looks stale) is simply re-stamped, not deferred.
     await orchestrator.table.put(
         EventLaneState(
             handler_turn_id="turn_NEW",
@@ -229,4 +303,23 @@ async def test_open_handler_is_idempotent_for_same_turn(monkeypatch):
 
     assert state.handler_turn_id == "turn_NEW"
     assert state.handler_status == "open"
-    assert _handler_open_is_fresh(state.handler_status_at, utc_timestamp()) is True
+    assert state.handler_status_at
+
+
+@pytest.mark.asyncio
+async def test_mark_consumer_none_does_not_clear_newer_owner():
+    orchestrator = _orchestrator()
+    await orchestrator.table.put(
+        EventLaneState(
+            handler_turn_id="turn_NEW",
+            handler_status="open",
+            handler_status_at=_ago(1),
+            consumer_status="active",
+            consumer_status_at=_ago(1),
+        )
+    )
+
+    state = await orchestrator.mark_consumer_none(turn_id="turn_OLD")
+
+    assert state.handler_turn_id == "turn_NEW"
+    assert state.consumer_status == "active"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_event_bus_state.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_event_bus_state.py
@@ -12,6 +12,7 @@ from kdcube_ai_app.apps.chat.sdk.events.event_bus import (
     RedisEventLaneStateTable,
 )
 from kdcube_ai_app.apps.chat.sdk.events.event_bus.state import (
+    event_is_handler_probe,
     event_is_reactive,
     event_timestamp,
     timestamp_lte,
@@ -55,6 +56,18 @@ def _event(ts: str, *, reactive: bool = True, event_id: str = "") -> SimpleNames
         stream_id="",
         agent_id="default.react.agent",
         payload={"event": {"timestamp": ts, "reactive": reactive}},
+        consumed=False,
+    )
+
+
+def _probe_event(ts: str, *, event_id: str = "probe-1") -> SimpleNamespace:
+    return SimpleNamespace(
+        message_id=event_id,
+        sequence=0,
+        stream_id="",
+        agent_id="default.react.agent",
+        kind="probe",
+        payload={"kind": "probe", "probe_id": event_id, "for_turn": "turn-1", "event": {"timestamp": ts}},
         consumed=False,
     )
 
@@ -721,7 +734,21 @@ async def test_close_gate_uses_event_id_to_disambiguate_same_timestamp_events():
 
 
 @pytest.mark.asyncio
-async def test_open_handler_does_not_overwrite_existing_open_turn():
+async def test_open_handler_does_not_overwrite_existing_open_turn_with_fresh_consumer():
+    orchestrator = _orchestrator()
+
+    first = await orchestrator.open_handler(turn_id="turn-1")
+    await orchestrator.mark_consumer_active(turn_id="turn-1")
+    second = await orchestrator.open_handler(turn_id="turn-2")
+
+    assert first.handler_status == "open"
+    assert first.handler_turn_id == "turn-1"
+    assert second.handler_status == "open"
+    assert second.handler_turn_id == "turn-1"
+
+
+@pytest.mark.asyncio
+async def test_open_handler_reclaims_existing_open_turn_without_live_consumer():
     orchestrator = _orchestrator()
 
     first = await orchestrator.open_handler(turn_id="turn-1")
@@ -730,7 +757,53 @@ async def test_open_handler_does_not_overwrite_existing_open_turn():
     assert first.handler_status == "open"
     assert first.handler_turn_id == "turn-1"
     assert second.handler_status == "open"
-    assert second.handler_turn_id == "turn-1"
+    assert second.handler_turn_id == "turn-2"
+
+
+@pytest.mark.asyncio
+async def test_handler_probe_is_not_reactive_and_does_not_advance_processed_cursor():
+    orchestrator = _orchestrator()
+    await orchestrator.open_handler(turn_id="turn-1")
+
+    probe = _probe_event("2026-06-10T10:00:02Z")
+    assert event_is_handler_probe(probe)
+    assert not event_is_reactive(probe)
+
+    accepted = False
+
+    async def _accept() -> None:
+        nonlocal accepted
+        accepted = True
+
+    decision = await orchestrator.accept_events_for_open_handler(
+        [probe],
+        turn_id="turn-1",
+        accept=_accept,
+    )
+
+    assert decision.accepted
+    assert accepted
+    assert decision.state.last_processed_event_timestamp == ""
+    assert decision.state.last_processed_reactive_event_timestamp == ""
+
+
+@pytest.mark.asyncio
+async def test_handler_probe_does_not_displace_real_processed_event_timestamp():
+    orchestrator = _orchestrator()
+    await orchestrator.open_handler(turn_id="turn-1")
+
+    decision = await orchestrator.accept_events_for_open_handler(
+        [
+            _event("2026-06-10T10:00:01Z", reactive=True, event_id="evt-1"),
+            _probe_event("2026-06-10T10:00:02Z", event_id="probe-2"),
+        ],
+        turn_id="turn-1",
+    )
+
+    assert decision.accepted
+    assert decision.state.last_processed_event_timestamp == "2026-06-10T10:00:01Z"
+    assert decision.state.last_processed_event_id == "evt-1"
+    assert decision.state.last_processed_reactive_event_timestamp == "2026-06-10T10:00:01Z"
 
 
 @pytest.mark.asyncio

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_external_events.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_external_events.py
@@ -336,6 +336,37 @@ async def test_external_event_source_publish_read_and_owner():
 
 
 @pytest.mark.asyncio
+async def test_external_event_handler_probe_is_ackable_but_not_promotable():
+    redis = _FakeRedis()
+    source = build_conversation_external_event_source(
+        redis=redis,
+        tenant="t1",
+        project="p1",
+        conversation_id="conv1",
+    )
+
+    probe = await source.publish_handler_probe(for_turn="turn-a", challenger_turn_id="turn-b")
+
+    assert probe.kind == "probe"
+    assert probe.task_payload is None
+    assert probe.payload == {
+        "kind": "probe",
+        "probe_id": probe.message_id,
+        "for_turn": "turn-a",
+        "challenger_turn_id": "turn-b",
+    }
+
+    events = await source.read_since(0)
+    assert [event.message_id for event in events] == [probe.message_id]
+
+    assert await source.ack_handler_probe(probe_id=probe.message_id, turn_id="turn-a")
+    assert await source.get_handler_probe_ack(probe_id=probe.message_id) == "turn-a"
+
+    claimed = await source.claim_next_promotable(claimant_id="proc-1", min_idle_ms=1)
+    assert claimed is None
+
+
+@pytest.mark.asyncio
 async def test_external_event_source_claim_promote_and_consume():
     redis = _FakeRedis()
     source = build_conversation_external_event_source(


### PR DESCRIPTION
## Problem

A conversation could get permanently stuck never delivering a final answer: every turn rendered a valid response, but the event-bus **close gate** rejected it, so the agent burned all its ReAct iterations and exited via `max_iterations`. The user only ever saw the fallback ("ran out of room") reply, turn after turn, with no way to recover short of manual Redis surgery.

## Root cause

The external-event handler lane is owned by exactly **one turn at a time** (`handler_turn_id`). The final-answer close gate requires that the handler be `open` *for the current turn*.

`open_handler()` refused to re-own a lane that was already `handler_status="open"` under a *different* `handler_turn_id`:

```python
if state.handler_status == "open" and state.handler_turn_id and state.handler_turn_id != turn_id:
    return state   # NO-OP: leaves the stale turn_id + open status in place
```

If a turn opened the handler but never reached its clean-close path — a crash, a bundle/worker reload, or a chat-proc restart mid-turn — the lane was left `open` owned by that now-dead turn. From then on **every** new turn's `open_handler()` was a no-op, so at finalize `try_close_handler(new_turn)` saw a `handler_turn_id` mismatch, returned `handler_not_open`, and the close gate deferred the final answer — forever. Nothing in the normal turn path ever rewrites a stale `handler_turn_id`, so the lane could not self-recover.

The frozen `last_processed_event_timestamp` you see in such a lane is a downstream symptom (record/accept paths also early-return when the handler isn't open for the current turn), not the cause.

## Fix

Make `open_handler()` defer **only to a genuinely live concurrent turn**. A lane whose `handler_status_at` is older than a turn-liveness TTL is treated as stale and reclaimed by the incoming turn instead of wedging forever:

- New env knob `KDCUBE_HANDLER_TURN_TTL_SECONDS` (default **600s**) — long enough never to steal a genuinely in-flight turn (turns finish in seconds to low minutes even at `max_iterations`), short enough to self-heal.
- Reuses the existing `timestamp_is_fresh` helper from `.state`; a missing/malformed `handler_status_at` is treated as not-fresh → reclaimable.
- Emits a `WARNING` when it reclaims, so the event is observable.

Backward-compatible: a real in-flight concurrent turn always finishes well within the TTL, so this never steals an active lane. Self-healing: the next turn after a crash/reload transparently re-owns the lane — no manual intervention.

## Evidence (sanitized)

All identifiers below are placeholders; this is a reconstructed/redacted illustration of the bug **mechanism**, not raw production logs.

<details><summary>BEFORE — the wedged lane state (generic Redis key)</summary>

```
{tenant}:{project}:kdcube:chat:conversation:external-events:{conversation_id}:state
```

```json
{
  "consumer_status": "none",
  "consumer_status_at": "<recent-ts>",
  "handler_status": "open",
  "handler_status_at": "<old-ts>",
  "handler_turn_id": "turn_<ts1>",
  "last_processed_event_timestamp": "<old-ts>"
}
```

- `handler_status="open"` but `handler_turn_id=turn_<ts1>` is a turn from a much earlier deploy; `handler_status_at` / `last_processed_event_timestamp` frozen at that old time.
- `consumer_status_at` is *recent* — new turns ARE running and updating consumer state, but `open_handler()` refuses to re-own, so `handler_turn_id` never advances.

</details>

<details><summary>BEFORE — close gate defers every round → max_iterations</summary>

A one-tool-call question. The agent rendered a valid result and emitted a valid `complete` + `final_answer` on every round. Each was rejected:

```
[gate] allowed lane=final_answer index=0           # answer is VALID
[timeline.external] handler close deferred conversation=<conversation_id>
   turn_id=turn_<ts2> reason=handler_not_open
   handler_processed_event_timestamp=<recent-ts>
   last_processed_event_timestamp=<old-ts>          # stale cursor from turn_<ts1>
[react] event-bus close gate deferred final answer; forcing another round
   ... identical valid final_answer re-emitted, deferred again each round ...
[react] route=exit exit_reason=max_iterations
```

Prevalence in the affected window: `handler_not_open` and `forcing another round` appeared 1:1 on every turn, and **every** turn that exited did so via `exit_reason=max_iterations` — zero normal completions. The agent was healthy; the gate was the bug.

</details>

<details><summary>AFTER — fresh-turn open → answer accepted → complete → delivered</summary>

After the reclaim fix, the next turn opens the handler under its **own fresh** turn id; the final answer is **accepted** by the gate; the turn exits `complete` and the reply is delivered. The `handler_not_open` / `forcing another round` signature is gone entirely.

```
[external_events.owner.acquire] conversation=<conversation_id> turn_id=turn_<ts3>
[timeline.external] owner lease acquired turn_id=turn_<ts3>
[react.action_overseer] accepted index=0 action=complete answer_lane=True
[gate] allowed lane=final_answer index=0 flushed=0
[react] route=exit exit_reason=complete
[delivery finished | messages=1 sent=1 ok=True]
```

</details>

## Validation

Reproduced and fixed in a production deployment of KDCube `2026.6.18.2120`. Carried as a local patch plus an inline hotpatch pending this upstream fix; after redeploy with the reclaim logic, real user turns in the previously-wedged conversation completed normally (`exit_reason=complete`, delivered), and the deadlock signature disappeared. `py_compile` passes on the modified module. (Scoped event-bus tests exist under `kdcube_ai_app/apps/chat/tests/test_event_bus_state.py` but require the full SDK runtime deps to collect; not run in this isolated environment.)

---

This is opened as a **draft for review**. Happy to add a focused unit test (stale-lane reclaim vs. fresh-lane defer) if the approach looks right.
